### PR TITLE
fix(actions): proofread inputs/outputs and descriptions

### DIFF
--- a/build-actions/docker-job/action.yaml
+++ b/build-actions/docker-job/action.yaml
@@ -28,13 +28,13 @@ inputs:
     # Build from the directory containing the Dockerfiles, to mimic the same behavior locally and from the CI.
     default: .
   secrets:
-    description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)"
+    description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)."
     required: false
   secret-envs:
-    description: "List of secret env vars to expose to the build (e.g., key=envname, MY_SECRET=MY_ENV_VAR)"
+    description: "List of secret env vars to expose to the build (e.g., key=envname, MY_SECRET=MY_ENV_VAR)."
     required: false
   secret-files:
-    description: "List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)"
+    description: "List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)."
     required: false
 
 outputs:
@@ -42,7 +42,7 @@ outputs:
     description: The digest of the built image.
     value: ${{ steps.build.outputs.digest }}
   imageid:
-    description: The tags of the built image.
+    description: The ID of the built image.
     value: ${{ steps.build.outputs.imageid }}
 
 runs:
@@ -90,7 +90,7 @@ runs:
         state="`docker inspect --type=container -f {{.State.Status}} test-container`"
 
         until [ "$state" == "exited" ]
-        do 
+        do
           state="`docker inspect --type=container -f {{.State.Status}} test-container`"
           ((c++)) && ((c==${{ inputs.timeout }})) && break
           sleep 0.1

--- a/build-actions/docker/action.yaml
+++ b/build-actions/docker/action.yaml
@@ -25,13 +25,13 @@ inputs:
     # Build from the directory containing the Dockerfiles, to mimic the same behavior locally and from the CI.
     default: .
   secrets:
-    description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)"
+    description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)."
     required: false
   secret-envs:
-    description: "List of secret env vars to expose to the build (e.g., key=envname, MY_SECRET=MY_ENV_VAR)"
+    description: "List of secret env vars to expose to the build (e.g., key=envname, MY_SECRET=MY_ENV_VAR)."
     required: false
   secret-files:
-    description: "List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)"
+    description: "List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)."
     required: false
 
 outputs:
@@ -39,7 +39,7 @@ outputs:
     description: The digest of the built image.
     value: ${{ steps.build.outputs.digest }}
   imageid:
-    description: The tags of the built image.
+    description: The ID of the built image.
     value: ${{ steps.build.outputs.imageid }}
 
 runs:

--- a/generic-actions/approve-bot/action.yaml
+++ b/generic-actions/approve-bot/action.yaml
@@ -4,7 +4,7 @@ description: Automatically approves a pull request. Make sure to only enable thi
 inputs:
   pull_request:
     required: true
-    description: The URL of the pull request to be merged.
+    description: The URL of the pull request to be approved.
   github_token:
     required: true
     description: The GitHub token to use for the action.

--- a/generic-actions/check-changes/action.yaml
+++ b/generic-actions/check-changes/action.yaml
@@ -17,7 +17,7 @@ inputs:
 
 outputs:
   diff:
-    description: "Whether or not there are uncommitted changes in the pathspec"
+    description: "Set to 1 when there are uncommitted changes in the pathspec; empty otherwise."
     value: ${{ steps.check_diff.outputs.diff }}
 
 runs:
@@ -30,7 +30,7 @@ runs:
         if [ -z "$(git status --porcelain -- ${{ inputs.pathspec }})" ];
         then
           exit 0
-        else 
+        else
           echo "diff=1" >> $GITHUB_OUTPUT
         fi
     - name: fail if changes

--- a/generic-actions/codecov/action.yaml
+++ b/generic-actions/codecov/action.yaml
@@ -4,16 +4,16 @@ description: Uploads code coverage reports to Codecov.
 inputs:
   coverage_artifact:
     required: false
-    description: The name of the artifact to store the coverage report.
+    description: The name of the artifact to download the coverage report from.
   coverage_artifact_ids:
     required: false
-    description: The ids of the coverage report file.
+    description: The IDs of the artifacts to download.
   coverage_files:
     required: false
-    description: The name of the coverage report file.
+    description: The coverage report file(s) to upload.
   codecov_token:
     required: true
-    description: The codecov token used to upload coverage reports
+    description: The codecov token used to upload coverage reports.
 
 runs:
   using: "composite"

--- a/generic-actions/pull-bot/action.yaml
+++ b/generic-actions/pull-bot/action.yaml
@@ -4,10 +4,10 @@ description: Generate a GitHub App token and check out the repository authentica
 inputs:
   app_private_key:
     required: true
-    description: The Github App private key.
+    description: The GitHub App private key.
   app_id:
     required: true
-    description: The Github App ID.
+    description: The GitHub App ID.
   fetch_depth:
     required: false
     description: Number of commits to fetch. 0 indicates all history for all branches and tags.

--- a/generic-actions/pull-bot/action.yaml
+++ b/generic-actions/pull-bot/action.yaml
@@ -1,4 +1,5 @@
 name: pull bot
