### PR TITLE
docs: link concepts doc; use "composite action" consistently

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to workflows
 
-Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file covers what's specific to `workflows`.
+The platform taxonomy — repository kinds, where the reusable **composite actions** sit in the tooling layer, and the versioning model — lives in the [libraries, tooling & platform concepts](https://github.com/a-novel-kit/.github/blob/master/CONTRIBUTING.md); this file covers what's specific to `workflows`. Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md).
 
 Everything here is a [composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action); GitHub's docs cover the [`runs` / `inputs` / `outputs` syntax](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions). The rest of this file is the conventions particular to this repo.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Reusable composite GitHub Actions powering A-Novel CI/CD.
 
 ## What this is
 
-The shared CI/CD building blocks for every **a-novel** and **a-novel-kit** repo. Rather than copy CI logic between repos, each project pulls these actions in with `uses:`, pinned to a release tag.
+The shared CI/CD building blocks for every **a-novel** and **a-novel-kit** repo. Each is a **composite action**: rather than copy CI logic between repos, a project pulls these composite actions in with `uses:`, pinned to a release tag.
 
-Each action lives at `<group>/<name>/action.yaml`, grouped by the kind of work it does. The [Action catalog](#action-catalog) lists them all.
+Each composite action lives at `<group>/<name>/action.yaml`, grouped by the kind of work it does. The [Action catalog](#action-catalog) lists them all.
 
 ## Using an action
 


### PR DESCRIPTION
## Summary

- Link CONTRIBUTING to the [libraries, tooling & platform concepts](https://github.com/a-novel-kit/.github/blob/master/CONTRIBUTING.md) (the #30 deliverable).
- Establish **composite action** as the unit term in the README role section (retiring the loose bare "action" on first/defining use). The fleet-standard `## Using an action` heading and the `#action-catalog` anchor are kept intact.

The `v*` pinning rule and single-unit release model were already explicit in CONTRIBUTING; no change needed there. Doc-only. Part of the **Taxonomy & glossary** milestone (a-novel-kit/.github#29).

Closes #181