### PR TITLE
docs: keep the version only in the copy-paste code block

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ When adding or changing an action:
 
 - Keep `name` and `description` accurate — the README catalog is derived from them by hand.
 - Give every `inputs:` entry a `description` and a `default` where sensible; expose results as `outputs`.
-- When one action calls another here, reference it by pinned tag (`a-novel-kit/workflows/<group>/<name>@v1.0.3`), never a relative path, so each release is self-consistent.
+- When one action calls another here, reference it by pinned tag (`a-novel-kit/workflows/<group>/<name>@<tag>`), never a relative path, so each release is self-consistent.
 
 ## How versions are tagged
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Reusable composite GitHub Actions powering A-Novel CI/CD.
 
 ## What this is
 
-The shared CI/CD building blocks for every **a-novel** and **a-novel-kit** repo. Rather than copy CI logic between repos, each project pulls these actions in with `uses:`, pinned to a release tag (currently `v1.0.3`).
+The shared CI/CD building blocks for every **a-novel** and **a-novel-kit** repo. Rather than copy CI logic between repos, each project pulls these actions in with `uses:`, pinned to a release tag.
 
 Each action lives at `<group>/<name>/action.yaml`, grouped by the kind of work it does. The [Action catalog](#action-catalog) lists them all.
 


### PR DESCRIPTION
The release tag was mentioned in prose ("pinned to a release tag (currently `v1.0.3`)") and in a placeholder example in CONTRIBUTING — both redundant with the repo's releases and prone to going stale.

- Prose now just says "pinned to a release tag".
- The CONTRIBUTING placeholder reads `@<tag>`.
- The concrete `@v1.0.3` stays only in the `uses:` snippet, which is meant to be copied as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)