### PR TITLE
chore: drop Makefile — pnpm format covers its only target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-format:
-	pnpm format


### PR DESCRIPTION
## Summary

- Deletes the Makefile; its only target (`format`) was a one-line wrapper over `pnpm format`.
- Part of the org-wide Makefile retirement shipping with a-novel-kit/stack#36 — merge together with it.

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)