### PR TITLE
chore(renovate): align self-hosted runner with pnpm supply-chain policy

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -33,7 +33,15 @@ runs:
         # installation from the main process (which has access to the correct token), so
         # all the node modules are available to the post upgrade tasks.
         RENOVATE_SKIP_INSTALLS: false
-        RENOVATE_ALLOWED_COMMANDS: ${{ inputs.allowed_commands }}
+        # Default to allowing pnpm so the postUpgradeTasks (pnpm format / pnpm i) actually run.
+        # Callers that pass an empty `allowed_commands` would otherwise silently skip them,
+        # leaving unformatted pnpm-workspace.yaml and stale lockfiles.
+        RENOVATE_ALLOWED_COMMANDS: ${{ inputs.allowed_commands || '["^pnpm "]' }}
+        # Match pnpm's minimumReleaseAge supply-chain policy (defined in nodelib-config) so
+        # Renovate never opens/rebases a PR for a package too fresh to pass `pnpm install`.
+        # Keep this >= pnpm's value; otherwise lockfile regeneration and CI lint fail on
+        # just-published versions.
+        RENOVATE_MINIMUM_RELEASE_AGE: "3 days"
         RENOVATE_REPOSITORIES: "['${{ github.repository }}']"
         RENOVATE_PR_HOURLY_LIMIT: 0
         LOG_LEVEL: debug

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -33,15 +33,11 @@ runs:
         # installation from the main process (which has access to the correct token), so
         # all the node modules are available to the post upgrade tasks.
         RENOVATE_SKIP_INSTALLS: false
-        # Default to allowing pnpm so the postUpgradeTasks (pnpm format / pnpm i) actually run.
-        # Callers that pass an empty `allowed_commands` would otherwise silently skip them,
-        # leaving unformatted pnpm-workspace.yaml and stale lockfiles.
-        RENOVATE_ALLOWED_COMMANDS: ${{ inputs.allowed_commands || '["^pnpm "]' }}
-        # Match pnpm's minimumReleaseAge supply-chain policy (defined in nodelib-config) so
-        # Renovate never opens/rebases a PR for a package too fresh to pass `pnpm install`.
-        # Keep this >= pnpm's value; otherwise lockfile regeneration and CI lint fail on
-        # just-published versions.
-        RENOVATE_MINIMUM_RELEASE_AGE: "3 days"
+        # Default to a tight pnpm allowlist (install + format + dedupe) so the postUpgradeTasks
+        # run without permitting arbitrary `pnpm exec` / `pnpm dlx`. Callers that pass an empty
+        # `allowed_commands` would otherwise silently skip them, leaving unformatted
+        # pnpm-workspace.yaml and stale lockfiles. Callers can still override.
+        RENOVATE_ALLOWED_COMMANDS: ${{ inputs.allowed_commands || '["^pnpm install", "^pnpm i ", "^pnpm format", "^pnpm dedupe"]' }}
         RENOVATE_REPOSITORIES: "['${{ github.repository }}']"
         RENOVATE_PR_HOURLY_LIMIT: 0
         LOG_LEVEL: debug
@@ -61,6 +57,11 @@ runs:
               "description": "Automerge updates",
               "matchPackageNames": ["!major"],
               "automerge": true
+            },
+            {
+              "description": "Match pnpm's minimumReleaseAge supply-chain gate, scoped to npm only so Renovate doesn't open/rebase PRs for packages too fresh to pass pnpm install. Other ecosystems (gomod, docker, github-actions) aren't gated by pnpm, so they keep landing security patches without delay. Keep >= pnpm's value (defined in nodelib-config).",
+              "matchManagers": ["npm"],
+              "minimumReleaseAge": "3 days"
             },
             {
               "description": "Always bump go version",


### PR DESCRIPTION
## Problem

Two config gaps in the shared Renovate runner caused most of the manual toil when draining the dependency backlog:

1. **`postUpgradeTasks` never run.** Repos call this action with an empty `allowed_commands`, so `RENOVATE_ALLOWED_COMMANDS` is blank and Renovate silently skips `pnpm format` / `pnpm i`. Result: Renovate-edited `pnpm-workspace.yaml` is left single-quoted and **fails `lint-node`** (`prettier --check`), and conflicted lockfiles are never regenerated.
2. **Renovate doesn't know about pnpm's supply-chain age gate.** There's no `minimumReleaseAge` in the Renovate config, so Renovate opens/rebases PRs for packages published seconds ago. pnpm's `minimumReleaseAge` policy then rejects them — both in CI (`lint-node` → `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`) **and inside Renovate's own lockfile-regeneration step**, which is what makes `renovate/artifacts` fail and leaves PRs stuck `DIRTY` (never auto-rebased).

## Fix

- Default `allowed_commands` to `["^pnpm "]` via a fallback, so the post-upgrade tasks run without every repo having to pass it. Callers can still override.
- Add `RENOVATE_MINIMUM_RELEASE_AGE: "3 days"` so Renovate waits until a version can pass pnpm's gate before opening/rebasing.

## Note for reviewer

`"3 days"` is set conservatively above pnpm's `minimumReleaseAge` (defined in `nodelib-config`, ~1 day observed). Please confirm pnpm's exact value and keep this **≥** it (a small margin avoids edge-timing flakes where Renovate opens a PR the instant it ages and pnpm still rejects it).

Propagates fleet-wide immediately since every repo's `renovate.yaml` references this action `@master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)