### PR TITLE
docs(migrations): add the v1.1.0 migration guide

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,7 @@
+# Migration guides
+
+One immutable guide per release that asks consumers to change something. Newest first.
+
+| Version               | Summary                                                                          |
+| --------------------- | -------------------------------------------------------------------------------- |
+| [v1.1.0](./v1.1.0.md) | `client_id` bot-token input (deprecates `app_id`); UI-dispatched releases added. |

--- a/docs/migrations/v1.1.0.md
+++ b/docs/migrations/v1.1.0.md
@@ -1,0 +1,48 @@
+# Upgrading to v1.1.0
+
+`v1.1.0` adds a `client_id` input to the bot-token actions (the legacy `app_id` is now deprecated),
+plus a new UI-dispatched release flow (`release-core`) and a board action (`archive-board-items`).
+
+## Do I need to act?
+
+**Recommended, not required.** `v1.1.0` is backward-compatible — your existing pinned usage keeps
+working untouched. The one migration worth doing is **`app_id` → `client_id`**, which silences the
+`app-id is deprecated` warning GitHub now prints on every bot-token mint.
+
+## Switch bot-token inputs from `app_id` to `client_id`
+
+The bot-token actions — `generic-actions/pull-bot`, `node-actions/setup-node`, `publish-actions/npm`,
+`generic-actions/renovate`, and every `node-actions/*` — now accept a **`client_id`** input alongside
+the legacy `app_id`. When `client_id` is set, the token is minted from the App **client id** and no
+deprecation warning is printed; `app_id` still works but is deprecated.
+
+Migrate each caller:
+
+```yaml
+# before
+app_id: ${{ vars.AGENT_BOT_ID }}
+# after
+client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+```
+
+- **Prerequisite:** the `*_BOT_CLIENT_ID` org variables. They exist for all three bots in both orgs —
+  map each one to its client-id var: `AGENT_BOT_ID → AGENT_BOT_CLIENT_ID`,
+  `PUBLISH_BOT_ID → PUBLISH_BOT_CLIENT_ID`, `DEPENDENCY_BOT_ID → DEPENDENCY_BOT_CLIENT_ID`.
+- **Old path:** **deprecated, not removed.** Keep passing `app_id` and nothing breaks; it will be
+  dropped in a future **major** release (you'll get a migration guide for that too).
+- **Verify:** the run log no longer shows `Input 'app-id' has been deprecated`.
+
+## New (optional): UI-dispatched releases
+
+`v1.1.0` also ships **`publish-actions/release-core`** and **`generic-actions/archive-board-items`** —
+the building blocks of a release cut from the **Actions tab** (run `release`, pick patch/minor/major)
+instead of pushing a tag. Adopting it for your repo's `release.yaml` is a larger change (the version
+becomes a job output, so each build job reads `needs.release.outputs.version` instead of
+`github.ref_name`), so it's opt-in. `publish-actions/auto-release` is unchanged and still works — migrate
+when you're ready.
+
+## Notes
+
+- Rolling `client_id` out across every repo is tracked in
+  [a-novel-kit/workflows#191](https://github.com/a-novel-kit/workflows/issues/191).
+- First guide written with the `prepare-release` skill.


### PR DESCRIPTION
The first **migration guide** for this repo — `docs/migrations/v1.1.0.md` (+ the `docs/migrations/` index), produced by applying the new `prepare-release` skill to the unpublished diff.

**Sizing:** since `v1.0.3` there are three `feat:` and no `BREAKING CHANGE`/`!` → **minor → v1.1.0**.
**Guide gate:** `client_id` adds a *preferred* input and *deprecates* `app_id` → a **Recommended** guide.

Merge this **before** cutting `v1.1.0`, so the tag ships its own guide.

Part of a-novel-kit/.github#34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)