### PR TITLE
fix(merge-gate): post the check on merge_group, not just pull_request

### DIFF
--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -1,9 +1,10 @@
 name: merge-gate
 description: >
   Posts the `merge-gate` check-run — the single "may this PR merge?" status check
-  — on the triggering pull request. It runs as a GitHub App rather than the
-  workflow's own identity so the check's integration id is fixed regardless of
-  what decides the outcome, letting a ruleset require it by that id.
+  — on the triggering pull request, or on the merge-queue group when the PR is in
+  the merge queue. It runs as a GitHub App rather than the workflow's own identity
+  so the check's integration id is fixed regardless of what decides the outcome,
+  letting a ruleset require it by that id.
 
 inputs:
   client_id:
@@ -36,14 +37,18 @@ runs:
       env:
         GH_TOKEN: ${{ steps.token.outputs.token }}
         REPO_FULL: ${{ github.repository }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         PR_URL: ${{ inputs.pull_request }}
       run: |
         set -euo pipefail
 
-        # The check must anchor to the PR head commit the ruleset evaluates.
+        # Anchor the check to the head commit the ruleset evaluates: the PR head on
+        # a pull_request event, or the merge-queue group's head on a merge_group
+        # event. The queue validates required checks on the group, so merge-gate
+        # must post there too — otherwise a queued PR waits out the check timeout
+        # and is dropped.
         if [ -z "${HEAD_SHA:-}" ]; then
-          echo "::error::merge-gate must run on a pull_request event (no head SHA)."
+          echo "::error::merge-gate must run on a pull_request or merge_group event (no head SHA)."
           exit 1
         fi
 


### PR DESCRIPTION
## Summary

Fixes a Stage-2 gap that stalls **every** merge-queue merge (surfaced by stuck Renovate PRs).

The master ruleset requires `merge-gate` **and** has a `merge_queue` rule. The queue validates required checks on the `merge_group` event / queue branch — `main.yaml` catches it via its `push: branches: ["**"]` trigger, but `merge-gate` runs only on `pull_request`, so it never posts on the queue branch. A queued PR then waits out `check_response_timeout_minutes` (60) and gets dropped.

- The action now anchors to `github.event.merge_group.head_sha` when the event is `merge_group` (falls back to `pull_request.head.sha`).
- Companion change (stack): add `on: merge_group:` to the pushed `merge-gate.yaml` template + re-pin it to this release.

## Rollout

Staged (manage-versions): release `workflows` (v1.5.0) → re-pin the stack template → `a-novel repo update`. Until then, queue merges must be admin-bypassed.

## Test plan

- [x] `prettier --check` + YAML parse clean
- [ ] After deploy: a queued PR shows `merge-gate` posting on the `gh-readonly-queue/…` head and the queue completes