### PR TITLE
ci: rename the lint job to lint-node

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-prettier:
+  lint-node:
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Renames `lint-prettier` → `lint-node` to match the master ruleset `repo update` reconciled. Refs a-novel-kit/.github#40

🤖 Generated with [Claude Code](https://claude.com/claude-code)