### PR TITLE
feat(ci): add archive-board-items action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,3 +18,10 @@ jobs:
       - uses: ./publish-actions/auto-release
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      # Everything on master just shipped, so clear this repo's awaiting-release
+      # work off the org board. Uses the [Agent] bot (App id inlined per org, as
+      # in bot-comment.yaml) since GITHUB_TOKEN can't see org Projects.
+      - uses: ./generic-actions/archive-board-items
+        with:
+          app_id: ${{ github.repository_owner == 'a-novel' && '3549319' || '3549379' }}
+          app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,3 +25,4 @@ jobs:
         with:
           app_id: ${{ github.repository_owner == 'a-novel' && '3549319' || '3549379' }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
+          project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}

--- a/generic-actions/archive-board-items/action.yaml
+++ b/generic-actions/archive-board-items/action.yaml
@@ -19,10 +19,12 @@ inputs:
     required: false
     default: Awaiting release
     description: Archive this repo's items whose Status equals this value.
-  project_title:
-    required: false
-    default: Tasks
-    description: Title of the org board to operate on (one "Tasks" board per org).
+  project_id:
+    required: true
+    description: >
+      Node id of the org "Tasks" board (e.g. PVT_…). Passed in directly — inline
+      it per-org in the caller, the same way app_id is — so the action needs no
+      title lookup. Find it with: gh project view <n> --owner <org> --format json.
   dry_run:
     required: false
     default: "false"
@@ -47,28 +49,21 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ steps.token.outputs.token }}
-        OWNER: ${{ github.repository_owner }}
         REPO_FULL: ${{ github.repository }}
         STATUS: ${{ inputs.status }}
