### PR TITLE
chore(renovate): group a-novel-kit/workflows action bumps

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -92,6 +92,11 @@ runs:
               "groupName": "nodelib"
             },
             {
+              "description": "Group every a-novel-kit/workflows action together — the composite actions are one repo released as a unit, so consumers must bump all their pinned refs at once.",
+              "matchPackageNames": ["/.*a-novel-kit\\/workflows.*/"],
+              "groupName": "a-novel-kit workflows"
+            },
+            {
               "matchPackageNames": ["/.*a-novel\\/service-json-keys.*/"],
               "groupName": "service json keys"
             },


### PR DESCRIPTION
Adds a `RENOVATE_PACKAGE_RULES` entry (in the shared renovate action) that groups all `a-novel-kit/workflows` updates into one PR — alongside the existing `nodelib` / `service-*` groupings. The composite actions are one repo released as a unit, so consumers should bump every pinned ref together, not as separate individually-incomplete PRs.

Done at the org-wide layer (the hardcoded `RENOVATE_PACKAGE_RULES`) rather than per-repo `renovate.json`, matching how every other internal package is grouped. Supersedes #166 (which put it in the wrong layer).

Takes effect once consumers adopt the version carrying this rule (the renovate config is itself versioned with the actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)