### PR TITLE
feat(generic-actions): add merge-gate + approve-pr skeleton actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,18 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 
 ### `generic-actions`
 
-| Action           | Purpose                                                            |
-| ---------------- | ------------------------------------------------------------------ |
-| `approve-bot`    | Auto-approve a PR (skips if already approved); trusted users only. |
-| `assign-bot`     | Assign the PR author to their own PR.                              |
-| `auto-merge-bot` | Enable auto-merge on a PR.                                         |
-| `check-changes`  | Detect uncommitted changes in a pathspec; optionally fail.         |
-| `codecov`        | Upload the coverage artifact to Codecov.                           |
-| `pull-bot`       | Mint a bot App token and check out the repo authenticated as it.   |
-| `renovate`       | Run self-hosted Renovate as the bot.                               |
+| Action                | Purpose                                                            |
+| --------------------- | ------------------------------------------------------------------ |
+| `approve-bot`         | Auto-approve a PR (skips if already approved); trusted users only. |
+| `approve-pr`          | Admin-only: record an [Agent] approval on a PR (Gate-2 override).  |
+| `archive-board-items` | Archive the repo's "Awaiting release" board items on release.      |
+| `assign-bot`          | Assign the PR author to their own PR.                              |
+| `auto-merge-bot`      | Enable auto-merge on a PR.                                         |
+| `check-changes`       | Detect uncommitted changes in a pathspec; optionally fail.         |
+| `codecov`             | Upload the coverage artifact to Codecov.                           |
+| `merge-gate`          | Required "may this PR merge?" check (skeleton: always passes).     |
+| `pull-bot`            | Mint a bot App token and check out the repo authenticated as it.   |
+| `renovate`            | Run self-hosted Renovate as the bot.                               |
 
 ### `github-pages-actions`
 

--- a/generic-actions/approve-pr/action.yaml
+++ b/generic-actions/approve-pr/action.yaml
@@ -1,10 +1,11 @@
 name: approve-pr
 description: >
-  Records a bot approval on a pull request on behalf of a repo admin. A PR author
-  can't approve their own PR, so an admin reviews it and dispatches this; the
-  approval is then submitted by the App, a separate identity. Refuses to run for
-  anyone who is not a repo admin, so it can't be turned into a self-approval.
-  Wraps `approve-bot`.
+  Approves a pull request through the App on a repo admin's behalf — in practice,
+  an admin approving their own PR. Self-approval is normally forbidden because it
+  makes review pointless, but it is tolerated for admins as an escape hatch: to act
+  under urgency, or to set things up when no other contributor is available to
+  review. The admin check keeps it to that case, refusing to run for anyone who is
+  not a repo admin. Wraps `approve-bot`.
 
 inputs:
   client_id:

--- a/generic-actions/approve-pr/action.yaml
+++ b/generic-actions/approve-pr/action.yaml
@@ -1,19 +1,18 @@
 name: approve-pr
 description: >
-  Gate-2 override: let a repo ADMIN record the approval a PR author can't give
-  themselves. A manual, audited path — an admin reviews the PR, then dispatches
-  this, and the [Agent] App (a distinct identity from the author) submits the
-  approval. Refuses to run for anyone who is not a repo admin, so a plain
-  write-access user can't use it to self-approve their own PR. Wraps the existing
-  `generic-actions/approve-bot`. See a-novel-kit/.github#50.
+  Records a bot approval on a pull request on behalf of a repo admin. A PR author
+  can't approve their own PR, so an admin reviews it and dispatches this; the
+  approval is then submitted by the App, a separate identity. Refuses to run for
+  anyone who is not a repo admin, so it can't be turned into a self-approval.
+  Wraps `approve-bot`.
 
 inputs:
   client_id:
     required: true
-    description: Client id of the org's [Agent] App (the AGENT_BOT_CLIENT_ID var).
+    description: Client id of a GitHub App with the contents read and pull-requests write permissions.
   app_private_key:
     required: true
-    description: The [Agent] App private key (PEM) — the AGENT_BOT_PRIVATE_KEY secret.
+    description: Private key (PEM) of that App.
   pull_request:
     required: true
     description: URL (or number) of the pull request to approve.
@@ -21,11 +20,10 @@ inputs:
 runs:
   using: composite
   steps:
