### PR TITLE
ci: add auto-release (security-update) and node-audit

### DIFF
--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -1,0 +1,20 @@
+name: run node audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  node-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./node-actions/audit
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
+          app_id: ${{ vars.PUBLISH_BOT_ID }}

--- a/.github/workflows/security-update.yaml
+++ b/.github/workflows/security-update.yaml
@@ -2,8 +2,10 @@ name: run security update
 
 on:
   workflow_dispatch:
+  # An hour after node-audit, so its lockfile fix is committed first and gets
+  # picked up by this release — and the two never race to push to master.
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 1 * * *"
 
 jobs:
   security-update:
@@ -18,7 +20,9 @@ jobs:
       # the runner, so install it first (Go is preinstalled; setup-go puts
       # $GOBIN on PATH for the action's publish step).
       - uses: actions/setup-go@v5
-      - run: go install github.com/a-novel-kit/stack/cli/cmd/a-novel@latest
+      # Pinned, not @latest: reproducible, and guarantees the multi-file stamp
+      # glob support (cli/v1.0.2+). Bump intentionally on a new CLI release.
+      - run: go install github.com/a-novel-kit/stack/cli/cmd/a-novel@v1.0.2
       - uses: ./node-actions/security-update
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-update.yaml
+++ b/.github/workflows/security-update.yaml
@@ -1,0 +1,26 @@
+name: run security update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  security-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - uses: actions/checkout@v7
+      # The auto-publish (publish:patch) runs prepublish:doc, which stamps the
+      # composite action refs with `a-novel publish stamp`. That CLI isn't on
+      # the runner, so install it first (Go is preinstalled; setup-go puts
+      # $GOBIN on PATH for the action's publish step).
+      - uses: actions/setup-go@v5
+      - run: go install github.com/a-novel-kit/stack/cli/cmd/a-novel@latest
+      - uses: ./node-actions/security-update
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
+          app_id: ${{ vars.PUBLISH_BOT_ID }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "format:prettier": "prettier --write . --config prettier.config.js",
     "lint": "pnpm run lint:prettier",
     "lint:prettier": "prettier --check . --config prettier.config.js",
-    "prepublish:doc": "a-novel publish stamp 'a-novel-kit/workflows/[^@]+@' '*/*/action.yaml'"
+    "prepublish:doc": "a-novel publish stamp 'a-novel-kit/workflows/[^@]+@' '*/*/action.yaml'",
+    "publish:patch": "pnpm version patch --no-git-tag-version && pnpm run prepublish:doc && git add -A && V=$(node -p \"require('./package.json').version\") && git commit -qm \"$V\" && git tag \"v$V\" && git push origin HEAD && git push origin \"v$V\""
   },
   "devDependencies": {
     "prettier": "^3.6.2",


### PR DESCRIPTION
Adds the two scheduled security workflows the other a-novel-kit repos run, with `workflows`-specific wiring so the **auto-release actually runs `prepublish:doc`** (the thing to double-check).

## What
- **`node-audit.yaml`** — daily `pnpm audit --fix`, commits the lockfile fix to master. Works standalone.
- **`security-update.yaml`** — daily; when master has commits since the last release, runs `pnpm run publish:patch` to auto-cut a patch (via the publish bot). Uses local `./` action refs + `setup-go`/`go install` (see below).
- **`publish:patch`** (package.json) — mirrors `a-novel publish version`: `pnpm version patch --no-git-tag-version` → `prepublish:doc` (stamps the composite refs) → commit → tag → push.

## The double-check — three real gaps it surfaced
1. **No `publish:patch` existed** in this repo (only jwt has one, and jwt's doesn't run `prepublish:doc`). Added one that does.
2. **`a-novel publish version` is TTY-gated** (human-only), so the bot can't use it — `publish:patch` is the automated equivalent.
3. **`prepublish:doc` calls `a-novel publish stamp`, which isn't on the runner.** Added `setup-go` + `go install …@latest` so the publish step has it.

## ⚠️ Blocking dependency
`prepublish:doc` uses the **multi-file glob** (`'*/*/action.yaml'`), which needs the stamp feature from **stack #79** — merged to master but **not in a released cli tag yet** (latest is `cli/v1.0.1`, tagged before #79). So `go install @latest` currently fetches a CLI that errors on the glob. **This auto-release won't work until the stack CLI is re-released (`cli/v1.0.2`) with the glob-stamp.**

Hold this PR until that release, or I can switch `go install` to `@master` (works now, but tracks unreleased code) — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)