### PR TITLE
fix(release-core): bump version with node, not pnpm version

### DIFF
--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -1,6 +1,6 @@
 name: release core
 description: >
-  Cut a release in CI: bump the version (pnpm, workspace-aware), refresh doc
+  Cut a release in CI: bump the version (workspace-aware, no pnpm), refresh doc
   version refs (prepublish:doc / `a-novel publish stamp`), commit, tag, push,
   and create the GitHub Release — and output the computed version for the
   downstream build/publish jobs. Replaces the local `a-novel publish version`
@@ -114,6 +114,7 @@ runs:
         RELEASE_TYPE: ${{ inputs.release_type }}
         DRY_RUN: ${{ inputs.dry_run }}
         BRANCH: ${{ github.ref_name }}
+        STAMP_NEEDED: ${{ steps.stamp.outputs.needed }}
       run: |
         set -euo pipefail
 
@@ -125,23 +126,24 @@ runs:
         git config user.name "${APP_SLUG}[bot]"
         git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
 
-        # Workspace-aware bump. In CI only this repo is checked out, so the
-        # gitignored-sibling filtering the local CLI needed does not apply.
-        # pnpm skips its own commit/tag in both forms — this action owns those.
-        #
-        # --config.trustLockfile=true skips pnpm's supply-chain verification pass:
-        # a version bump installs nothing, so re-checking minimumReleaseAge over the
-        # already-verified lockfile would only risk failing a release on a too-fresh
-        # transitive dep (it fails on bigger lockfiles, e.g. the stack/CLI repo).
-        if grep -q '^packages:' pnpm-workspace.yaml 2>/dev/null; then
-          pnpm version "$RELEASE_TYPE" --recursive --config.trustLockfile=true
-        else
-          pnpm version "$RELEASE_TYPE" --no-git-tag-version --config.trustLockfile=true
-        fi
+        # Bump the root + every workspace member package.json with a small Node
+        # script instead of `pnpm version`. In CI's cold pnpm store `pnpm version`
+        # runs pnpm's supply-chain verification ("Verifying lockfile against
+        # supply-chain policies") and fails the release whenever any transitive
+        # dep is younger than minimumReleaseAge — a race that has nothing to do
+        # with cutting a release, and the `--config.*` flags don't reach that
+        # path. A version bump needs no dependency resolution (a package's own
+        # version isn't recorded in the lockfile), so the script just rewrites the
+        # version field — no resolution, no supply-chain pass. See bump.cjs.
+        node "$GITHUB_ACTION_PATH/bump.cjs"
 
         # Refresh vX.Y.Z references in docs/config to the new version, before the
-        # commit — the kept `a-novel publish stamp`, invoked via prepublish:doc.
-        pnpm run --if-present prepublish:doc
+        # commit — `a-novel publish stamp`, invoked via the prepublish:doc script.
+        # Gated on the detector so a repo without that script never invokes pnpm
+        # here (and so cannot trip the supply-chain pass either).
+        if [ "$STAMP_NEEDED" = "true" ]; then
+          pnpm run prepublish:doc
+        fi
 
         version=$(node -p "require('./package.json').version")
 

