### PR TITLE
chore(renovate): group Go toolchain bumps and fix automerge matcher

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -50,16 +50,23 @@ runs:
         RENOVATE_PACKAGE_RULES: |
           [
             {
-              "description": "Automerge updates",
-              "matchPackageNames": ["!major"],
+              "description": "Automerge everything except major updates",
+              "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
               "automerge": true
             },
             {
-              "description": "Always bump go version",
+              "description": "Bump the go directive, grouped with the golang base image",
               "matchManagers": ["gomod"],
               "matchDepNames": ["go"],
               "matchDepTypes": ["golang"],
-              "rangeStrategy": "bump"
+              "rangeStrategy": "bump",
+              "groupName": "go toolchain"
+            },
+            {
+              "description": "Keep the golang base image in the same PR as the go directive",
+              "matchManagers": ["dockerfile", "docker-compose"],
+              "matchDepNames": ["docker.io/library/golang"],
+              "groupName": "go toolchain"
             },
             {
               "matchPackageNames": ["/.*a-novel-kit\\/nodelib.*/"],


### PR DESCRIPTION
## Two packageRules corrections

### 1. Group the Go toolchain
The `go` directive (gomod) and the `golang` base image (Dockerfile / compose) were bumped by **separate** PRs. Whichever lands first breaks the build: with `GOTOOLCHAIN=local`, `go mod download` fails with `go.mod requires go >= X (running Y)` until the other side catches up — this red-built every Go service this week until the docker-tag PR was merged by hand first.

This puts both under one `"go toolchain"` group so they always move together. The existing `rangeStrategy: bump` on the directive is preserved.

### 2. Fix the automerge matcher
`"matchPackageNames": ["!major"]` matches by package *name*, not update type — not what "Automerge updates" intended. Replaced with:
```json
"matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"]
```
so non-major updates automerge as intended (and majors correctly require a human).

Propagates fleet-wide via `@master`. Independent of #146 (different region of the same file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)