### PR TITLE
docs: standardize README, add CONTRIBUTING and LICENSE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to workflows
+
+For platform-wide setup (Go, Node, Podman, the `a-novel` CLI) and the day-to-day commands, see the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file documents what is specific to `workflows`.
+
+## How an action is structured
+
+Every action lives at `<group>/<name>/action.yaml` and is a [composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action): a `runs: { using: "composite" }` block that chains other actions and `shell: bash` steps. The top-level group encodes the kind of work the action does — `build-actions`, `generic-actions`, `github-pages-actions`, `go-actions`, `node-actions`, `publish-actions`.
+
+When adding or changing an action:
+
+- Keep its `name` and `description` accurate — the root `README.md` catalog is generated from them by hand, and operators trust it as a reference.
+- Declare every parameter under `inputs:` with a `description` and a sensible `default` where one exists; surface anything a caller needs back as an `output`.
+- Several actions compose others in this repo (`setup-node`, `pull-bot`, …). Reference them by their pinned tag (`a-novel-kit/workflows/<group>/<name>@v1.0.3`), not by a relative path, so a given release is internally consistent.
+
+## How versions are tagged and consumed
+
+The actions are released **as a single unit**: one `v*` tag covers the whole repo. Consumers pin every `uses:` reference to that tag (e.g. `@v1.0.3`) rather than to `@master`, and bump them all together on upgrade — Renovate groups them under `a-novel-kit workflows` for exactly that reason. A release is cut by tagging the repo; the `publish-actions/auto-release` action turns the pushed tag into a GitHub release with generated notes.
+
+## Questions?
+
+- Open an issue at https://github.com/a-novel-kit/workflows/issues
+- Check existing issues for similar problems
+- Include relevant logs and environment details

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 A-Novel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,92 @@
 # Workflows
 
