### PR TITLE
docs: make the workflows CONTRIBUTING actually explain itself

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,23 @@ Platform setup and day-to-day commands are in the [developer onboarding guide](h
 
 ## How an action is structured
 
-Every action lives at `<group>/<name>/action.yaml` — a [composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action) chaining other actions and `shell: bash` steps. The group names the kind of work it does (`build-actions`, `go-actions`, `node-actions`, …).
+Each action is a [composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action): a small, reusable building block that bundles several steps behind a single `uses:` reference, so a caller runs the whole thing in one line. Its definition lives at `<group>/<name>/action.yaml`, and the `<group>` says what kind of work it does — `build-actions` build container images, `go-actions` and `node-actions` drive the Go and Node toolchains, `generic-actions` are language-agnostic helpers (bots, Renovate, Codecov), and `publish-actions` / `github-pages-actions` ship releases and docs.
 
-When adding or changing an action:
+Inside an `action.yaml`, the `runs:` block is the list of steps the action performs. A step either calls another action (`uses:`) or runs a shell script (`run:`, with `shell: bash`). A caller passes values _in_ through the action's `inputs:` and reads results _out_ through its `outputs:`.
 
-- Keep `name` and `description` accurate — the README catalog is derived from them by hand.
-- Give every `inputs:` entry a `description` and a `default` where sensible; expose results as `outputs`.
-- When one action calls another here, reference it by pinned tag (`a-novel-kit/workflows/<group>/<name>@<tag>`), never a relative path, so each release is self-consistent.
+When you add or change an action, keep it self-describing:
 
-## How versions are tagged
+- **`name` and `description`** are the first thing a reader sees, and the action catalog in the [README](./README.md) is written by hand from them. Keep both accurate, and update the README whenever they change.
+- **Give every input a `description`**, plus a `default` when there's a sensible one — that way a caller only has to pass the values it actually wants to override. Reserve `required: true` for inputs the action genuinely cannot run without.
+- **Surface anything a caller might need back** — a token, an artifact id, a computed flag — as an `output` wired to the step that produces it. A useful result left unexposed is effectively lost.
 
-One `v*` tag covers the whole repo. Consumers pin every `uses:` to that tag (not `@master`) and bump them together — Renovate groups them under `a-novel-kit workflows`. Tagging the repo cuts a release: `publish-actions/auto-release` turns the tag into a GitHub release with generated notes.
+## How versions are released and consumed
+
+The whole repository is versioned as one unit: a single `v*` git tag (for example `v1.0.3`) covers every action at once. There are no per-action version numbers.
+
+**Releasing.** Pushing a `v*` tag is what creates a release — the `publish-actions/auto-release` action turns that tag into a GitHub Release with auto-generated notes. Because everything ships together, one action may depend on another in this repo, but it must reference it by its **pinned tag** (`a-novel-kit/workflows/<group>/<name>@<tag>`), never a relative path. That keeps a release internally consistent: every action in `v1.0.3` calls the `v1.0.3` version of its siblings, rather than silently picking up whatever currently sits on `master`.
+
+**Consuming.** Downstream repos pin every `uses:` to a release tag (never `@master`) so their CI is reproducible. When they upgrade, they bump all of those references at once — Renovate groups them into a single `a-novel-kit workflows` update so the versions never drift apart.
 
 ## Questions?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ When you add or change an action, keep it self-describing:
 
 - **`name` and `description`** are the first thing a reader sees, and the action catalog in the [README](./README.md) is written by hand from them. Keep both accurate, and update the README whenever they change.
 - **Give every input a `description`**, plus a `default` when there's a sensible one — that way a caller only has to pass the values it actually wants to override. Reserve `required: true` for inputs the action genuinely cannot run without.
-- **Surface anything a caller might need back** — a token, an artifact id, a computed flag — as an `output` wired to the step that produces it. A useful result left unexposed is effectively lost.
+- **Surface anything a caller might need back** — a token, an artifact ID, a computed flag — as an `output` wired to the step that produces it. A useful result left unexposed is effectively lost.
 
 ## How versions are released and consumed
 
-The whole repository is versioned as one unit: a single `v*` git tag (for example `v1.0.3`) covers every action at once. There are no per-action version numbers.
+The whole repository is versioned as one unit: a single `v*` Git tag (for example `v1.0.3`) covers every action at once. There are no per-action version numbers.
 
 **Releasing.** Pushing a `v*` tag is what creates a release — the `publish-actions/auto-release` action turns that tag into a GitHub Release with auto-generated notes. Because everything ships together, one action may depend on another in this repo, but it must reference it by its **pinned tag** (`a-novel-kit/workflows/<group>/<name>@<tag>`), never a relative path. That keeps a release internally consistent: every action in `v1.0.3` calls the `v1.0.3` version of its siblings, rather than silently picking up whatever currently sits on `master`.
 


### PR DESCRIPTION
The CONTRIBUTING had been tightened to the point of being hard to follow — it gestured at the composite-action and release models instead of explaining them.

This rewrite teaches the reader:
- **What a composite action is** (a reusable block bundling steps behind one `uses:`), what each group does, and the `inputs`/`outputs` data flow.
- **The self-describing checklist** with the reasoning behind each point (why the README catalog must match `name`/`description`; why defaults matter; why results need outputs).
- **The release model** — single repo-wide `v*` tag, why internal references are pinned by tag (a release calls its own siblings, not `master`), and how downstream repos consume + bump via Renovate.

Longer than before, on purpose: the topic needs the words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)