### PR TITLE
ci(release): add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/auto-release@master
+      # Check out the tagged commit and run the local action from it, so the
+      # release is cut with this repo's own action at the tag — reproducible,
+      # and with no unpinned cross-repo @master self-reference.
+      - uses: actions/checkout@v7
+      - uses: ./publish-actions/auto-release
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: a-novel-kit/workflows/publish-actions/auto-release@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

This repo had no versioning, so consumers reference its actions with `@master` — which CodeQL flags as an unpinned (supply-chain-mutable) reference. This adds the release workflow so the repo can be **versioned and published**, enabling consumers to pin to a tag.

## What

Adds `.github/workflows/release.yaml` — on a tag push it runs the repo's own `publish-actions/auto-release` action to cut a GitHub Release. Identical to the release workflow already used by the other `a-novel-kit` repos (e.g. golib).

The `package.json` version stays `0.0.0`; the first real version is cut after merge.

## Next steps (after merge)

1. Cut the first version: `a-novel publish version <X.Y.Z>` (bumps `package.json`, commits, tags `vX.Y.Z`, pushes; this workflow then creates the Release).
2. Repin every `a-novel-kit/workflows/...@master` reference across the org (and this repo's own internal references) to `@vX.Y.Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)