### PR TITLE
build: add pnpm-workspace.yaml to anchor the workspace root

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
+
 importers:
 
   .:
@@ -29,7 +32,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -41,8 +44,8 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   prettier-plugin-packagejson@3.0.2:
@@ -81,15 +84,15 @@ snapshots:
 
   detect-newline@4.0.1: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   git-hooks-list@4.2.1: {}
 
   is-plain-obj@4.1.0: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   prettier-plugin-packagejson@3.0.2(prettier@3.8.4):
     dependencies:
@@ -115,5 +118,5 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  picomatch@>=4.0.0 <4.0.4: ">=4.0.4"


### PR DESCRIPTION
## Problem

Running `a-novel publish version` from this repo failed with `ERR_PNPM_UNCLEAN_WORKING_TREE` even though the repo's own git tree was clean.

**Root cause:** this is the only a-novel-kit repo without a `pnpm-workspace.yaml`. When the repo is cloned inside the `stack` workspace (the operator's base-of-operations checkout), pnpm walks up and resolves the *workspace root* to the stack directory — so `pnpm version`'s clean-tree check inspects the **stack's** working tree, not this repo's. golib, jwt, and nodelib all ship their own `pnpm-workspace.yaml`, which anchors the workspace root to themselves; this repo just missed it.

## Fix

Add `pnpm-workspace.yaml`. `pnpm root -w` now resolves to this repo (verified), so publish is isolated from the parent checkout — the same way publishing from the stack ignores the pulled repos.

It also carries the `picomatch@>=4.0.0 <4.0.4 → >=4.0.4` override (matching golib/jwt), which bumps the lockfile off the vulnerable `picomatch@4.0.3` — incidentally clearing the Dependabot security-update finding on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)