### PR TITLE
ci!: remove legacy app_id from shared bot-token actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -17,4 +17,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.PUBLISH_BOT_ID }}
+          client_id: ${{ vars.PUBLISH_BOT_CLIENT_ID }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -21,4 +21,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}

--- a/generic-actions/pull-bot/action.yaml
+++ b/generic-actions/pull-bot/action.yaml
@@ -5,9 +5,6 @@ inputs:
   app_private_key:
     required: true
     description: The GitHub App private key.
-  app_id:
-    required: false
-    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
   client_id:
     required: false
     description: GitHub App client id (recommended).
@@ -31,34 +28,25 @@ inputs:
 outputs:
   token:
     description: The bot token.
-    value: ${{ steps.token_client.outputs.token || steps.token_app.outputs.token }}
+    value: ${{ steps.token_client.outputs.token }}
   app_login:
     description: The login name of the bot.
-    value: ${{ steps.token_client.outputs.app-slug || steps.token_app.outputs.app-slug }}[bot]
+    value: ${{ steps.token_client.outputs.app-slug }}[bot]
 
 runs:
   using: "composite"
   steps:
-    # Two mints, so the client-id path passes NO app-id: the deprecation warning
-    # fires whenever app-id is present in `with:` (even empty), so it can only be
-    # avoided by omitting it. Legacy callers passing app_id keep working.
-    - name: get app token (client id)
+    # Mint the bot token from the App client id; passing no app-id avoids the
+    # actions/create-github-app-token app-id deprecation warning.
+    - name: get app token
       id: token_client
-      if: ${{ inputs.client_id != '' }}
       uses: actions/create-github-app-token@v3
       with:
         private-key: ${{ inputs.app_private_key }}
         client-id: ${{ inputs.client_id }}
-    - name: get app token (legacy app id)
-      id: token_app
-      if: ${{ inputs.client_id == '' }}
-      uses: actions/create-github-app-token@v3
-      with:
-        private-key: ${{ inputs.app_private_key }}
-        app-id: ${{ inputs.app_id }}
     - uses: actions/checkout@v7
       with:
-        token: ${{ steps.token_client.outputs.token || steps.token_app.outputs.token }}
+        token: ${{ steps.token_client.outputs.token }}
         ref: ${{ inputs.ref != '' && inputs.ref || github.head_ref }}
         # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
         persist-credentials: false

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -11,9 +11,6 @@ inputs:
   app_private_key:
     required: true
     description: The GitHub App private key.
-  app_id:
-    required: false
-    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
   client_id:
     required: false
     description: GitHub App client id (recommended).
@@ -24,7 +21,6 @@ runs:
     - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.3.1
       id: app_token
       with:
-        app_id: ${{ inputs.app_id }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
     - name: self-hosted renovate

--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -8,9 +8,6 @@ inputs:
   app_private_key:
     required: true
     description: The GitHub App private key.
-  app_id:
-    required: false
-    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
   client_id:
     required: false
     description: GitHub App client id (recommended).
@@ -21,7 +18,6 @@ runs:
     - uses: a-novel-kit/workflows/node-actions/setup-node@v1.3.1
       id: app_token
       with:
-        app_id: ${{ inputs.app_id }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}

--- a/node-actions/build-node/action.yaml
+++ b/node-actions/build-node/action.yaml
@@ -12,9 +12,6 @@ inputs:
   app_private_key:
     required: true
     description: The GitHub App private key.
-  app_id:
-    required: false
-    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
   client_id:
     required: false
     description: GitHub App client id (recommended).
@@ -25,7 +22,6 @@ runs:
     - uses: a-novel-kit/workflows/node-actions/setup-node@v1.3.1
       id: app_token
       with:
-        app_id: ${{ inputs.app_id }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}

--- a/node-actions/lint-node/action.yaml
+++ b/node-actions/lint-node/action.yaml
@@ -12,9 +12,6 @@ inputs:
   app_private_key:
     required: true
     description: The GitHub App private key.
-  app_id:
-    required: false
-    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
   client_id:
     required: false
     description: GitHub App client id (recommended).
@@ -25,7 +22,6 @@ runs:
     - uses: a-novel-kit/workflows/node-actions/setup-node@v1.3.1
       id: app_token
       with:
-        app_id: ${{ inputs.app_id }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}

--- a/node-actions/setup-node/action.yaml
+++ b/node-actions/setup-node/action.yaml
@@ -8,9 +8,6 @@ inputs:
   app_private_key:
     required: true
     description: The GitHub App private key.
-  app_id:
-    required: false
-    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
   client_id:
     required: false
     description: GitHub App client id (recommended).
@@ -36,7 +33,6 @@ runs:
     - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.3.1
       id: app_token
       with:
-        app_id: ${{ inputs.app_id }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         ref: ${{ inputs.ref }}

--- a/node-actions/test-node/action.yaml
+++ b/node-actions/test-node/action.yaml
@@ -12,9 +12,6 @@ inputs:
   app_private_key:
     required: true
     description: The GitHub App private key.
-  app_id:
-    required: false
-    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
   client_id:
     required: false
     description: GitHub App client id (recommended).
@@ -38,7 +35,6 @@ runs:
     - uses: a-novel-kit/workflows/node-actions/setup-node@v1.3.1
       id: app_token
       with:
-        app_id: ${{ inputs.app_id }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}

--- a/publish-actions/npm/action.yaml
+++ b/publish-actions/npm/action.yaml
@@ -12,9 +12,6 @@ inputs:
   app_private_key:
     required: true
     description: The GitHub App private key.
-  app_id:
-    required: false
-    description: (legacy) numeric App id — prefer client_id, which avoids the app-id deprecation warning.
   client_id:
     required: false
     description: GitHub App client id (recommended).
@@ -33,7 +30,6 @@ runs:
     - uses: a-novel-kit/workflows/node-actions/setup-node@v1.3.1
       id: app_token
       with:
-        app_id: ${{ inputs.app_id }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         github_token: ${{ inputs.github_token }}


### PR DESCRIPTION
## Summary

**#191 Stage 3** (final). Removes the deprecated `app_id` input and the legacy app-id mint step from the shared bot-token actions, leaving `client_id` as the only token path. Clears the `'app-id' deprecated` warning at the source.

> ⚠️ **Stacked on #205** (Stage 2 self-callers). Base auto-retargets to `master` once #205 merges; merge #205 first.

## Changed (8 actions)

- `generic-actions/pull-bot` — drop `app_id` input, the second (legacy) mint step, and the `|| token_app` fallbacks; the client-id mint is now unconditional.
- `generic-actions/renovate`, `node-actions/{setup-node,lint-node,test-node,build-node,audit}`, `publish-actions/npm` — drop the `app_id` input + its `app_id: ${{ inputs.app_id }}` forward.

Inter-action refs stay `@v…`-pinned (stamped on release).

## Breaking changes

**Yes — `app_id` is removed.** Callers must pass `client_id` (`vars.*_BOT_CLIENT_ID`). All in-scope consumers were migrated in Stage 2 (services, kit libs, both `.github` repos, workflows-self). **`service-narrative-engine` still passes `app_id`** and will break when it bumps to this release — intentionally deferred to its own catch-up (owner decision). → suggests a **major** version bump.

## Test plan

- [x] `prettier --check` passes on all 8 edited actions
- [x] no `app_id`/`app-id` left in any action source
- [ ] CI on this PR (self-callers via `client_id`) is green