### PR TITLE
fix(ci): harden release trigger and clear CI warnings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,10 +32,12 @@ on:
 
 run-name: "🚀 release ${{ inputs.release_type }}${{ inputs.dry_run && ' (dry-run)' || '' }}"
 
-# One release at a time per repo, so two runs can't race the version bump.
-concurrency:
-  group: release-${{ github.repository }}
-  cancel-in-progress: false
+# No concurrency lock, on purpose. If two releases are triggered at once both
+# compute the same next tag; the first push wins and the second is rejected
+# (non-fast-forward / tag already exists) and fails in the release job below,
+# before any build job runs — so accidental double-triggers can't double-release.
+# A concurrency *queue* would instead serialize them and let the second cut a
+# second release. The protected `release` environment is the human gate on top.
 
 jobs:
   release:

--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -39,6 +39,17 @@ outputs:
 runs:
   using: composite
   steps:
+    # Releases run from the default branch only — reject a dispatch (or a
+    # workflow_call) from any other ref before minting a token or mutating
+    # anything. Pushing the bump tag from a feature branch would be wrong.
+    - name: Guard — default branch only
+      shell: bash
+      run: |
+        if [ "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]; then
+          echo "::error::releases run from the default branch (${{ github.event.repository.default_branch }}) only — got '${{ github.ref_name }}'"
+          exit 1
+        fi
+
     # Token that can push the bump commit + tag and create the release. Scoped
     # to this repo and to contents only — the [Agent] App can do more.
     - name: Mint push token
@@ -62,7 +73,7 @@ runs:
         fetch-tags: true
 
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: lts/*
     - name: Enable pnpm
@@ -81,9 +92,12 @@ runs:
         fi
     - name: Setup Go
       if: ${{ steps.stamp.outputs.needed == 'true' }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: stable
+        # Nothing in this repo's Go (if any) is built here — we only `go install`
+        # the a-novel CLI — so skip the module cache and its "no go.sum" warning.
+        cache: false
     - name: Install a-novel CLI (for stamp)
       if: ${{ steps.stamp.outputs.needed == 'true' }}
       shell: bash


### PR DESCRIPTION
Follow-ups from the first `release-core` dry-run (#187). Part of a-novel-kit/.github#36.

## Changes

1. **Default-branch only** — `release-core` now rejects a `workflow_dispatch`/`workflow_call` from any ref other than the repo's default branch, before minting a token. (Releases must come from `master`.)
2. **Concurrent runs fail instead of double-releasing** — removed the per-repo concurrency queue. Two accidental triggers now race; the first push wins, the second is rejected (non-fast-forward / tag already exists) and fails in the `release` job *before any build job runs*. A queue would have serialized them and let the second cut a second release. The protected `release` environment remains the human gate.
3. **Cleared run warnings** — `actions/setup-node@v6` + `actions/setup-go@v6` (Node 24, ends the Node-20 deprecation notice) and `setup-go` `cache: false` (ends the "no go.sum" cache-restore warning).

## Not in this PR

The remaining warning — **`'app-id' deprecated — use 'client-id'`** from `create-github-app-token` — is **cross-cutting** (every workflow + composite action that mints a bot token, across this repo and the two bot-comment dispatchers). Client-ids are retrievable via the installations API, so it's doable in one sweep, but it's a mechanical rename touching ~15 files in 3 repos and warrants its own PR. Proposed as a follow-up chore.

## Test plan

- [x] YAML parses, all `run:` blocks pass `bash -n`, `prettier --check` clean.
- [x] Default-branch guard logic verified.
- [ ] Re-run the release dry-run after merge — confirm the node20 + go-cache warnings are gone.

Part of a-novel-kit/.github#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)