### PR TITLE
fix(ci): unfreeze audit lockfile + explicit renovate permissions

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -11,6 +11,10 @@ jobs:
       checks: write
       statuses: write
       contents: write
+      # generic-actions/renovate wires GITHUB_TOKEN as the npm.pkg.github.com
+      # token; an explicit permissions block drops packages to none, so grant
+      # read back or Renovate can't resolve private GitHub Packages deps.
+      packages: read
     steps:
       - uses: actions/checkout@v7
       - uses: ./generic-actions/renovate

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -7,6 +7,10 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      statuses: write
+      contents: write
     steps:
       - uses: actions/checkout@v7
       - uses: ./generic-actions/renovate

--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -30,6 +30,12 @@ runs:
       shell: bash
       # --fix requires a mode since pnpm 11; "override" pins vulnerable
       # transitive deps via package.json overrides without moving direct deps.
+      env:
+        # `pnpm audit --fix` writes new overrides then runs an install to apply
+        # them; under CI pnpm defaults that install to --frozen-lockfile, which
+        # then fails ERR_PNPM_LOCKFILE_CONFIG_MISMATCH against the just-changed
+        # overrides. Let the lockfile update here — it is committed below.
+        npm_config_frozen_lockfile: "false"
       run: |
         pnpm audit --fix=override
         pnpm format


### PR DESCRIPTION
Two CI fixes surfaced while auditing the fleet's failing scheduled workflows and CodeQL reports.

## `node-audit` failure — frozen lockfile
`a-novel-kit/workflows/node-actions/audit` fails on any repo that actually has an advisory to fix:

```
pnpm audit --fix=override
4 overrides were added to pnpm-workspace.yaml to fix vulnerabilities.
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation.
[ERROR] Command failed with exit code 1: pnpm install
```

`pnpm audit --fix` writes the overrides, then runs an install to apply them. Under CI pnpm defaults that install to `--frozen-lockfile`, which mismatches the just-written overrides — so the step dies before reaching the action's own `pnpm i --no-frozen-lockfile`. Setting `npm_config_frozen_lockfile=false` on the step lets the internal install update the lockfile; the result is committed by the existing publish step.

Observed failing: nodelib, service-authentication, service-json-keys (repos with open advisories). golib/jwt pass only because they have nothing to fix.

## CodeQL `actions/missing-workflow-permissions` — renovate.yaml
The renovate workflow had no `permissions:` block, running with the default broad token scope. Every other repo's renovate workflow already pins `checks/statuses/contents: write`; match it here.

## Propagation
The audit fix is a reusable action — consumers pin `@v1.0.2`, so it reaches them after a new workflows release and a Renovate bump. The renovate permissions fix is this repo's own workflow and takes effect on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)