### PR TITLE
chore(ci): source the agent app-id from the AGENT_BOT_ID org var

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,13 +57,13 @@ jobs:
         with:
           release_type: ${{ inputs.release_type }}
           dry_run: ${{ inputs.dry_run }}
-          app_id: ${{ github.repository_owner == 'a-novel' && '3549319' || '3549379' }}
+          app_id: ${{ vars.AGENT_BOT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
       # Everything on master just shipped — clear this repo's awaiting-release
       # items off the board. Skipped on a dry run (nothing was released).
       - if: ${{ !inputs.dry_run }}
         uses: ./generic-actions/archive-board-items
         with:
-          app_id: ${{ github.repository_owner == 'a-novel' && '3549319' || '3549379' }}
+          app_id: ${{ vars.AGENT_BOT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
           project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}


### PR DESCRIPTION
Both orgs now declare **`AGENT_BOT_ID`** (+ `AGENT_BOT_LOGIN`) at org level, matching the publish/dependency bots. So the release workflow now reads the agent app id from **`vars.AGENT_BOT_ID`** instead of a per-org inline conditional — in both the `release-core` and `archive-board-items` steps.

No behavior change (the variable holds the same numeric app id that was inlined); just cleaner, single-source config.

> Note: this does **not** clear the `'app-id' is deprecated, use 'client-id'` warning — that's about the `create-github-app-token` *input name*, not where the value comes from. `AGENT_BOT_ID` is the numeric app id, so it still feeds `app-id:`. Clearing the warning is the separate `app-id → client-id` sweep.

Part of a-novel-kit/.github#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)