### PR TITLE
chore(renovate): consolidate non-major npm updates into one PR per repo

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -96,7 +96,7 @@ runs:
             {
               "description": "Consolidate non-major npm updates into one PR per repo. They all edit the shared pnpm-lock.yaml, so as separate PRs they conflict pairwise and the merge queue can only land one per cycle. This rule is last so it supersedes the per-name/monorepo groups for non-major npm updates; major npm updates keep their named groups and individual review.",
               "matchManagers": ["npm"],
-              "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+              "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
               "groupName": "javascript dependencies"
             }
           ]

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -92,6 +92,12 @@ runs:
             {
               "matchPackageNames": ["/.playwright.*/"],
               "groupName": "playwright"
+            },
+            {
+              "description": "Consolidate non-major npm updates into one PR per repo. They all edit the shared pnpm-lock.yaml, so as separate PRs they conflict pairwise and the merge queue can only land one per cycle. This rule is last so it supersedes the per-name/monorepo groups for non-major npm updates; major npm updates keep their named groups and individual review.",
+              "matchManagers": ["npm"],
+              "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+              "groupName": "javascript dependencies"
             }
           ]
         # NPM internal registries.


### PR DESCRIPTION
## Problem

Every npm dependency PR edits the **shared `pnpm-lock.yaml`**. As individual PRs they conflict pairwise, so the merge queue can only land one per cycle — the rest go `DIRTY`/`BEHIND` and wait for the next Renovate rebase. A backlog of ~10 lockfile PRs per repo therefore drains one-at-a-time over many hours (and, until #146 lands, several never auto-rebase at all).

## Fix

Group all **non-major** npm updates under one `"javascript dependencies"` group, so each repo produces a single, conflict-free lockfile PR per cycle that automerges green.

- Placed **last** in `RENOVATE_PACKAGE_RULES`, so it supersedes the per-name and monorepo groups *for non-major npm updates only*.
- **Major** npm updates are untouched — they keep their named/monorepo groups and land individually for review.
- **gomod is untouched** (Go modules don't share the lockfile; the `go toolchain` grouping is #147).

## Tradeoff (the bit worth a maintainer's eye)

This makes the per-name groups (`nodelib`, `playwright`, the monorepo presets, …) stop applying to *non-major* npm updates — they fold into the single `javascript dependencies` PR. That's the point (one lockfile PR = zero conflicts), but it's a visible behavior change. Majors still surface individually, and the org/cross-repo coordination for major bumps is unaffected.

Best reviewed/merged after #146 (post-upgrade tasks + age gate); independent of #147. Propagates fleet-wide via `@master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)