### PR TITLE
docs: tighten prose and the action catalog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,21 @@
 # Contributing to workflows
 
-For platform-wide setup (Go, Node, Podman, the `a-novel` CLI) and the day-to-day commands, see the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file documents what is specific to `workflows`.
+Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file covers what's specific to `workflows`.
 
 ## How an action is structured
 
-Every action lives at `<group>/<name>/action.yaml` and is a [composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action): a `runs: { using: "composite" }` block that chains other actions and `shell: bash` steps. The top-level group encodes the kind of work the action does — `build-actions`, `generic-actions`, `github-pages-actions`, `go-actions`, `node-actions`, `publish-actions`.
+Every action lives at `<group>/<name>/action.yaml` — a [composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action) chaining other actions and `shell: bash` steps. The group names the kind of work it does (`build-actions`, `go-actions`, `node-actions`, …).
 
 When adding or changing an action:
 
-- Keep its `name` and `description` accurate — the root `README.md` catalog is generated from them by hand, and operators trust it as a reference.
-- Declare every parameter under `inputs:` with a `description` and a sensible `default` where one exists; surface anything a caller needs back as an `output`.
-- Several actions compose others in this repo (`setup-node`, `pull-bot`, …). Reference them by their pinned tag (`a-novel-kit/workflows/<group>/<name>@v1.0.3`), not by a relative path, so a given release is internally consistent.
+- Keep `name` and `description` accurate — the README catalog is hand-copied from them.
+- Give every `inputs:` entry a `description` and a `default` where sensible; expose results as `outputs`.
+- When one action calls another here, reference it by pinned tag (`…@v1.0.3`), never a relative path, so each release is self-consistent.
 
-## How versions are tagged and consumed
+## How versions are tagged
 
-The actions are released **as a single unit**: one `v*` tag covers the whole repo. Consumers pin every `uses:` reference to that tag (e.g. `@v1.0.3`) rather than to `@master`, and bump them all together on upgrade — Renovate groups them under `a-novel-kit workflows` for exactly that reason. A release is cut by tagging the repo; the `publish-actions/auto-release` action turns the pushed tag into a GitHub release with generated notes.
+One `v*` tag covers the whole repo. Consumers pin every `uses:` to that tag (not `@master`) and bump them together — Renovate groups them under `a-novel-kit workflows`. Tagging the repo cuts a release: `publish-actions/auto-release` turns the tag into a GitHub release with generated notes.
 
 ## Questions?
 
