### PR TITLE
feat(npm): publish from an explicit ref (the release tag)

### DIFF
--- a/generic-actions/pull-bot/action.yaml
+++ b/generic-actions/pull-bot/action.yaml
@@ -19,6 +19,14 @@ inputs:
     required: false
     description: Whether to fetch tags, even if fetch-depth > 0.
     default: "false"
+  ref:
+    required: false
+    description: >
+      Ref (branch, tag, or SHA) to check out. Defaults to github.head_ref — the PR
+      branch on a pull_request event. Pass an explicit ref when the trigger isn't a
+      PR: e.g. a dispatched release passes the new release tag so the checkout is the
+      bumped commit, not the pre-bump default branch.
+    default: ""
 
 outputs:
   token:
@@ -51,7 +59,7 @@ runs:
     - uses: actions/checkout@v7
       with:
         token: ${{ steps.token_client.outputs.token || steps.token_app.outputs.token }}
-        ref: ${{ github.head_ref }}
+        ref: ${{ inputs.ref != '' && inputs.ref || github.head_ref }}
         # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
         persist-credentials: false
         fetch-depth: ${{ inputs.fetch_depth }}

--- a/node-actions/setup-node/action.yaml
+++ b/node-actions/setup-node/action.yaml
@@ -14,6 +14,13 @@ inputs:
   client_id:
     required: false
     description: GitHub App client id (recommended).
+  ref:
+    required: false
+    description: >
+      Ref to check out (forwarded to pull-bot). Defaults to github.head_ref; pass a
+      release tag when publishing from a dispatched release so the build is the
+      bumped commit, not the pre-bump default branch.
+    default: ""
 
 outputs:
   token:
@@ -32,6 +39,7 @@ runs:
         app_id: ${{ inputs.app_id }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
+        ref: ${{ inputs.ref }}
     - uses: pnpm/action-setup@v6
     - uses: actions/setup-node@v6
       with:

--- a/publish-actions/npm/action.yaml
+++ b/publish-actions/npm/action.yaml
@@ -18,6 +18,14 @@ inputs:
   client_id:
     required: false
     description: GitHub App client id (recommended).
+  ref:
+    required: false
+    description: >
+      Ref to check out and publish from. Leave empty for the legacy tag-push flow
+      (the ref is already the tag). In the dispatched release flow, pass the new
+      release tag (needs.release.outputs.tag) so the published package carries the
+      bumped version, not the pre-bump default branch.
+    default: ""
 
 runs:
   using: "composite"
@@ -29,6 +37,7 @@ runs:
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}
+        ref: ${{ inputs.ref }}
     - name: build
       shell: bash
       run: pnpm run ${{ inputs.build_action }}


### PR DESCRIPTION
## Summary

In the dispatched release flow, `build-js` publishes the **pre-bump** version. Root cause: `pull-bot` checks out `ref: github.head_ref`, which is empty on `workflow_dispatch`, so the checkout falls back to the default branch (before release-core's bump commit). The npm package's identity *is* its version, so this republishes the stale one.

Thread an optional **`ref`** input through `npm → setup-node → pull-bot`. The dispatched release's `build-js` passes `ref: ${{ needs.release.outputs.tag }}`, so the build/publish runs against the bumped, tagged commit.

- Default is `''` → `pull-bot` falls back to `github.head_ref` exactly as before, so PR runs and the legacy tag-push release are unaffected.
- **Only npm needs this.** Docker images are content-identical across the bump commit (it only touches `package.json`), so they just need the `version:` tag input (#194).
- Internal `@vX.Y.Z` cross-refs are left as-is; the release's `prepublish:doc` stamps them.

## Test plan
- [x] `prettier --check` clean.
- [ ] After release + a service migration: the dispatched release publishes the JS client at the new version (not N-1).

Prerequisite for the nodelib + service release migrations. Part of a-novel-kit/.github#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)