### PR TITLE
ci(lint-go): resolve go.mod under working-directory

### DIFF
--- a/go-actions/lint-go/action.yaml
+++ b/go-actions/lint-go/action.yaml
@@ -19,7 +19,10 @@ runs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version-file: "go.mod"
+        # Resolve go.mod relative to working-directory so the action also works
+        # when the Go module is not at the repo root (e.g. a CLI under cli/).
+        # An empty working-directory keeps the previous behaviour exactly.
+        go-version-file: ${{ inputs.working-directory && format('{0}/go.mod', inputs.working-directory) || 'go.mod' }}
     - uses: golangci/golangci-lint-action@v9
       with:
         args: --output.checkstyle.path=${{ inputs.golangci_lint_file }}


### PR DESCRIPTION
## Summary

- `go-actions/lint-go` hardcoded `setup-go` with `go-version-file: "go.mod"`, so it only worked when the Go module sat at the repository root.
- It already exposes a `working-directory` input (passed to `golangci-lint-action`). This derives the `go-version-file` path from that same input, so repos whose module lives in a subdirectory (e.g. a CLI under `cli/`) can use the action unchanged.

## Change

```yaml
go-version-file: ${{ inputs.working-directory && format('{0}/go.mod', inputs.working-directory) || 'go.mod' }}
```

## Backward compatibility

None broken — an empty `working-directory` evaluates to `'go.mod'`, identical to the previous hardcoded value. Every existing caller (which does not set `working-directory`) is unaffected.

## Consumer

Needed by `a-novel-kit/stack` to lint its `cli/` Go module via this shared action. That PR re-targets `@master` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)