### PR TITLE
feat(ci): UI-dispatched release with release-core

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,27 +1,66 @@
 name: release
 
+# Releases are cut from the GitHub UI (Actions ▸ release ▸ pick a type ▸ Run),
+# not from a developer's terminal. workflow_call exposes the same inputs so an
+# agent can drive an identical release headlessly later. The protected `release`
+# environment is the "who can publish" gate (configure its required reviewers).
 on:
-  push:
-    tags:
-      - "**"
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Version bump to cut
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: Bump & report only — no commit, tag, push, or release
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      release_type:
+        required: true
+        type: string
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+
+run-name: "🚀 release ${{ inputs.release_type }}${{ inputs.dry_run && ' (dry-run)' || '' }}"
+
+# One release at a time per repo, so two runs can't race the version bump.
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.core.outputs.version }}
+      tag: ${{ steps.core.outputs.tag }}
     steps:
-      # Check out the tagged commit and run the local action from it, so the
-      # release is cut with this repo's own action at the tag — reproducible,
-      # and with no unpinned cross-repo @master self-reference.
+      # Initial checkout makes the local ./publish-actions/* actions available;
+      # release-core re-checks-out with the bot token to push.
       - uses: actions/checkout@v7
-      - uses: ./publish-actions/auto-release
+      - id: core
+        uses: ./publish-actions/release-core
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      # Everything on master just shipped, so clear this repo's awaiting-release
-      # work off the org board. Uses the [Agent] bot (App id inlined per org, as
-      # in bot-comment.yaml) since GITHUB_TOKEN can't see org Projects.
-      - uses: ./generic-actions/archive-board-items
+          release_type: ${{ inputs.release_type }}
+          dry_run: ${{ inputs.dry_run }}
+          app_id: ${{ github.repository_owner == 'a-novel' && '3549319' || '3549379' }}
+          app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
+      # Everything on master just shipped — clear this repo's awaiting-release
+      # items off the board. Skipped on a dry run (nothing was released).
+      - if: ${{ !inputs.dry_run }}
+        uses: ./generic-actions/archive-board-items
         with:
           app_id: ${{ github.repository_owner == 'a-novel' && '3549319' || '3549379' }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -1,0 +1,166 @@
+name: release core
+description: >
+  Cut a release in CI: bump the version (pnpm, workspace-aware), refresh doc
+  version refs (prepublish:doc / `a-novel publish stamp`), commit, tag, push,
+  and create the GitHub Release — and output the computed version for the
+  downstream build/publish jobs. Replaces the local `a-novel publish version`
+  and the tag-push `auto-release`. The release-type selector and the protected
+  `release` environment live in the caller (the per-repo release workflow).
+
+inputs:
+  release_type:
+    required: true
+    description: Semver bump to apply — patch, minor, or major.
+  app_id:
+    required: true
+    description: >
+      [Agent] App id. Needs contents:write plus a branch/tag-protection bypass,
+      since the bump commit lands on the protected default branch and the tag is
+      protected (v*).
+  app_private_key:
+    required: true
+    description: The [Agent] App private key (PEM) — the AGENT_BOT_PRIVATE_KEY org secret.
+  dry_run:
+    required: false
+    default: "false"
+    description: >
+      When "true", bump and report the version/tag but do NOT commit, tag, push,
+      or release — the working tree is reverted. Lets a release be rehearsed
+      safely before the bot has push rights.
+
+outputs:
+  version:
+    description: The bumped version (e.g. 1.2.3).
+    value: ${{ steps.cut.outputs.version }}
+  tag:
+    description: The release tag — vX.Y.Z, or <subdir>/vX.Y.Z for a sub-directory Go module.
+    value: ${{ steps.cut.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    # Token that can push the bump commit + tag and create the release. Scoped
+    # to this repo and to contents only — the [Agent] App can do more.
+    - name: Mint push token
+      id: token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+        permission-contents: write
+
+    # Bot-authenticated checkout so the later push carries the bot's rights;
+    # full history + tags so the tag and release notes resolve correctly.
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        token: ${{ steps.token.outputs.token }}
+        ref: ${{ github.ref_name }}
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Setup node
+      uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Enable pnpm
+      shell: bash
+      run: corepack enable
+
+    # Only repos that stamp docs (a prepublish:doc script) need the a-novel CLI.
+    - name: Detect prepublish:doc
+      id: stamp
+      shell: bash
+      run: |
+        if node -e "process.exit(require('./package.json').scripts?.['prepublish:doc']?0:1)" 2>/dev/null; then
+          echo "needed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "needed=false" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Setup Go
+      if: ${{ steps.stamp.outputs.needed == 'true' }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+    - name: Install a-novel CLI (for stamp)
+      if: ${{ steps.stamp.outputs.needed == 'true' }}
+      shell: bash
+      run: |
+        go install github.com/a-novel-kit/stack/cli/cmd/a-novel@latest
+        echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+    - name: Cut release
+      id: cut
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.token.outputs.token }}
+        APP_SLUG: ${{ steps.token.outputs.app-slug }}
+        RELEASE_TYPE: ${{ inputs.release_type }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        BRANCH: ${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+
+        case "$RELEASE_TYPE" in
+          patch | minor | major) ;;
+          *) echo "::error::release_type must be patch, minor, or major (got '$RELEASE_TYPE')"; exit 1 ;;
+        esac
+
+        git config user.name "${APP_SLUG}[bot]"
+        git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+
+        # Workspace-aware bump. In CI only this repo is checked out, so the
+        # gitignored-sibling filtering the local CLI needed does not apply.
+        # pnpm skips its own commit/tag in both forms — this action owns those.
+        if grep -q '^packages:' pnpm-workspace.yaml 2>/dev/null; then
+          pnpm version "$RELEASE_TYPE" --recursive
+        else
+          pnpm version "$RELEASE_TYPE" --no-git-tag-version
+        fi
+
+        # Refresh vX.Y.Z references in docs/config to the new version, before the
+        # commit — the kept `a-novel publish stamp`, invoked via prepublish:doc.
+        pnpm run --if-present prepublish:doc
+
+        version=$(node -p "require('./package.json').version")
+
+        # Tag prefix: a sub-directory Go module releases as <dir>/vX.Y.Z (that is
+        # how Go resolves it); a root module or a JS-only repo uses plain vX.Y.Z.
+        # The pathspec also matches lookalikes (cargo.mod), so require an exact
+        # go.mod basename. No bash arrays here — keep it portable and testable.
+        gomods=$(git ls-files '*go.mod' | grep -E '(^|/)go\.mod$' || true)
+        count=$(printf '%s' "$gomods" | grep -c . || true)
+        prefix=""
+        if [ "$count" -gt 1 ]; then
+          echo "::error::multiple Go modules — no single release tag; tag manually:"
+          printf '%s\n' "$gomods"
+          exit 1
+        elif [ "$count" -eq 1 ]; then
+          d=$(dirname "$gomods")
+          [ "$d" != "." ] && prefix="$d/"
+        fi
+        tag="${prefix}v${version}"
+
+        {
+          echo "version=$version"
+          echo "tag=$tag"
+        } >> "$GITHUB_OUTPUT"
+        echo "Release **$tag** (bump: $RELEASE_TYPE)" | tee -a "$GITHUB_STEP_SUMMARY"
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "- [dry-run] bumped to $version; would tag \`$tag\`, push to \`$BRANCH\`, and release — no mutation." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          git checkout -- . 2>/dev/null || true
+          exit 0
+        fi
+
+        git add -A
+        git commit -m "$version"
+        git tag "$tag"
+        git push origin "HEAD:$BRANCH"
+        git push origin "refs/tags/$tag"
+        gh release create "$tag" --repo "$GITHUB_REPOSITORY" \
+          --title "${GITHUB_REPOSITORY#*/} ${version}" --generate-notes
+        echo "- ✓ released \`$tag\`" | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- New **`publish-actions/release-core`** composite action — the version-cutting core of a UI-dispatched release: workspace-aware `pnpm version` bump → `prepublish:doc` stamp → commit → tag → push → GitHub Release, **outputting the computed version** for downstream build/publish jobs.
- Converts this repo's `release.yaml` to **`workflow_dispatch`** (a `patch`/`minor`/`major` selector + `dry_run`) **+ `workflow_call`**, gated by a protected **`release` environment**, with a concurrency lock. Relocates the #34 archive step into it.
- First step of a-novel-kit/.github#36 — replacing the local `a-novel publish version` + tag-push `auto-release` with releases cut from the Actions tab (and, via `workflow_call`, by agents later).

## How it works

- Reimplements `a-novel publish version` for CI: workspace detection (`--recursive` vs `--no-git-tag-version`), the sub-dir Go-module tag prefix (`<dir>/vX.Y.Z`), and the kept `a-novel publish stamp` (installs the now-public CLI only when a repo declares `prepublish:doc`).
- Pushes the bump commit + tag as the **`[Agent]` bot** (App id inlined per org; key = `AGENT_BOT_PRIVATE_KEY`), requesting only `contents: write`.
- **`dry_run: true`** bumps and reports the version/tag, then reverts — so a release can be rehearsed **before** the bot has push rights.

## Security / dependency

The bot push needs the `[Agent]` **Contents: write** grant (done) **plus** a branch/tag-protection **bypass** and the **`release` environment's required reviewers** — Epic #36 sub-issue 2. Until those land, use `dry_run: true`; a real run will fail at the push step.

## Breaking changes

The tag-push trigger is removed from this repo's release. During the cutover, the old local `publish:patch` script / `a-novel publish version` would push a tag that no longer triggers anything — the CLI/script cleanup (Epic #36 sub-issue 5) removes those once every repo is on the new flow.

## Test plan

- [x] YAML parses; all `run:` blocks pass `bash -n`; `prettier --check` clean.
- [x] Tag-prefix + workspace detection validated against real repos (`stack` → `cli/`, `service-*`/`golib`/`workflows` → ``); rewritten array-free after catching a zsh-vs-bash `${arr[0]}` indexing trap locally.
- [ ] `dry_run` run from the Actions tab (rehearsal) once merged.
- [ ] First real release after the bypass + `release` environment are configured.

Closes #186. Part of a-novel-kit/.github#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)