-    # Fail closed unless the triggering actor is a repo admin. workflow_dispatch is
-    # open to anyone with WRITE access, so this — not the trigger ACL — is the real
-    # Gate-2 control. Uses the default GITHUB_TOKEN: the collaborator-permission
-    # endpoint needs only Metadata:read, which every token carries and can't be
-    # stripped, so no Administration scope is required.
+    # Fail closed unless the actor who dispatched this is a repo admin —
+    # workflow_dispatch is open to anyone with write access, so this check is what
+    # keeps it admin-only. The collaborator-permission endpoint needs only
+    # Metadata:read (always present), so the default token suffices.
     - name: Require admin
       shell: bash
       env:

--- a/generic-actions/approve-pr/action.yaml
+++ b/generic-actions/approve-pr/action.yaml
@@ -53,11 +53,13 @@ runs:
         permission-contents: read
         permission-pull-requests: write
 
-    # approve-bot runs `gh pr checkout`, so a base checkout must exist first.
-    # persist-credentials:false — the minted token is passed explicitly, never
-    # baked into the git remote.
+    # approve-bot runs `gh pr checkout`, so a base checkout must exist first. Use
+    # the minted token so the action stays on its least-privilege token and never
+    # depends on the default token's contents permission; persist-credentials:false
+    # keeps it out of the git config (approve-bot passes it to gh explicitly).
     - uses: actions/checkout@v7
       with:
+        token: ${{ steps.token.outputs.token }}
         persist-credentials: false
 
     - uses: a-novel-kit/workflows/generic-actions/approve-bot@v1.3.2

