### PR TITLE
docs: focus CONTRIBUTING on repo specifics, link GitHub docs for the rest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,25 +2,19 @@
 
 Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file covers what's specific to `workflows`.
 
-## How an action is structured
+Everything here is a [composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action); GitHub's docs cover the [`runs` / `inputs` / `outputs` syntax](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions). The rest of this file is the conventions particular to this repo.
 
-Each action is a [composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action): a small, reusable building block that bundles several steps behind a single `uses:` reference, so a caller runs the whole thing in one line. Its definition lives at `<group>/<name>/action.yaml`, where `<group>` collects actions by the kind of work they do — the [Action catalog](./README.md#action-catalog) in the README lists every group and what's in it.
+## Layout and the catalog
 
-Inside an `action.yaml`, the `runs:` block is the list of steps the action performs. A step either calls another action (`uses:`) or runs a shell script (`run:`, with `shell: bash`). A caller passes values _in_ through the action's `inputs:` and reads results _out_ through its `outputs:`.
+Each action lives at `<group>/<name>/action.yaml`, grouped by the kind of work it does — the [Action catalog](./README.md#action-catalog) in the README is the full list. That catalog is maintained by hand from each action's `name` and `description`, so keep those two fields accurate and update the README whenever they change.
 
-When you add or change an action, keep it self-describing:
+## Versioning
 
-- **`name` and `description`** are the first thing a reader sees, and the action catalog in the [README](./README.md) is written by hand from them. Keep both accurate, and update the README whenever they change.
-- **Give every input a `description`**, plus a `default` when there's a sensible one — that way a caller only has to pass the values it actually wants to override. Reserve `required: true` for inputs the action genuinely cannot run without.
-- **Surface anything a caller might need back** — a token, an artifact ID, a computed flag — as an `output` wired to the step that produces it. A useful result left unexposed is effectively lost.
+The whole repository is released as a single unit: one `v*` Git tag covers every action at once, with no per-action versions. Pushing a `v*` tag creates the release, and `publish-actions/auto-release` turns it into a GitHub Release with generated notes.
 
-## How versions are released and consumed
+Because everything ships together, an action may depend on another in this repo — but reference it by its pinned tag (`a-novel-kit/workflows/<group>/<name>@<tag>`), never a relative path. That keeps a release internally consistent: every action in a release calls that same release's version of its siblings, rather than whatever currently sits on `master`.
 
-The whole repository is versioned as one unit: a single `v*` Git tag (for example `v1.0.3`) covers every action at once. There are no per-action version numbers.
-
-**Releasing.** Pushing a `v*` tag is what creates a release — the `publish-actions/auto-release` action turns that tag into a GitHub Release with auto-generated notes. Because everything ships together, one action may depend on another in this repo, but it must reference it by its **pinned tag** (`a-novel-kit/workflows/<group>/<name>@<tag>`), never a relative path. That keeps a release internally consistent: every action in `v1.0.3` calls the `v1.0.3` version of its siblings, rather than silently picking up whatever currently sits on `master`.
-
-**Consuming.** Downstream repos pin every `uses:` to a release tag (never `@master`) so their CI is reproducible. When they upgrade, they bump all of those references at once — Renovate groups them into a single `a-novel-kit workflows` update so the versions never drift apart.
+Downstream repos pin every `uses:` to a release tag (never `@master`) so their CI is reproducible, and bump them together on upgrade — Renovate groups them into one `a-novel-kit workflows` update so the versions never drift apart.
 
 ## Questions?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Each action lives at `<group>/<name>/action.yaml`, grouped by the kind of work i
 
 ## Versioning
 
-The whole repository is released as a single unit: one `v*` Git tag covers every action at once, with no per-action versions. Pushing a `v*` tag creates the release, and `publish-actions/auto-release` turns it into a GitHub Release with generated notes.
+The whole repository is released as a single unit: a single Git tag covers every action at once, with no per-action versions. Release tags follow the `v*` convention; pushing one triggers `publish-actions/auto-release`, which turns it into a GitHub Release with generated notes.
 
 Because everything ships together, an action may depend on another in this repo — but reference it by its pinned tag (`a-novel-kit/workflows/<group>/<name>@<tag>`), never a relative path. That keeps a release internally consistent: every action in a release calls that same release's version of its siblings, rather than whatever currently sits on `master`.
 


### PR DESCRIPTION
CONTRIBUTING is for contributors, who already know GitHub Actions — so it shouldn't re-document how composite actions / `runs` / `inputs` / `outputs` work. This rewrite links the official docs for that and keeps only what's specific to this repo:

- **Layout + catalog** — the `<group>/<name>/action.yaml` layout and the `name`/`description` ↔ README Action-catalog coupling.
- **Versioning** — the single repo-wide `v*` tag, why internal references are pinned by tag, and how downstream repos consume + bump via Renovate.

Also removes the useless `(for example v1.0.3)` example tag (and the other inline `v1.0.3` examples) from the versioning section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)