### PR TITLE
fix(actions): pnpm 11 requires a mode for audit --fix

### DIFF
--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -28,8 +28,10 @@ runs:
         GH_TOKEN: ${{ steps.app_token.outputs.token }}
     - name: run audit
       shell: bash
+      # --fix requires a mode since pnpm 11; "override" pins vulnerable
+      # transitive deps via package.json overrides without moving direct deps.
       run: |
-        pnpm audit --fix
+        pnpm audit --fix=override
         pnpm format
         pnpm i --no-frozen-lockfile
     - name: check diff


### PR DESCRIPTION
## Summary

`pnpm audit --fix` is rejected by pnpm ≥ 11 (`ERR_PNPM_INVALID_FIX_OPTION: Should be one of "override" or "update"`), which fails the nightly `node audit` workflow on every node repo. `--fix=override` keeps the pre-11 behavior — pin vulnerable transitive deps via `overrides`, leave direct deps alone.

Verified against service-json-keys on pnpm 11.5.2: the bare form exits 1; `--fix=override` exits 0 and produces the expected overrides (currently 6 pending svelte/storybook pins, which the nightly run will commit once this merges).

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)