+description: Generate a GitHub App token and check out the repository authenticated as the bot.
 
 inputs:
   app_private_key:
@@ -19,7 +20,7 @@ inputs:
 outputs:
   token:
     description: The bot token.
-    value: ${{ steps.get_token.outputs.token  }}
+    value: ${{ steps.get_token.outputs.token }}
   app_login:
     description: The login name of the bot.
     value: ${{ steps.get_token.outputs.app-slug }}[bot]

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -1,4 +1,5 @@
 name: self-hosted renovate
+description: Run a self-hosted Renovate pass against the repository, authenticated as the bot.
 
 inputs:
   allowed_commands:

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -10,10 +10,10 @@ inputs:
     description: The GitHub token to use for the action.
   app_private_key:
     required: true
-    description: The Github App private key.
+    description: The GitHub App private key.
   app_id:
     required: true
-    description: The Github App ID.
+    description: The GitHub App ID.
 
 runs:
   using: "composite"

--- a/github-pages-actions/publish-vuepress/action.yaml
+++ b/github-pages-actions/publish-vuepress/action.yaml
@@ -1,4 +1,5 @@
 name: publish vuepress page
+description: Build a VuePress site and deploy it to GitHub Pages.
 
 inputs:
   cmd:

--- a/go-actions/go-report-card/action.yaml
+++ b/go-actions/go-report-card/action.yaml
@@ -1,4 +1,5 @@
 name: go report card
+description: Refresh the repository's goreportcard.com report.
 
 runs:
   using: "composite"

--- a/go-actions/lint-go/action.yaml
+++ b/go-actions/lint-go/action.yaml
@@ -1,10 +1,7 @@
 name: lint go
+description: Run golangci-lint and write a checkstyle report.
 
 inputs:
-  golangci_lint_artifact:
-    required: false
-    description: The name of the artifact to store the lint report.
-    default: go-lint
   golangci_lint_file:
     required: false
     description: The name of the lint report file.

--- a/go-actions/lint-go/action.yaml
+++ b/go-actions/lint-go/action.yaml
@@ -1,11 +1,7 @@
 name: lint go
-description: Run golangci-lint and write a checkstyle report.
+description: Run golangci-lint over the Go module.
 
 inputs:
-  golangci_lint_file:
-    required: false
-    description: The name of the lint report file.
-    default: golangci-lint-report.xml
   working-directory:
     required: false
     description: The working directory to run the scan from.
@@ -22,6 +18,5 @@ runs:
         go-version-file: ${{ inputs.working-directory && format('{0}/go.mod', inputs.working-directory) || 'go.mod' }}
     - uses: golangci/golangci-lint-action@v9
       with:
-        args: --output.checkstyle.path=${{ inputs.golangci_lint_file }}
         version: latest
         working-directory: ${{ inputs.working-directory }}

--- a/go-actions/test-go/action.yaml
+++ b/go-actions/test-go/action.yaml
@@ -1,10 +1,7 @@
 name: test go
+description: Run the Go test suite across the workspace with coverage and upload the report.
 
 inputs:
-  test_args:
-    required: false
-    description: The arguments to pass to the test command.
-    default: -p 1 -race
   test_artifact:
     required: false
     description: The name of the artifact to store the test report.

--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -1,4 +1,5 @@
 name: audit
+description: Run pnpm audit --fix and commit any resulting dependency fixes as the bot.
 
 inputs:
   github_token:
@@ -6,10 +7,10 @@ inputs:
     description: The GitHub token to use for the action.
   app_private_key:
     required: true
-    description: The Github App private key.
+    description: The GitHub App private key.
   app_id:
     required: true
-    description: The Github App ID.
+    description: The GitHub App ID.
 
 runs:
   using: "composite"
@@ -44,10 +45,10 @@ runs:
       id: check_diff
       shell: bash
       run: |
-        if [ -z "$(git status --porcelain -- ${{ inputs.pathspec }})" ];
+        if [ -z "$(git status --porcelain)" ];
         then
           echo "diff=0" >> $GITHUB_OUTPUT
-        else 
+        else
           echo "diff=1" >> $GITHUB_OUTPUT
         fi
     - name: publish audit update

--- a/node-actions/build-node/action.yaml
+++ b/node-actions/build-node/action.yaml
@@ -1,4 +1,5 @@
 name: build node
+description: Set up Node and run the package's build script.
 
 inputs:
   build_action:
@@ -10,10 +11,10 @@ inputs:
     description: The GitHub token to use for the action.
   app_private_key:
     required: true
-    description: The Github App private key.
+    description: The GitHub App private key.
   app_id:
     required: true
-    description: The Github App ID.
+    description: The GitHub App ID.
 
 runs:
   using: "composite"

--- a/node-actions/lint-node/action.yaml
+++ b/node-actions/lint-node/action.yaml
@@ -1,4 +1,5 @@
 name: lint node
+description: Set up Node and run the package's lint script.
 
 inputs:
   lint_action:
