### PR TITLE
feat(ci): accept client_id on the shared bot-token actions

### DIFF
--- a/generic-actions/pull-bot/action.yaml
+++ b/generic-actions/pull-bot/action.yaml
@@ -6,8 +6,11 @@ inputs:
     required: true
     description: The GitHub App private key.
   app_id:
-    required: true
-    description: The GitHub App ID.
+    required: false
+    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
+  client_id:
+    required: false
+    description: GitHub App client id (recommended).
   fetch_depth:
     required: false
     description: Number of commits to fetch. 0 indicates all history for all branches and tags.
@@ -20,23 +23,34 @@ inputs:
 outputs:
   token:
     description: The bot token.
-    value: ${{ steps.get_token.outputs.token }}
+    value: ${{ steps.token_client.outputs.token || steps.token_app.outputs.token }}
   app_login:
     description: The login name of the bot.
-    value: ${{ steps.get_token.outputs.app-slug }}[bot]
+    value: ${{ steps.token_client.outputs.app-slug || steps.token_app.outputs.app-slug }}[bot]
 
 runs:
   using: "composite"
   steps:
-    - name: get app token
-      id: get_token
+    # Two mints, so the client-id path passes NO app-id: the deprecation warning
+    # fires whenever app-id is present in `with:` (even empty), so it can only be
+    # avoided by omitting it. Legacy callers passing app_id keep working.
+    - name: get app token (client id)
+      id: token_client
+      if: ${{ inputs.client_id != '' }}
+      uses: actions/create-github-app-token@v3
+      with:
+        private-key: ${{ inputs.app_private_key }}
+        client-id: ${{ inputs.client_id }}
+    - name: get app token (legacy app id)
+      id: token_app
+      if: ${{ inputs.client_id == '' }}
       uses: actions/create-github-app-token@v3
       with:
         private-key: ${{ inputs.app_private_key }}
         app-id: ${{ inputs.app_id }}
     - uses: actions/checkout@v7
       with:
-        token: ${{ steps.get_token.outputs.token }}
+        token: ${{ steps.token_client.outputs.token || steps.token_app.outputs.token }}
         ref: ${{ github.head_ref }}
         # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
         persist-credentials: false

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -12,8 +12,11 @@ inputs:
     required: true
     description: The GitHub App private key.
   app_id:
-    required: true
-    description: The GitHub App ID.
+    required: false
+    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
+  client_id:
+    required: false
+    description: GitHub App client id (recommended).
 
 runs:
   using: "composite"
@@ -22,6 +25,7 @@ runs:
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}
+        client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
     - name: self-hosted renovate
       uses: renovatebot/github-action@v46.1.16

--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -9,8 +9,11 @@ inputs:
     required: true
     description: The GitHub App private key.
   app_id:
-    required: true
-    description: The GitHub App ID.
+    required: false
+    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
+  client_id:
+    required: false
+    description: GitHub App client id (recommended).
 
 runs:
   using: "composite"
@@ -19,6 +22,7 @@ runs:
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}
+        client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}
     - name: get github app user id

--- a/node-actions/build-node/action.yaml
+++ b/node-actions/build-node/action.yaml
@@ -13,8 +13,11 @@ inputs:
     required: true
     description: The GitHub App private key.
   app_id:
-    required: true
-    description: The GitHub App ID.
+    required: false
+    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
+  client_id:
+    required: false
+    description: GitHub App client id (recommended).
 
 runs:
   using: "composite"
@@ -23,6 +26,7 @@ runs:
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}
+        client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}
     - name: build

--- a/node-actions/lint-node/action.yaml
+++ b/node-actions/lint-node/action.yaml
@@ -13,8 +13,11 @@ inputs:
     required: true
     description: The GitHub App private key.
   app_id:
-    required: true
-    description: The GitHub App ID.
+    required: false
+    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
+  client_id:
+    required: false
+    description: GitHub App client id (recommended).
 
 runs:
   using: "composite"
