### PR TITLE
ci: reference this repo's own actions locally

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == vars.DEPENDENCY_BOT_LOGIN || github.event.pull_request.user.login == vars.DEPENDABOT_SECURITY_LOGIN }}
     steps:
       - uses: actions/checkout@v7
-      - uses: a-novel-kit/workflows/generic-actions/approve-bot@master
+      - uses: ./generic-actions/approve-bot
         with:
           pull_request: ${{ github.event.pull_request.html_url }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -11,6 +11,7 @@ jobs:
       pull-requests: write
     if: ${{ github.event.pull_request.user.login != vars.DEPENDENCY_BOT_LOGIN }}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@master
+      - uses: actions/checkout@v7
+      - uses: ./generic-actions/assign-bot
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@master
+      - uses: actions/checkout@v7
+      - uses: ./node-actions/lint-node
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -8,7 +8,8 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@master
+      - uses: actions/checkout@v7
+      - uses: ./generic-actions/renovate
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
The repo's CI workflows referenced its **own** actions via `a-novel-kit/workflows/…@master` — mutable cross-repo self-references. This checks out the repo and uses the local `./` actions instead (the pattern Copilot endorsed for `release.yaml` in #162): reproducible, tests the *current* code on each PR, and removes the unpinned self-reference.

Converted: `main.yaml`, `renovate.yaml`, `auto-assign-author.yaml`, `auto-approve-dependabot.yaml` (release.yaml already done). The 3 that lacked it get an `actions/checkout` first (required for a local action).

**Note — composite actions are separate.** The 8 composite-action→sibling references (e.g. `lint-node` → `setup-node`) **cannot** use local `./` paths: GitHub resolves them against the *consumer's* workspace, not this repo. They need their own decision (`@master` vs `@v1.0.0`) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)