### PR TITLE
chore(ci): use client-id for the release/archive bot token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,13 +57,13 @@ jobs:
         with:
           release_type: ${{ inputs.release_type }}
           dry_run: ${{ inputs.dry_run }}
-          app_id: ${{ github.repository_owner == 'a-novel' && '3549319' || '3549379' }}
+          client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
       # Everything on master just shipped — clear this repo's awaiting-release
       # items off the board. Skipped on a dry run (nothing was released).
       - if: ${{ !inputs.dry_run }}
         uses: ./generic-actions/archive-board-items
         with:
-          app_id: ${{ github.repository_owner == 'a-novel' && '3549319' || '3549379' }}
+          client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
           project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}

--- a/generic-actions/archive-board-items/action.yaml
+++ b/generic-actions/archive-board-items/action.yaml
@@ -7,10 +7,10 @@ description: >
   off the board automatically. Idempotent and safe to re-run.
 
 inputs:
-  app_id:
+  client_id:
     required: true
     description: >
-      App ID for the org's [Agent] bot. The default GITHUB_TOKEN cannot see
+      Client id for the org's [Agent] bot. The default GITHUB_TOKEN cannot see
       org-level Projects v2, so a bot token is required.
   app_private_key:
     required: true
@@ -23,7 +23,7 @@ inputs:
     required: true
     description: >
       Node id of the org "Tasks" board (e.g. PVT_…). Passed in directly — inline
-      it per-org in the caller, the same way app_id is — so the action needs no
+      it per-org in the caller, the same way client_id is — so the action needs no
       title lookup. Find it with: gh project view <n> --owner <org> --format json.
   dry_run:
     required: false
@@ -40,7 +40,7 @@ runs:
       id: token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.app_id }}
+        client-id: ${{ inputs.client_id }}
         private-key: ${{ inputs.app_private_key }}
         owner: ${{ github.repository_owner }}
         permission-organization-projects: write

--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -11,10 +11,10 @@ inputs:
   release_type:
     required: true
     description: Semver bump to apply — patch, minor, or major.
-  app_id:
+  client_id:
     required: true
     description: >
-      [Agent] App id. Needs contents:write plus a branch/tag-protection bypass,
+      [Agent] App client id. Needs contents:write plus a branch/tag-protection bypass,
       since the bump commit lands on the protected default branch and the tag is
       protected (v*).
   app_private_key:
@@ -56,7 +56,7 @@ runs:
       id: token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.app_id }}
+        client-id: ${{ inputs.client_id }}
         private-key: ${{ inputs.app_private_key }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}


### PR DESCRIPTION
Clears the `'app-id' is deprecated — use 'client-id'` warning from the release run, using the new `*_CLIENT_ID` org variables.

## Changes
- **`release-core`** + **`archive-board-items`**: `create-github-app-token` now uses `client-id:` instead of `app-id:`; their `app_id` input is renamed to **`client_id`**.
- **`release.yaml`**: both steps pass `client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}`.

## Why this is safe (non-breaking)
These two actions have **no external consumers yet** — only this repo's `release.yaml` calls them. So renaming their input is free. (Also supersedes #189, which only swapped the inline app-id for the `AGENT_BOT_ID` var; this goes all the way to `client_id` + clears the warning.)

## Deliberately *not* in this PR — the shared CI actions
`setup-node`, `npm`, `pull-bot`, `node-actions/*` are consumed by **other repos** that pin `@v…` and pass a **numeric** `app_id`. Renaming their input is a **breaking change** that can't be transparently aliased (numeric app-id vs `Iv23li…` client-id), so it needs a staged `manage-versions` migration. Tracked separately. The `bot-comment` dispatchers (stack + `a-novel/.github`) are a separate, self-contained swap, also a follow-up.

## Test plan
- [x] YAML parses; `prettier --check` clean; no `app_id`/`app-id` left in the three files.
- [ ] Re-run the release dry-run after merge — confirm the app-id warning is gone.

Part of a-novel-kit/.github#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)