### PR TITLE
chore(renovate): group a-novel-kit/workflows action bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Group every a-novel-kit/workflows action bump into one PR — all the composite actions are the same repo, released as a unit, so their pinned refs must move together.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["a-novel-kit/workflows"],
+      "groupName": "a-novel-kit/workflows"
+    }
+  ]
 }


### PR DESCRIPTION
The composite actions pin their sibling actions to `a-novel-kit/workflows/<path>@vX.Y.Z` — all the same repo, released as a unit. This groups their Renovate updates into one PR so the pinned refs always move together instead of arriving as separate, individually-incomplete bumps.

`matchPackageNames: ["a-novel-kit/workflows"]` covers every sub-action: for `owner/repo/subdir@ref`, Renovate's packageName is `owner/repo`, so all 8 refs share it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)