-Shared workflows for A-Novel projects.
+Reusable composite GitHub Actions powering A-Novel CI/CD.
+
+[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/agorastoryverse)](https://twitter.com/agorastoryverse)
+[![Discord](https://img.shields.io/discord/1315240114691248138?logo=discord)](https://discord.gg/rp4Qr8cA)
+
+<hr />
+
+![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/a-novel-kit/workflows)
+![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/a-novel-kit/workflows)
+
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/a-novel-kit/workflows/main.yaml)
+
+## What this is
+
+`workflows` is the shared catalog of reusable composite GitHub Actions that standardize lint, test, build, publish, and security tasks across every repo in the **a-novel** and **a-novel-kit** organizations. Instead of copying CI logic from one repo to the next, each project pulls these actions in with `uses:` and pins them to a release tag — currently `v1.0.3`.
+
+Each action lives at `<group>/<name>/action.yaml` and is a self-contained composite step. The groups (`build-actions`, `generic-actions`, `github-pages-actions`, `go-actions`, `node-actions`, `publish-actions`) map to the kind of work the action does; the full list is in the [Action catalog](#action-catalog) below.
+
+## Using an action
+
+Reference an action from a `.github/workflows/*.yaml` job step. The path is `a-novel-kit/workflows/<group>/<action>@<tag>`:
+
+```yaml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.0.3
+        with:
+          working-directory: . # optional; defaults to the repo root
+```
+
+Always pin to a release tag (`@v1.0.3`), never to `@master`. The composite actions are released as a single unit, so bump every pinned ref together when you upgrade — Renovate groups them under `a-novel-kit workflows` to do exactly that.
+
+## Action catalog
+
+### `build-actions`
+
+| Action       | Purpose                                                                                                          |
+| ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `docker`     | Build a Docker image from a Dockerfile and verify it reports **healthy** when run (long-lived service).          |
+| `docker-job` | Build a Docker image from a Dockerfile and verify it **exits 0** when run (one-shot job); healthcheck skippable. |
+
+### `generic-actions`
+
+| Action           | Purpose                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------- |
+| `approve-bot`    | Auto-approve a pull request (skips if already approved). Restrict to a trusted set of users. |
+| `assign-bot`     | Assign the PR author as the assignee on their own pull request.                              |
+| `auto-merge-bot` | Enable GitHub auto-merge (merge strategy) on a pull request.                                 |
+| `check-changes`  | Detect uncommitted changes in a pathspec; optionally fail the job when any are found.        |
+| `codecov`        | Download the coverage artifact and upload the report to Codecov.                             |
+| `pull-bot`       | Mint a GitHub App token and check out the repo authenticated as the bot.                     |
+| `renovate`       | Run self-hosted Renovate against the repo using the bot App token.                           |
+
+### `github-pages-actions`
+
+| Action             | Purpose                                              |
+| ------------------ | ---------------------------------------------------- |
+| `publish-vuepress` | Build a VuePress site and deploy it to GitHub Pages. |
+
+### `go-actions`
+
+| Action           | Purpose                                                                          |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `go-report-card` | Trigger a [Go Report Card](https://goreportcard.com) refresh for the repo.       |
+| `lint-go`        | Run `golangci-lint` (checkstyle output), supporting a non-root module directory. |
+| `test-go`        | Run the Go test suite with race + coverage via `gotestsum`; upload the reports.  |
+
+### `node-actions`
+
+| Action            | Purpose                                                                             |
+| ----------------- | ----------------------------------------------------------------------------------- |
+| `audit`           | Run `pnpm audit --fix`, reformat, and commit the resulting lockfile/override fixes. |
+| `build-node`      | Run the package's build script (default `build`) after a Node/pnpm setup.           |
+| `lint-node`       | Run the package's lint script (default `lint`) after a Node/pnpm setup.             |
+| `security-update` | Publish a patch release for accumulated security fixes, gated on release age.       |
+| `setup-node`      | Set up Node + pnpm wired to the GitHub package registry and install dependencies.   |
+| `test-node`       | Run the package's test script (default `test`) and upload the coverage artifact.    |
+
+### `publish-actions`
+
+| Action         | Purpose                                                                |
+| -------------- | ---------------------------------------------------------------------- |
+| `auto-release` | Create a GitHub release from the pushed tag with auto-generated notes. |
+| `npm`          | Build and publish the workspace packages to the npm (GitHub) registry. |
+
+## Contributing
+
+Platform setup and the day-to-day commands live in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); `workflows`-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Reusable composite GitHub Actions powering A-Novel CI/CD.
 
 ## What this is
 
-`workflows` is the shared catalog of reusable composite GitHub Actions that standardize lint, test, build, publish, and security tasks across every repo in the **a-novel** and **a-novel-kit** organizations. Instead of copying CI logic from one repo to the next, each project pulls these actions in with `uses:` and pins them to a release tag — currently `v1.0.3`.
+`workflows` is the shared catalog of reusable composite GitHub Actions that standardize CI and release tasks across every repo in the **a-novel** and **a-novel-kit** organizations. Instead of copying CI logic from one repo to the next, each project pulls these actions in with `uses:` and pins them to a release tag — currently `v1.0.3`.
 
-Each action lives at `<group>/<name>/action.yaml` and is a self-contained composite step. The groups (`build-actions`, `generic-actions`, `github-pages-actions`, `go-actions`, `node-actions`, `publish-actions`) map to the kind of work the action does; the full list is in the [Action catalog](#action-catalog) below.
+Each action lives at `<group>/<name>/action.yaml` and is a self-contained composite step, grouped by the kind of work it does; the full list is in the [Action catalog](#action-catalog) below.
 
 ## Using an action
 


### PR DESCRIPTION
Part of the fleet-wide docs standardization. Brings `workflows` up to the fleet README/CONTRIBUTING/LICENSE standard.

## What changed

- **README.md** — replaces the 3-line placeholder with a real reference: standard header + tech/CI badges, a `## What this is`, a `## Using an action` example (tag-pinned `uses:`), a `## Action catalog` table grouped by the six top-level directories, and a `## Contributing` pointer. Every action name/purpose was verified against its `<group>/<name>/action.yaml`.
- **CONTRIBUTING.md** (new) — links the developer onboarding guide, documents how a composite action is structured here and how versions are tagged/consumed as a single unit, plus a `## Questions?` section.
- **LICENSE** (new) — adds the MIT license (A-Novel, 2024), copied verbatim from the rest of the fleet. This was the only fleet repo missing a LICENSE.

All 20 actions across `build-actions`, `generic-actions`, `github-pages-actions`, `go-actions`, `node-actions`, and `publish-actions` are catalogued. Markdown is prettier-formatted and passes `--check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