--- a/generic-actions/approve-pr/action.yaml
+++ b/generic-actions/approve-pr/action.yaml
@@ -1,0 +1,68 @@
+name: approve-pr
+description: >
+  Gate-2 override: let a repo ADMIN record the approval a PR author can't give
+  themselves. A manual, audited path — an admin reviews the PR, then dispatches
+  this, and the [Agent] App (a distinct identity from the author) submits the
+  approval. Refuses to run for anyone who is not a repo admin, so a plain
+  write-access user can't use it to self-approve their own PR. Wraps the existing
+  `generic-actions/approve-bot`. See a-novel-kit/.github#50.
+
+inputs:
+  client_id:
+    required: true
+    description: Client id of the org's [Agent] App (the AGENT_BOT_CLIENT_ID var).
+  app_private_key:
+    required: true
+    description: The [Agent] App private key (PEM) — the AGENT_BOT_PRIVATE_KEY secret.
+  pull_request:
+    required: true
+    description: URL (or number) of the pull request to approve.
+
+runs:
+  using: composite
+  steps:
+    # Fail closed unless the triggering actor is a repo admin. workflow_dispatch is
+    # open to anyone with WRITE access, so this — not the trigger ACL — is the real
+    # Gate-2 control. Uses the default GITHUB_TOKEN: the collaborator-permission
+    # endpoint needs only Metadata:read, which every token carries and can't be
+    # stripped, so no Administration scope is required.
+    - name: Require admin
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO_FULL: ${{ github.repository }}
+        ACTOR: ${{ github.actor }}
+      run: |
+        set -euo pipefail
+        # `|| echo ""` keeps a failed lookup from tripping `set -e` — an empty
+        # permission then falls through to the admin check and fails closed.
+        perm=$(gh api "repos/${REPO_FULL}/collaborators/${ACTOR}/permission" -q '.permission' 2>/dev/null || echo "")
+        if [ "$perm" != "admin" ]; then
+          echo "::error::approve-pr is admin-only; @${ACTOR} has permission '${perm:-none}'."
+          exit 1
+        fi
+        echo "@${ACTOR} is a repo admin — recording an [Agent] approval." | tee -a "$GITHUB_STEP_SUMMARY"
+
+    # Mint a token scoped to ONLY what an approval needs: read the repo (so the
+    # nested approve-bot can `gh pr checkout`) plus write the PR review.
+    - name: Mint approval token
+      id: token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.client_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: ${{ github.repository_owner }}
+        permission-contents: read
+        permission-pull-requests: write
+
+    # approve-bot runs `gh pr checkout`, so a base checkout must exist first.
+    # persist-credentials:false — the minted token is passed explicitly, never
+    # baked into the git remote.
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+
+    - uses: a-novel-kit/workflows/generic-actions/approve-bot@v1.3.2
+      with:
+        pull_request: ${{ inputs.pull_request }}
+        github_token: ${{ steps.token.outputs.token }}

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -1,0 +1,72 @@
+name: merge-gate
+description: >
+  The single required "may this PR merge?" status check. Stage 2 ships it as a
+  SKELETON that always reports success: its only job today is to reliably post a
+  `merge-gate` check-run — as the [Agent] App, so the ruleset can require it by a
+  stable integration id — without ever blocking a merge. The real predicates,
+  epic-atomicity (every cross-repo sibling sub-issue PR is mergeable) and the
+  draft/review state, land in Stage 3, which changes only the `conclusion`
+  computed below — never the poster or the wiring. See a-novel-kit/.github#50.
+
+inputs:
+  client_id:
+    required: true
+    description: >
+      Client id of the org's [Agent] App (the AGENT_BOT_CLIENT_ID var). The check
+      is posted as the App — a stable integration id — so the required-status-check
+      match in the ruleset stays put when Stage 3 swaps in the real logic.
+  app_private_key:
+    required: true
+    description: The [Agent] App private key (PEM) — the AGENT_BOT_PRIVATE_KEY secret.
+  pull_request:
+    required: false
+    default: ${{ github.event.pull_request.html_url }}
+    description: >
+      URL of the PR under evaluation, for the check output and Stage-3 logic.
+      Defaults to the PR that triggered the workflow.
+
+runs:
+  using: composite
+  steps:
+    # Mint a token scoped to ONLY checks:write — a leak of this step's token can
+    # write check-runs and nothing else (no issues, PRs, or contents). This
+    # request fails until the [Agent] App is granted Checks:write (.github#59).
+    - name: Mint checks-write token
+      id: token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.client_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: ${{ github.repository_owner }}
+        permission-checks: write
+
+    - name: Post merge-gate check (skeleton — always success)
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.token.outputs.token }}
+        REPO_FULL: ${{ github.repository }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_URL: ${{ inputs.pull_request }}
+      run: |
+        set -euo pipefail
+
+        # The check must anchor to the PR head commit the ruleset evaluates.
+        if [ -z "${HEAD_SHA:-}" ]; then
+          echo "::error::merge-gate must run on a pull_request event (no head SHA)."
+          exit 1
+        fi
+
+        # Stage 2: unconditional success. Stage 3 computes the conclusion from the
+        # epic-atomicity + draft/review predicates and fills a real summary.
+        summary="Skeleton gate (Stage 2): always passes so the required check never blocks a merge. Epic-atomicity and draft/review predicates land in Stage 3 (a-novel-kit/.github#50). PR: ${PR_URL:-<none>}"
+
+        # Build the payload with jq so a summary containing quotes can't break the
+        # JSON (defensive — Stage 3 summaries will be dynamic).
+        jq -n \
+          --arg sha "$HEAD_SHA" \
+          --arg summary "$summary" \
+          '{name: "merge-gate", head_sha: $sha, status: "completed", conclusion: "success",
+            output: {title: "merge-gate skeleton — always passing", summary: $summary}}' \
+          | gh api "repos/${REPO_FULL}/check-runs" --method POST --input - >/dev/null
+
+        echo "Posted merge-gate=success on ${REPO_FULL}@${HEAD_SHA}" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -1,36 +1,27 @@
 name: merge-gate
 description: >
-  The single required "may this PR merge?" status check. Stage 2 ships it as a
-  SKELETON that always reports success: its only job today is to reliably post a
-  `merge-gate` check-run — as the [Agent] App, so the ruleset can require it by a
-  stable integration id — without ever blocking a merge. The real predicates,
-  epic-atomicity (every cross-repo sibling sub-issue PR is mergeable) and the
-  draft/review state, land in Stage 3, which changes only the `conclusion`
-  computed below — never the poster or the wiring. See a-novel-kit/.github#50.
+  Posts the `merge-gate` check-run — the single "may this PR merge?" status check
+  — on the triggering pull request. It runs as a GitHub App rather than the
+  workflow's own identity so the check's integration id is fixed regardless of
+  what decides the outcome, letting a ruleset require it by that id.
 
 inputs:
   client_id:
     required: true
-    description: >
-      Client id of the org's [Agent] App (the AGENT_BOT_CLIENT_ID var). The check
-      is posted as the App — a stable integration id — so the required-status-check
-      match in the ruleset stays put when Stage 3 swaps in the real logic.
+    description: Client id of a GitHub App with the checks write permission.
   app_private_key:
     required: true
