### PR TITLE
ci: pin composite-action sibling refs to v1.0.0, stamped on release

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: a-novel-kit/workflows/generic-actions/pull-bot@master
+    - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.0.0
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}

--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: a-novel-kit/workflows/node-actions/setup-node@master
+    - uses: a-novel-kit/workflows/node-actions/setup-node@v1.0.0
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}

--- a/node-actions/build-node/action.yaml
+++ b/node-actions/build-node/action.yaml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: a-novel-kit/workflows/node-actions/setup-node@master
+    - uses: a-novel-kit/workflows/node-actions/setup-node@v1.0.0
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}

--- a/node-actions/lint-node/action.yaml
+++ b/node-actions/lint-node/action.yaml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: a-novel-kit/workflows/node-actions/setup-node@master
+    - uses: a-novel-kit/workflows/node-actions/setup-node@v1.0.0
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}

--- a/node-actions/security-update/action.yaml
+++ b/node-actions/security-update/action.yaml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: a-novel-kit/workflows/node-actions/setup-node@master
+    - uses: a-novel-kit/workflows/node-actions/setup-node@v1.0.0
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}

--- a/node-actions/setup-node/action.yaml
+++ b/node-actions/setup-node/action.yaml
@@ -22,7 +22,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: a-novel-kit/workflows/generic-actions/pull-bot@master
+    - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.0.0
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}

--- a/node-actions/test-node/action.yaml
+++ b/node-actions/test-node/action.yaml
@@ -31,7 +31,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: a-novel-kit/workflows/node-actions/setup-node@master
+    - uses: a-novel-kit/workflows/node-actions/setup-node@v1.0.0
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "format": "pnpm run format:prettier",
     "format:prettier": "prettier --write . --config prettier.config.js",
     "lint": "pnpm run lint:prettier",
-    "lint:prettier": "prettier --check . --config prettier.config.js"
+    "lint:prettier": "prettier --check . --config prettier.config.js",
+    "prepublish:doc": "a-novel publish stamp 'a-novel-kit/workflows/[^@]+@' '*/*/action.yaml'"
   },
   "devDependencies": {
     "prettier": "^3.6.2",

--- a/publish-actions/npm/action.yaml
+++ b/publish-actions/npm/action.yaml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: a-novel-kit/workflows/node-actions/setup-node@master
+    - uses: a-novel-kit/workflows/node-actions/setup-node@v1.0.0
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}


### PR DESCRIPTION
## Why

The composite actions reference **sibling** actions in this repo (e.g. `lint-node` → `setup-node`). These can't use local `./` paths — GitHub resolves those against the *consumer's* workspace, not this repo. So they need a version ref, and that ref must stay in sync with each release (otherwise a consumer pinning `lint-node@v1.0.0` would float `setup-node@master`).

## What

- Pin the 8 composite→sibling references from `@master` to `@v1.0.0`.
- Add a `prepublish:doc` hook that re-stamps them to the new version on every release:
  ```json
  "prepublish:doc": "a-novel publish stamp 'a-novel-kit/workflows/[^@]+@' '*/*/action.yaml'"
  ```
  `a-novel publish version <X.Y.Z>` runs this between the bump and the release commit, so the tagged commit always has a self-consistent action chain (`lint-node@vX.Y.Z` → `setup-node@vX.Y.Z`). Verified locally: `stamped 8 reference(s) across 21 file(s)`.

**Depends on** the multi-file stamp glob — `a-novel-kit/stack#79`. The hook only runs at publish time, so this can merge first, but the operator needs the updated CLI before the next `workflows` release.

Complements #164 (the repo's *own CI* uses local `./` refs; this handles the composite-internal refs that can't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)