-        PROJECT_TITLE: ${{ inputs.project_title }}
+        PROJECT_ID: ${{ inputs.project_id }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         set -euo pipefail
 
-        # 1. Resolve the org's project id by title — one "Tasks" board per org.
-        proj_id=$(gh api graphql -f query='
-          query($org:String!){ organization(login:$org){
-            projectsV2(first:50){ nodes{ id title } } } }' \
-          -F org="$OWNER" \
-          | jq -r --arg t "$PROJECT_TITLE" \
-              '.data.organization.projectsV2.nodes[] | select(.title==$t) | .id' \
-          | head -n1)
+        # The org "Tasks" board id is passed in directly — no title lookup.
+        proj_id="$PROJECT_ID"
         if [ -z "$proj_id" ]; then
-          echo "::error::no org project titled '$PROJECT_TITLE' under '$OWNER'"
+          echo "::error::project_id is required (the org \"Tasks\" board node id)"
           exit 1
         fi
 
-        # 2. Page the board, keeping this repo's still-on-board items in $STATUS.
+        # Page the board, keeping this repo's still-on-board items in $STATUS.
         #    isArchived guards idempotency: an already-archived item is skipped,
         #    so a re-run (or overlapping triggers) never double-archives.
         items_q='
@@ -103,7 +98,7 @@ runs:
         echo "Found ${count:-0} '$STATUS' item(s) for $REPO_FULL." | tee -a "$GITHUB_STEP_SUMMARY"
         [ "${count:-0}" -eq 0 ] && exit 0
 
-        # 3. Archive each match (or just report, under dry-run).
+        # Archive each match (or just report, under dry-run).
         archive_m='mutation($proj:ID!,$item:ID!){
           archiveProjectV2Item(input:{projectId:$proj,itemId:$item}){ item{ id } } }'
         while IFS= read -r row; do

--- a/generic-actions/archive-board-items/action.yaml
+++ b/generic-actions/archive-board-items/action.yaml
@@ -1,0 +1,119 @@
+name: archive board items
+description: >
+  Archive a repository's "Awaiting release" items from the org "Tasks" project.
+  Run it from the release workflow when the repo publishes (everything on master
+  ships, so its awaiting-release work is now released), or — for repos that never
+  publish (e.g. .github) — on merge to the default branch, to clear shipped work
+  off the board automatically. Idempotent and safe to re-run.
+
+inputs:
+  app_id:
+    required: true
+    description: >
+      App ID for the org's [Agent] bot. The default GITHUB_TOKEN cannot see
+      org-level Projects v2, so a bot token is required.
+  app_private_key:
+    required: true
+    description: The [Agent] bot App private key (PEM) — the AGENT_BOT_PRIVATE_KEY org secret.
+  status:
+    required: false
+    default: Awaiting release
+    description: Archive this repo's items whose Status equals this value.
+  project_title:
+    required: false
+    default: Tasks
+    description: Title of the org board to operate on (one "Tasks" board per org).
+  dry_run:
+    required: false
+    default: "false"
+    description: When "true", log what would be archived without archiving anything.
+
+runs:
+  using: composite
+  steps:
+    # Mint a token that can write the org's Projects v2 — and nothing else.
+    # The [Agent] App can do more (issues/PRs), but we request only the org
+    # Projects scope, so a leak of this step's token is bounded to board edits.
+    - name: Mint org-Projects token
+      id: token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: ${{ github.repository_owner }}
+        permission-organization-projects: write
+
+    - name: Archive this repo's awaiting-release items
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.token.outputs.token }}
+        OWNER: ${{ github.repository_owner }}
+        REPO_FULL: ${{ github.repository }}
+        STATUS: ${{ inputs.status }}
+        PROJECT_TITLE: ${{ inputs.project_title }}
+        DRY_RUN: ${{ inputs.dry_run }}
+      run: |
+        set -euo pipefail
+
+        # 1. Resolve the org's project id by title — one "Tasks" board per org.
+        proj_id=$(gh api graphql -f query='
+          query($org:String!){ organization(login:$org){
+            projectsV2(first:50){ nodes{ id title } } } }' \
+          -F org="$OWNER" \
+          | jq -r --arg t "$PROJECT_TITLE" \
+              '.data.organization.projectsV2.nodes[] | select(.title==$t) | .id' \
+          | head -n1)
+        if [ -z "$proj_id" ]; then
+          echo "::error::no org project titled '$PROJECT_TITLE' under '$OWNER'"
+          exit 1
+        fi
+
+        # 2. Page the board, keeping this repo's still-on-board items in $STATUS.
+        #    isArchived guards idempotency: an already-archived item is skipped,
+        #    so a re-run (or overlapping triggers) never double-archives.
+        items_q='
+          query($proj:ID!,$cursor:String){ node(id:$proj){ ... on ProjectV2{
+            items(first:100, after:$cursor){
+              pageInfo{ hasNextPage endCursor }
+              nodes{ id isArchived
+                status: fieldValueByName(name:"Status"){
+                  ... on ProjectV2ItemFieldSingleSelectValue{ name } }
+                content{
+                  ... on Issue{ repository{ nameWithOwner } number url }
+                  ... on PullRequest{ repository{ nameWithOwner } number url } } } } } } }'
+
+        matches=$(mktemp)
+        cursor=""
+        while :; do
+          args=(-F proj="$proj_id")
+          [ -n "$cursor" ] && args+=(-F cursor="$cursor")
+          resp=$(gh api graphql -f query="$items_q" "${args[@]}")
+          echo "$resp" | jq -c --arg repo "$REPO_FULL" --arg status "$STATUS" '
+            .data.node.items.nodes[]
+            | select(
+                (.isArchived | not)
+                and .status.name == $status
+                and (.content.repository.nameWithOwner // "") == $repo)
+            | {id, number: .content.number, url: .content.url}' >> "$matches"
+          [ "$(echo "$resp" | jq -r '.data.node.items.pageInfo.hasNextPage')" = "true" ] || break
+          cursor=$(echo "$resp" | jq -r '.data.node.items.pageInfo.endCursor')
+        done
+
+        count=$(grep -c '' "$matches" || true)
+        echo "Found ${count:-0} '$STATUS' item(s) for $REPO_FULL." | tee -a "$GITHUB_STEP_SUMMARY"
+        [ "${count:-0}" -eq 0 ] && exit 0
+
+        # 3. Archive each match (or just report, under dry-run).
+        archive_m='mutation($proj:ID!,$item:ID!){
+          archiveProjectV2Item(input:{projectId:$proj,itemId:$item}){ item{ id } } }'
+        while IFS= read -r row; do
+          id=$(echo "$row" | jq -r '.id')
+          num=$(echo "$row" | jq -r '.number')
+          url=$(echo "$row" | jq -r '.url')
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "- [dry-run] would archive #$num ($url)" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            gh api graphql -f query="$archive_m" -F proj="$proj_id" -F item="$id" >/dev/null
+            echo "- archived #$num ($url)" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+        done < "$matches"


### PR DESCRIPTION
## Summary

- New composite action `generic-actions/archive-board-items` that archives a repo's **`Awaiting release`** items from the org **Tasks** board when the work ships — the one piece of code behind a-novel-kit/.github#34 (release-aware board lifecycle).
- Wires it into this repo's own `release` workflow to dogfood the publish path.

## How it works

- Mints an **`[Agent]`** App token inline, requesting **only** `permission-organization-projects: write` — the default `GITHUB_TOKEN` can't see org-level Projects v2. App id is inlined per org (as in `bot-comment.yaml`); key is the existing `AGENT_BOT_PRIVATE_KEY` org secret. No dispatcher needed (CI-triggered → key already in CI; an inline Projects-only token is simpler and equally contained).
- Resolves the org `Tasks` project, pages its items, and archives those whose **Repository == this repo** and **Status == `Awaiting release`**.
- **Idempotent**: an `isArchived` guard skips already-archived items, so overlapping triggers/re-runs never double-archive.
- **`dry_run`** input logs what *would* be archived without touching anything.

## Invocation

- **Repos that publish** — add the step to the `release` workflow (done here for this repo).
- **No-release repos (`.github`)** — call it on merge to the default branch instead.

## Breaking changes

None. New action; the only wiring change is additive (a step after `auto-release`).

## Test plan

- [x] YAML parses; embedded bash passes `bash -n`.
- [x] `prettier --check` clean.
- [x] GraphQL project-resolution + the exact `repo + status` filter (incl. `isArchived` and null-repo guards) validated against the live board with a `project`-scoped token: `Done`+`.github` → #30/#35; `Awaiting release` → 0.
- [ ] CI dry-run on the real board (the `dry_run` input) before the first live archival.
- [ ] Exercised end-to-end on this repo's next release (token minting is CI-only).

Closes #182. Part of a-novel-kit/.github#34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)