### PR TITLE
ci: migrate self-caller workflows from app_id to client_id

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -17,4 +17,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.PUBLISH_BOT_ID }}
+          client_id: ${{ vars.PUBLISH_BOT_CLIENT_ID }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -21,4 +21,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}


### PR DESCRIPTION
## Summary

Part of #191 Stage 2. Migrates this repo's **own** workflow callers from the deprecated `app_id` input to `client_id`, clearing the `'app-id' deprecated — use 'client-id'` warning. The shared actions already support `client_id` (shipped in v1.3.1).

## Changed

- `main.yaml` — `./node-actions/lint-node`: `DEPENDENCY_BOT_ID` → `DEPENDENCY_BOT_CLIENT_ID`
- `node-audit.yaml` — `./node-actions/audit`: `PUBLISH_BOT_ID` → `PUBLISH_BOT_CLIENT_ID`
- `renovate.yaml` — `./generic-actions/renovate`: `DEPENDENCY_BOT_ID` → `DEPENDENCY_BOT_CLIENT_ID`

The `*_BOT_CLIENT_ID` org vars already exist. `main.yaml`'s run on this PR exercises the `client_id` path end-to-end.

## Breaking changes

None — input swap only; `app_id` still works (removed later in #191 Stage 3).

## Test plan

- [x] `prettier --check` passes on the 3 edited files (repo's only lint)
- [ ] CI `lint-node` (this PR) passes via the `client_id` path