--- a/publish-actions/release-core/bump.cjs
+++ b/publish-actions/release-core/bump.cjs
@@ -1,0 +1,56 @@
+// Bump the release version across this repo's package.json files.
+//
+// Why Node and not `pnpm version`: in CI (a cold pnpm store) `pnpm version`
+// triggers pnpm's supply-chain verification ("Verifying lockfile against
+// supply-chain policies"), which fails a release whenever any transitive dep is
+// younger than `minimumReleaseAge` — a race that has nothing to do with cutting
+// a release. The `--config.*` flags don't reach that verification path. A
+// package's own version isn't recorded in pnpm-lock.yaml (the lockfile tracks
+// dependencies, not the importer's version), so a release bump only has to
+// rewrite the `version` field — no dependency resolution, hence no supply-chain
+// pass. This also sidesteps `pnpm version`'s clean-tree requirement.
+//
+// Reads RELEASE_TYPE (patch|minor|major) from the env; writes the new version
+// to stdout. Bumps the root and every workspace member to one version, matching
+// the old `pnpm version --recursive`.
+const fs = require("fs");
+const cp = require("child_process");
+
+const type = process.env.RELEASE_TYPE;
+if (!["patch", "minor", "major"].includes(type)) {
+  console.error(`release_type must be patch, minor, or major (got '${type}')`);
+  process.exit(1);
+}
+
+// Every tracked package.json: the root plus any workspace members. node_modules
+// is gitignored so it never appears; the basename filter drops lookalikes such
+// as `mypackage.json` that the `*package.json` pathspec would otherwise match.
+const files = cp
+  .execSync("git ls-files '*package.json'", { encoding: "utf8" })
+  .split("\n")
+  .filter((f) => f === "package.json" || f.endsWith("/package.json"));
+
+const root = JSON.parse(fs.readFileSync("package.json", "utf8"));
+let [major, minor, patch] = root.version.split(".").map(Number);
+if (type === "major") {
+  major += 1;
+  minor = 0;
+  patch = 0;
+} else if (type === "minor") {
+  minor += 1;
+  patch = 0;
+} else {
+  patch += 1;
+}
+const next = `${major}.${minor}.${patch}`;
+
+for (const file of files) {
+  const text = fs.readFileSync(file, "utf8");
+  const current = JSON.parse(text).version;
+  if (current == null) continue; // a member package.json may omit a version
+  // Swap only the value, so the file's exact formatting (and the key order
+  // prettier-plugin-packagejson enforces) survives untouched.
+  fs.writeFileSync(file, text.replace(`"version": ${JSON.stringify(current)}`, `"version": ${JSON.stringify(next)}`));
+}
+
+process.stdout.write(next);


### PR DESCRIPTION
## Summary

The dispatched release fails in CI on `pnpm version`: a cold pnpm store runs pnpm's **supply-chain verification** ("Verifying lockfile against supply-chain policies") and rejects the release whenever any transitive dep is younger than `minimumReleaseAge`. That's a race that has nothing to do with cutting a release, and it bites bigger lockfiles (it killed `stack`'s `cli/v1.1.0`).

`v1.2.1` tried to silence it with `--config.trustLockfile=true` — **it didn't work**: the flag doesn't reach the version command's verification path, and the release failed again with the flag present.

This removes pnpm from the bump entirely:

- **`bump.cjs`** rewrites the `version` field in the root + every workspace member. A package's own version isn't recorded in `pnpm-lock.yaml` (the lockfile tracks *dependencies*), so a bump needs **no** dependency resolution — hence no supply-chain pass. It edits only the value, preserving formatting / `prettier-plugin-packagejson` key order. Replaces both the single-package and `--recursive` `pnpm version` forms.
- **`prepublish:doc` is gated** on the existing detector, so a repo without that script (stack, golib, nodelib) now invokes **zero** pnpm commands during a release.

## Why this is the right fix, not another guess

Reproduced the cold-store condition locally (fresh clone, `CI=true`, forced `minimumReleaseAge`) and confirmed `--config` flags don't reach the check. The Node bump was tested on a fresh `stack` clone: `1.0.6 → 1.1.0`, diff touches only the `version` line.

## Test plan

- [x] `bump.cjs` bumps root package.json, formatting preserved (tested on a clean stack clone).
- [x] `prettier --check` clean (yaml + cjs).
- [ ] Release **workflows v1.2.2** (patch) — validates the fix on this repo (it stamps docs via `prepublish:doc`, exercising that path too).
- [ ] Re-pin stack to `@v1.2.2`, re-run the stack release → `cli/v1.1.0` cuts without the supply-chain failure.

Fixes the stack `cli/v1.1.0` release failure. Part of a-novel-kit/.github#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)