### PR TITLE
fix(release-core): skip pnpm's pre-run deps check for the doc stamp

### DIFF
--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -139,10 +139,16 @@ runs:
 
         # Refresh vX.Y.Z references in docs/config to the new version, before the
         # commit — `a-novel publish stamp`, invoked via the prepublish:doc script.
-        # Gated on the detector so a repo without that script never invokes pnpm
-        # here (and so cannot trip the supply-chain pass either).
+        # Gated on the detector so a repo without that script never invokes pnpm.
+        #
+        # PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false stops pnpm from running an
+        # install before the script. The stamp only needs the a-novel CLI (already
+        # installed), never node_modules; that pre-run install would otherwise need
+        # npm-registry auth (private @a-novel deps -> 401) and re-run the
+        # supply-chain verification. It's an env var (not a --config flag) so the
+        # script's nested `pnpm` calls inherit it; npm_config_* is ignored by pnpm.
         if [ "$STAMP_NEEDED" = "true" ]; then
-          pnpm run prepublish:doc
+          PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run prepublish:doc
         fi
 
         version=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary

service-json-keys' dispatched release failed in `release-core` at the `prepublish:doc` step:

> `Verifying lockfile against supply-chain policies (473 entries)... ✗` and `[ERR_PNPM_FETCH_401] GET .../@a-novel-kit%2Fnodelib-test: Unauthorized`

`prepublish:doc` only runs `a-novel publish stamp …` (stamps version strings into README/openapi) — it needs the Go CLI release-core already installs, **never node_modules**. But pnpm 11's `verifyDepsBeforeRun` runs `pnpm install` before any `pnpm run`, and on a service's cold checkout that install needs npm-registry auth (private `@a-novel-kit` deps → 401) and re-runs the supply-chain verification.

Fix: set `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false` on the stamp invocation so pnpm skips the pre-run install. It's an **env var, not a `--config` flag**, so the script's nested `pnpm prepublish:doc:*` subprocesses inherit it (verified: `npm_config_*` is ignored by pnpm; `PNPM_CONFIG_*` works).

Only repos with a `prepublish:doc` script are affected (the three services). jwt/nodelib/golib have none. workflows has one but only 2 public deps, so its install quietly succeeded.

## Test plan
- [x] prettier clean; confirmed `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm config get verify-deps-before-run` → `false`.
- [ ] After release + service re-pin: a service's dispatched release stamps docs and pushes without the 401 / supply-chain failure.

Part of a-novel-kit/.github#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)