@@ -23,6 +26,7 @@ runs:
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}
+        client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}
     - name: run lint

--- a/node-actions/security-update/action.yaml
+++ b/node-actions/security-update/action.yaml
@@ -13,8 +13,11 @@ inputs:
     required: true
     description: The GitHub App private key.
   app_id:
-    required: true
-    description: The GitHub App ID.
+    required: false
+    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
+  client_id:
+    required: false
+    description: GitHub App client id (recommended).
   min_days_since_last_release:
     required: false
     description: The minimum number of days since the last release to trigger a security update.
@@ -27,6 +30,7 @@ runs:
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}
+        client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}
     - name: get github app user id

--- a/node-actions/setup-node/action.yaml
+++ b/node-actions/setup-node/action.yaml
@@ -9,8 +9,11 @@ inputs:
     required: true
     description: The GitHub App private key.
   app_id:
-    required: true
-    description: The GitHub App ID.
+    required: false
+    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
+  client_id:
+    required: false
+    description: GitHub App client id (recommended).
 
 outputs:
   token:
@@ -27,6 +30,7 @@ runs:
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}
+        client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
     - uses: pnpm/action-setup@v6
     - uses: actions/setup-node@v6

--- a/node-actions/test-node/action.yaml
+++ b/node-actions/test-node/action.yaml
@@ -13,8 +13,11 @@ inputs:
     required: true
     description: The GitHub App private key.
   app_id:
-    required: true
-    description: The GitHub App ID.
+    required: false
+    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
+  client_id:
+    required: false
+    description: GitHub App client id (recommended).
   coverage_artifact:
     required: false
     description: The name of the artifact to store the coverage report.
@@ -36,6 +39,7 @@ runs:
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}
+        client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}
     - name: run test

--- a/publish-actions/npm/action.yaml
+++ b/publish-actions/npm/action.yaml
@@ -13,8 +13,11 @@ inputs:
     required: true
     description: The GitHub App private key.
   app_id:
-    required: true
-    description: The GitHub App ID.
+    required: false
+    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
+  client_id:
+    required: false
+    description: GitHub App client id (recommended).
 
 runs:
   using: "composite"
@@ -23,6 +26,7 @@ runs:
       id: app_token
       with:
         app_id: ${{ inputs.app_id }}
+        client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}
     - name: build


### PR DESCRIPTION
**Stage 1** of a-novel-kit/.github#191 — clears the `'app-id' deprecated` warning on the shared bot-token actions, backward-compatibly.

## What changed
- Optional **`client_id`** input added alongside `app_id` (now `required: false`) across the whole token chain: `pull-bot`, `setup-node`, `renovate`, `node-actions/{audit,build-node,lint-node,security-update,test-node}`, `npm`.
- **`pull-bot`** (the single mint point) now mints with **two conditional steps**: `client_id` set → `client-id:` only (no `app-id:`, so no warning); else → legacy `app-id:`. Outputs fall back: `token_client || token_app`.

## Why two steps (not "pass both, one empty")
The deprecation warning fires whenever `app-id:` is **present in `with:`** — even as an empty string. So the only way to actually silence it is to *omit* `app-id` on the client-id path, which requires the conditional split.

## Backward compatibility
Existing consumers (service repos pinned `@v…`) pass numeric `app_id` and keep working unchanged via the legacy step. Nothing breaks on this release.

## Next (separate)
- **Stage 2** — migrate callers (this repo's `main`/`node-audit`/`security-update`/`renovate` + each service repo) to `client_id: ${{ vars.*_BOT_CLIENT_ID }}`.
- **Stage 3** — remove `app_id` + the legacy mint step.

## Test plan
- [x] All 9 action YAMLs parse; `prettier --check` clean; every `app_id` now optional; `client_id` wired end-to-end.
- [ ] After release, a consumer passing `client_id` mints with no app-id warning; one passing `app_id` still works.

Part of a-novel-kit/.github#36, #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)