-    description: The [Agent] App private key (PEM) — the AGENT_BOT_PRIVATE_KEY secret.
+    description: Private key (PEM) of that App.
   pull_request:
     required: false
     default: ${{ github.event.pull_request.html_url }}
-    description: >
-      URL of the PR under evaluation, for the check output and Stage-3 logic.
-      Defaults to the PR that triggered the workflow.
+    description: URL of the PR under evaluation. Defaults to the PR that triggered the run.
 
 runs:
   using: composite
   steps:
-    # Mint a token scoped to ONLY checks:write — a leak of this step's token can
-    # write check-runs and nothing else (no issues, PRs, or contents). This
-    # request fails until the [Agent] App is granted Checks:write (.github#59).
+    # Mint a token scoped to checks:write only — a leak is bounded to writing
+    # check-runs, nothing else.
     - name: Mint checks-write token
       id: token
       uses: actions/create-github-app-token@v3
@@ -40,7 +31,7 @@ runs:
         owner: ${{ github.repository_owner }}
         permission-checks: write
 
-    - name: Post merge-gate check (skeleton — always success)
+    - name: Post merge-gate check
       shell: bash
       env:
         GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -56,17 +47,17 @@ runs:
           exit 1
         fi
 
-        # Stage 2: unconditional success. Stage 3 computes the conclusion from the
-        # epic-atomicity + draft/review predicates and fills a real summary.
-        summary="Skeleton gate (Stage 2): always passes so the required check never blocks a merge. Epic-atomicity and draft/review predicates land in Stage 3 (a-novel-kit/.github#50). PR: ${PR_URL:-<none>}"
+        # TODO: placeholder that always passes. Replace the hard-coded success
+        # with the real merge-eligibility decision and a summary explaining it.
+        summary="No merge conditions are enforced yet — this check always passes. PR: ${PR_URL:-<none>}"
 
         # Build the payload with jq so a summary containing quotes can't break the
-        # JSON (defensive — Stage 3 summaries will be dynamic).
+        # JSON.
         jq -n \
           --arg sha "$HEAD_SHA" \
           --arg summary "$summary" \
           '{name: "merge-gate", head_sha: $sha, status: "completed", conclusion: "success",
-            output: {title: "merge-gate skeleton — always passing", summary: $summary}}' \
+            output: {title: "merge-gate", summary: $summary}}' \
           | gh api "repos/${REPO_FULL}/check-runs" --method POST --input - >/dev/null
 
         echo "Posted merge-gate=success on ${REPO_FULL}@${HEAD_SHA}" | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Stage-2 enforcement skeletons (epic a-novel-kit/.github#50). Two new composite actions in `generic-actions/`:

- **`merge-gate`** — posts an always-`success` `merge-gate` check-run **as the [Agent] App** (via the Checks API on the PR head SHA). Its only job in Stage 2 is to *exist as a requirable check that never blocks a merge*; the epic-atomicity + draft/review predicates land in Stage 3 and change only the computed `conclusion`, not the poster or the wiring. Posting as the App (not the Actions app) keeps the ruleset's required-check `integration` id stable across stages. Mints a token scoped to **`checks: write` only**.
- **`approve-pr`** — the admin-only **Gate-2 override**. `workflow_dispatch` is open to anyone with write, so the action itself is the gate: it verifies the dispatching actor has **`admin`** on the repo (fail-closed on any error — the collaborator-permission endpoint needs only Metadata:read, so no `Administration` scope) and then records an **[Agent]** approval the author can't self-give, wrapping the existing `generic-actions/approve-bot`. Mints a token scoped to **`contents: read` + `pull-requests: write` only**.

## Notes

- **Ordering:** `merge-gate` mints a `checks: write` token, so it only *functions* once the [Agent] App is granted **Checks:write** (a-novel-kit/.github#59). The code ships now; the grant + per-repo wiring (`stack` #156) + require-the-check land alongside.
- The per-repo caller workflows (`merge-gate.yaml` on `pull_request`, `approve-pr.yaml` on `workflow_dispatch`) and the `checks.yaml` `always` entry are **stack #156** (`repocfg`).
- README action catalog updated (also restores the missing `archive-board-items` row).

## Test plan

- [x] `prettier --check` clean on all changed files
- [x] Both `action.yaml` parse as valid composite actions
- [ ] End-to-end validation on a real PR — tracked as a-novel-kit/.github#60 (after #59 grant + #156 wiring)

Closes #207