-- Open an issue at https://github.com/a-novel-kit/workflows/issues
-- Check existing issues for similar problems
-- Include relevant logs and environment details
+[Open an issue](https://github.com/a-novel-kit/workflows/issues) — include logs and environment details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ Every action lives at `<group>/<name>/action.yaml` — a [composite action](http
 
 When adding or changing an action:
 
-- Keep `name` and `description` accurate — the README catalog is hand-copied from them.
+- Keep `name` and `description` accurate — the README catalog is derived from them by hand.
 - Give every `inputs:` entry a `description` and a `default` where sensible; expose results as `outputs`.
-- When one action calls another here, reference it by pinned tag (`…@v1.0.3`), never a relative path, so each release is self-consistent.
+- When one action calls another here, reference it by pinned tag (`a-novel-kit/workflows/<group>/<name>@v1.0.3`), never a relative path, so each release is self-consistent.
 
 ## How versions are tagged
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 
 ### `build-actions`
 
-| Action       | Purpose                                                       |
-| ------------ | ------------------------------------------------------------- |
-| `docker`     | Build an image and verify it runs **healthy** (long service). |
-| `docker-job` | Build an image and verify it **exits 0** (one-shot job).      |
+| Action       | Purpose                                                             |
+| ------------ | ------------------------------------------------------------------- |
+| `docker`     | Build an image and verify it runs **healthy** (long-lived service). |
+| `docker-job` | Build an image and verify it **exits 0** (one-shot job).            |
 
 ### `generic-actions`
 
@@ -52,7 +52,7 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | `auto-merge-bot` | Enable auto-merge on a PR.                                         |
 | `check-changes`  | Detect uncommitted changes in a pathspec; optionally fail.         |
 | `codecov`        | Upload the coverage artifact to Codecov.                           |
-| `pull-bot`       | Check out the repo authenticated as the bot.                       |
+| `pull-bot`       | Mint a bot App token and check out the repo authenticated as it.   |
 | `renovate`       | Run self-hosted Renovate as the bot.                               |
 
 ### `github-pages-actions`

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Reusable composite GitHub Actions powering A-Novel CI/CD.
 
 ## What this is
 
-`workflows` is the shared catalog of reusable composite GitHub Actions that standardize CI and release tasks across every repo in the **a-novel** and **a-novel-kit** organizations. Instead of copying CI logic from one repo to the next, each project pulls these actions in with `uses:` and pins them to a release tag — currently `v1.0.3`.
+The shared CI/CD building blocks for every **a-novel** and **a-novel-kit** repo. Rather than copy CI logic between repos, each project pulls these actions in with `uses:`, pinned to a release tag (currently `v1.0.3`).
 
-Each action lives at `<group>/<name>/action.yaml` and is a self-contained composite step, grouped by the kind of work it does; the full list is in the [Action catalog](#action-catalog) below.
+Each action lives at `<group>/<name>/action.yaml`, grouped by the kind of work it does. The [Action catalog](#action-catalog) lists them all.
 
 ## Using an action
 
-Reference an action from a `.github/workflows/*.yaml` job step. The path is `a-novel-kit/workflows/<group>/<action>@<tag>`:
+Reference an action from a job step as `a-novel-kit/workflows/<group>/<action>@<tag>`:
 
 ```yaml
 jobs:
@@ -32,61 +32,61 @@ jobs:
           working-directory: . # optional; defaults to the repo root
 ```
 
-Always pin to a release tag (`@v1.0.3`), never to `@master`. The composite actions are released as a single unit, so bump every pinned ref together when you upgrade — Renovate groups them under `a-novel-kit workflows` to do exactly that.
+Pin to a release tag, never `@master`. The actions ship as one unit, so bump every reference together on upgrade — Renovate groups them under `a-novel-kit workflows` to do this for you.
 
 ## Action catalog
 
 ### `build-actions`
 
-| Action       | Purpose                                                                                                          |
-| ------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `docker`     | Build a Docker image from a Dockerfile and verify it reports **healthy** when run (long-lived service).          |
-| `docker-job` | Build a Docker image from a Dockerfile and verify it **exits 0** when run (one-shot job); healthcheck skippable. |
+| Action       | Purpose                                                       |
+| ------------ | ------------------------------------------------------------- |
+| `docker`     | Build an image and verify it runs **healthy** (long service). |
+| `docker-job` | Build an image and verify it **exits 0** (one-shot job).      |
 
 ### `generic-actions`
 
-| Action           | Purpose                                                                                      |
-| ---------------- | -------------------------------------------------------------------------------------------- |
-| `approve-bot`    | Auto-approve a pull request (skips if already approved). Restrict to a trusted set of users. |
-| `assign-bot`     | Assign the PR author as the assignee on their own pull request.                              |
-| `auto-merge-bot` | Enable GitHub auto-merge (merge strategy) on a pull request.                                 |
-| `check-changes`  | Detect uncommitted changes in a pathspec; optionally fail the job when any are found.        |
-| `codecov`        | Download the coverage artifact and upload the report to Codecov.                             |
-| `pull-bot`       | Mint a GitHub App token and check out the repo authenticated as the bot.                     |
-| `renovate`       | Run self-hosted Renovate against the repo using the bot App token.                           |
+| Action           | Purpose                                                            |
+| ---------------- | ------------------------------------------------------------------ |
+| `approve-bot`    | Auto-approve a PR (skips if already approved); trusted users only. |
+| `assign-bot`     | Assign the PR author to their own PR.                              |
+| `auto-merge-bot` | Enable auto-merge on a PR.                                         |
+| `check-changes`  | Detect uncommitted changes in a pathspec; optionally fail.         |
+| `codecov`        | Upload the coverage artifact to Codecov.                           |
+| `pull-bot`       | Check out the repo authenticated as the bot.                       |
+| `renovate`       | Run self-hosted Renovate as the bot.                               |
 
 ### `github-pages-actions`
 
-| Action             | Purpose                                              |
-| ------------------ | ---------------------------------------------------- |
-| `publish-vuepress` | Build a VuePress site and deploy it to GitHub Pages. |
+| Action             | Purpose                                    |
+| ------------------ | ------------------------------------------ |
+| `publish-vuepress` | Build a VuePress site and deploy to Pages. |
 
 ### `go-actions`
 
-| Action           | Purpose                                                                          |
-| ---------------- | -------------------------------------------------------------------------------- |
-| `go-report-card` | Trigger a [Go Report Card](https://goreportcard.com) refresh for the repo.       |
-| `lint-go`        | Run `golangci-lint` (checkstyle output), supporting a non-root module directory. |
-| `test-go`        | Run the Go test suite with race + coverage via `gotestsum`; upload the reports.  |
+| Action           | Purpose                                                        |
+| ---------------- | -------------------------------------------------------------- |
+| `go-report-card` | Refresh the repo's [Go Report Card](https://goreportcard.com). |
+| `lint-go`        | Run `golangci-lint` (supports a non-root module dir).          |
+| `test-go`        | Run Go tests (race + coverage) via `gotestsum`.                |
 
 ### `node-actions`
 
-| Action            | Purpose                                                                             |
-| ----------------- | ----------------------------------------------------------------------------------- |
-| `audit`           | Run `pnpm audit --fix`, reformat, and commit the resulting lockfile/override fixes. |
-| `build-node`      | Run the package's build script (default `build`) after a Node/pnpm setup.           |
-| `lint-node`       | Run the package's lint script (default `lint`) after a Node/pnpm setup.             |
-| `security-update` | Publish a patch release for accumulated security fixes, gated on release age.       |
-| `setup-node`      | Set up Node + pnpm wired to the GitHub package registry and install dependencies.   |
-| `test-node`       | Run the package's test script (default `test`) and upload the coverage artifact.    |
+| Action            | Purpose                                                |
+| ----------------- | ------------------------------------------------------ |
+| `audit`           | Run `pnpm audit --fix` and commit the fixes.           |
+| `build-node`      | Run the package's build script (default `build`).      |
+| `lint-node`       | Run the package's lint script (default `lint`).        |
+| `security-update` | Publish a patch release for security fixes, age-gated. |
+| `setup-node`      | Set up Node + pnpm (GitHub registry) and install.      |
+| `test-node`       | Run the package's tests and upload coverage.           |
 
 ### `publish-actions`
 
-| Action         | Purpose                                                                |
-| -------------- | ---------------------------------------------------------------------- |
-| `auto-release` | Create a GitHub release from the pushed tag with auto-generated notes. |
-| `npm`          | Build and publish the workspace packages to the npm (GitHub) registry. |
+| Action         | Purpose                                                |
+| -------------- | ------------------------------------------------------ |
+| `auto-release` | Turn a pushed tag into a GitHub release with notes.    |
+| `npm`          | Publish the workspace packages to the GitHub registry. |
 
 ## Contributing
 
-Platform setup and the day-to-day commands live in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); `workflows`-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md).
+Setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); workflows-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
A further concision pass. These edits were originally pushed onto #173's branch *after* #173 had already merged, so no PR captured them — re-opened cleanly here off current `master`.

- Action-catalog purposes cut to the essential verb.
- Intro/usage prose trimmed; "Questions?" reduced to one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)