@@ -10,10 +11,10 @@ inputs:
     description: The GitHub token to use for the action.
   app_private_key:
     required: true
-    description: The Github App private key.
+    description: The GitHub App private key.
   app_id:
     required: true
-    description: The Github App ID.
+    description: The GitHub App ID.
 
 runs:
   using: "composite"

--- a/node-actions/security-update/action.yaml
+++ b/node-actions/security-update/action.yaml
@@ -1,4 +1,5 @@
 name: security update node
+description: Publish a patch release for accumulated security fixes when the latest release is old enough.
 
 inputs:
   publish_action:
@@ -10,10 +11,10 @@ inputs:
     description: The GitHub token to use for the action.
   app_private_key:
     required: true
-    description: The Github App private key.
+    description: The GitHub App private key.
   app_id:
     required: true
-    description: The Github App ID.
+    description: The GitHub App ID.
   min_days_since_last_release:
     required: false
     description: The minimum number of days since the last release to trigger a security update.

--- a/node-actions/setup-node/action.yaml
+++ b/node-actions/setup-node/action.yaml
@@ -1,4 +1,5 @@
 name: setup node
+description: Authenticate as the GitHub App, set up pnpm and Node against the GitHub package registry, and install dependencies.
 
 inputs:
   github_token:
@@ -6,10 +7,10 @@ inputs:
     description: The GitHub token to use for the action.
   app_private_key:
     required: true
-    description: The Github App private key.
+    description: The GitHub App private key.
   app_id:
     required: true
-    description: The Github App ID.
+    description: The GitHub App ID.
 
 outputs:
   token:

--- a/node-actions/test-node/action.yaml
+++ b/node-actions/test-node/action.yaml
@@ -1,4 +1,5 @@
 name: test node
+description: Set up Node, run the package's test script, and upload the coverage report.
 
 inputs:
   test_action:
@@ -10,10 +11,10 @@ inputs:
     description: The GitHub token to use for the action.
   app_private_key:
     required: true
-    description: The Github App private key.
+    description: The GitHub App private key.
   app_id:
     required: true
-    description: The Github App ID.
+    description: The GitHub App ID.
   coverage_artifact:
     required: false
     description: The name of the artifact to store the coverage report.
@@ -40,7 +41,7 @@ runs:
     - name: run test
       shell: bash
       run: pnpm run ${{ inputs.test_action }}
-    - name: Archive code coverage results
+    - name: archive code coverage results
       id: upload-artifact
       uses: actions/upload-artifact@v7
       with:

--- a/publish-actions/auto-release/action.yaml
+++ b/publish-actions/auto-release/action.yaml
@@ -1,9 +1,10 @@
 name: auto release
+description: Create a GitHub release for the pushed tag with auto-generated notes.
 
 inputs:
   github_token:
     required: true
-    description: The GitHub token to use for deleting old images
+    description: The GitHub token used to create the release.
 
 runs:
   using: "composite"

--- a/publish-actions/npm/action.yaml
+++ b/publish-actions/npm/action.yaml
@@ -1,4 +1,5 @@
 name: publish npm
+description: Set up Node, build the package, and publish it to the GitHub npm registry.
 
 inputs:
   build_action:
@@ -10,10 +11,10 @@ inputs:
     description: The GitHub token to use for the action.
   app_private_key:
     required: true
-    description: The Github App private key.
+    description: The GitHub App private key.
   app_id:
     required: true
-    description: The Github App ID.
+    description: The GitHub App ID.
 
 runs:
   using: "composite"


### PR DESCRIPTION
Proofreads all 21 composite actions — inputs/outputs, stale inputs, description accuracy and formatting.

## Fixes
- **Top-level `description:`** added to the 14 actions that lacked one.
- **Stale inputs removed:** `test-go: test_args` and `lint-go: golangci_lint_artifact` (declared, never referenced).
- **Bug:** `audit` referenced an undeclared `inputs.pathspec` (rendered empty) → now a plain whole-tree `git status`.
- **Inaccurate descriptions corrected:** `docker`/`docker-job` `imageid` ("tags" → "ID"); `auto-release` token ("deleting old images" → "create the release"); `approve-bot` ("merged" → "approved"); three `codecov` inputs; `check-changes` `diff`.
- **Typo:** "Github" → "GitHub" in the App-credential inputs (9 actions).
- **Formatting:** missing periods, a double space in `pull-bot`'s output value, trailing whitespace, one Title-cased step name.

## Maintainer decisions (now applied)
- **`test-go` race detector:** the removed `test_args` defaulted to `-p 1 -race`, but the test command never used it. Decision — drop the dead input; do **not** enable the race detector (adds CI constraints, unreliable in CI).
- **`lint-go` report:** the checkstyle report was written but never uploaded or consumed, and `golangci-lint-action` already annotates findings and fails on errors. Decision — **scrap it**: removed the report file input and the `--output.checkstyle.path` arg entirely.

No behavior change for consumers pinned to the current tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)