### PR TITLE
fix(actions): route renovate go mod tidy through the module proxy

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -43,10 +43,19 @@ runs:
         RENOVATE_PR_HOURLY_LIMIT: 0
         LOG_LEVEL: debug
         RENOVATE_SECRETS: '{"GITHUB_TOKEN": "${{ inputs.github_token }}"}'
+        # Fetch public deps through the CDN-backed module proxy (reliable, cached) and
+        # fall back to direct only when the proxy can't serve a version. Plain "direct"
+        # made `go mod tidy` resolve every dependency from origin, which intermittently
+        # failed on vanity-import hosts (e.g. gonum.org reset the connection mid-fetch),
+        # aborting the tidy and leaving go.sum un-regenerated after a go.mod bump.
+        # GOPRIVATE keeps our own a-novel / a-novel-kit modules off the proxy and sumdb,
+        # so freshly tagged internal versions are fetched straight from GitHub without
+        # waiting for proxy.golang.org to index them.
         RENOVATE_CUSTOM_ENV_VARIABLES: |
           {
             "GITHUB_TOKEN": "'{{ secrets.GITHUB_TOKEN }}'",
-            "GOPROXY": "direct"
+            "GOPROXY": "https://proxy.golang.org,direct",
+            "GOPRIVATE": "github.com/a-novel,github.com/a-novel-kit"
           }
         RENOVATE_ALLOW_SCRIPTS: true
         RENOVATE_ASSIGN_AUTOMERGE: true


### PR DESCRIPTION
## What

Switches the self-hosted Renovate action's Go environment from `GOPROXY=direct` to `GOPROXY=https://proxy.golang.org,direct`, and adds `GOPRIVATE=github.com/a-novel,github.com/a-novel-kit`.

## Why

With `GOPROXY=direct`, Renovate's `go mod tidy` (run via `postUpdateOptions: gomodTidy`) resolves **every** dependency straight from its origin. For vanity-import paths this means an HTTPS `?go-get=1` meta lookup + git clone against the upstream host, which is far flakier than the CDN-backed module proxy.

This morning a transitive dep reset the connection mid-fetch:

```
gonum.org/v1/gonum/stat/distuv: unrecognized import path "gonum.org/v1/gonum":
  https fetch: Get "https://gonum.org/v1/gonum?go-get=1": read: connection reset by peer
Command failed: go mod tidy
```

When `go mod tidy` aborts, `go.sum` is never regenerated. The bumped PR then ships a `go.mod` referencing the new version with a `go.sum` still on the old one — which surfaces downstream as the cryptic `generated-go` failure `could not import <module> (invalid package name: "")` (mockery / `go/packages` refusing to load an unverifiable module). It hit `a-novel/service-authentication#987` and `a-novel/service-json-keys#711` (both `jwt v1.1.69` bumps).

## Fix

- **Public deps** go through `proxy.golang.org` (reliable, cached), with `direct` as fallback when the proxy can't serve a version.
- **Internal modules** (`a-novel*`) are covered by `GOPRIVATE`, so they're fetched directly from GitHub (reliable host) and skip the public sumdb — meaning freshly tagged internal versions work immediately without waiting for `proxy.golang.org` to index them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)