### PR TITLE
feat(generic-actions): add derive-status action

### DIFF
--- a/generic-actions/board-write/action.yaml
+++ b/generic-actions/board-write/action.yaml
@@ -43,6 +43,13 @@ inputs:
     description: >
       When "true" (default), add content to the board if it isn't a member yet, so a
       derived write can't silently no-op on an un-boarded item. "false" errors instead.
+  only_if_empty:
+    required: false
+    default: "false"
+    description: >
+      When "true", write only if the field is currently empty; a field that already
+      holds any value is left untouched. Use it for set-once fields like Start date, so
+      a re-run or the reconcile sweep can't overwrite the original stamp.
   dry_run:
     required: false
     default: "false"
@@ -81,6 +88,7 @@ runs:
         FIELD: ${{ inputs.field }}
         VALUE: ${{ inputs.value }}
         ADD_IF_MISSING: ${{ inputs.add_if_missing }}
+        ONLY_IF_EMPTY: ${{ inputs.only_if_empty }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         set -euo pipefail
@@ -184,6 +192,17 @@ runs:
           fieldValueByName(name:\$field){ $cur_frag } } } }"
         cur=$(gh api graphql -f query="$cur_q" -F item="$item_id" -F field="$FIELD" \
           | jq -r '.data.node.fieldValueByName.current // empty')
+
+        # A set-once field (Start date): if it already holds anything, leave it — don't
+        # let a re-run or the sweep overwrite the original stamp.
+        if [ "$ONLY_IF_EMPTY" = "true" ] && [ -n "$cur" ]; then
+          echo "No change — \"$FIELD\" already set (\"$cur\") and only_if_empty." | tee -a "$GITHUB_STEP_SUMMARY"
+          {
+            echo "item_id=$item_id"
+            echo "changed=false"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
 
         if [ "$cur" = "$VALUE" ]; then
           echo "No change — \"$FIELD\" already \"$VALUE\" on item $item_id." | tee -a "$GITHUB_STEP_SUMMARY"

--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -54,11 +54,32 @@ runs:
           pullRequest(number:$num){
             state isDraft reviewDecision
             closingIssuesReferences(first:5){ nodes{ id number } } } } }'
-        pr=$(gh api graphql -f query="$q" -F owner="$OWNER" -F repo="$REPO" -F num="$PR")
+        # A not-found / inaccessible PR makes the GraphQL call error; catch that here so
+        # it fails with a clear message rather than gh's raw error mid-pipeline.
+        if ! pr=$(gh api graphql -f query="$q" -F owner="$OWNER" -F repo="$REPO" -F num="$PR"); then
+          echo "::error::could not query PR #$PR (not found, or the token lacks access)"
+          exit 1
+        fi
         state=$(echo "$pr" | jq -r '.data.repository.pullRequest.state')
         draft=$(echo "$pr" | jq -r '.data.repository.pullRequest.isDraft')
         review=$(echo "$pr" | jq -r '.data.repository.pullRequest.reviewDecision // ""')
-        issue_id=$(echo "$pr" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[0].id // empty')
+
+        # A missing/inaccessible PR resolves to null — fail with that, not a downstream
+        # "unexpected state 'null'".
+        if [ -z "$state" ] || [ "$state" = "null" ]; then
+          echo "::error::PR #$PR not found or inaccessible (check the number and token access)"
+          exit 1
+        fi
+
+        # A Task pairs with exactly one PR, so normally one closing ref. If a PR closes
+        # several, pick the lowest-numbered deterministically (not arbitrary node order)
+        # and warn — the reconcile sweep derives the others from their own PRs anyway.
+        refs=$(echo "$pr" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes')
+        ref_count=$(echo "$refs" | jq 'length')
+        issue_id=$(echo "$refs" | jq -r 'sort_by(.number) | .[0].id // empty')
+        if [ "$ref_count" -gt 1 ]; then
+          echo "::warning::PR #$PR closes $ref_count issues; deriving the lowest-numbered. The reconcile sweep covers the rest."
+        fi
 
         # Pure function of the PR's CURRENT state — the reconcile sweep re-runs this
         # identically, so it must not depend on which event fired.

--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -1,0 +1,132 @@
+name: derive-status
+description: >
+  Derive a Task's board Status from its pull request's CURRENT state and write it as
+  the [Agent] App, so the board follows PR activity with a single writer. The mapping
+  is a pure function of the PR (draft / approved / merged / closed), NOT of the event
+  that fired — which is exactly why the reconcile sweep can re-run this same derivation
+  to repair drift from dropped or cross-repo events. On first activity it also stamps
+  the Task's Start date, once. The Task is resolved through the PR's closing-issue
+  reference; a PR that closes no issue is a no-op. Writes go through board-write, so
+  the board stays single-writer.
+
+inputs:
+  client_id:
+    required: true
+    description: Client id for the org's [Agent] bot (for the board write, via board-write).
+  app_private_key:
+    required: true
+    description: The [Agent] bot App private key (PEM) — the AGENT_BOT_PRIVATE_KEY org secret.
+  project_id:
+    required: true
+    description: Node id of the org "Tasks" board (PVT_…). Passed in per-org by the caller.
+  pull_request_number:
+    required: false
+    default: ${{ github.event.pull_request.number }}
+    description: >
+      Number of the PR to derive from. Defaults to the PR that triggered the run, which
+      works for both pull_request and pull_request_review events; the reconcile sweep
+      passes each open Task's PR explicitly.
+
+runs:
+  using: composite
+  steps:
+    # Read the PR and compute the target Status. Reads only (PR state + the closing
+    # issue), so this runs on the caller's default token — the caller grants
+    # contents:read + pull-requests:read; the [Agent] token is minted only for the
+    # write, inside board-write.
+    - name: Compute Status + resolve the Task
+      id: derive
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+        PR: ${{ inputs.pull_request_number }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${PR:-}" ]; then
+          echo "::error::no PR number — run on a pull_request / pull_request_review event, or pass pull_request_number"
+          exit 1
+        fi
+
+        q='query($owner:String!,$repo:String!,$num:Int!){ repository(owner:$owner,name:$repo){
+          pullRequest(number:$num){
+            state isDraft reviewDecision
+            closingIssuesReferences(first:5){ nodes{ id number } } } } }'
+        pr=$(gh api graphql -f query="$q" -F owner="$OWNER" -F repo="$REPO" -F num="$PR")
+        state=$(echo "$pr" | jq -r '.data.repository.pullRequest.state')
+        draft=$(echo "$pr" | jq -r '.data.repository.pullRequest.isDraft')
+        review=$(echo "$pr" | jq -r '.data.repository.pullRequest.reviewDecision // ""')
+        issue_id=$(echo "$pr" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[0].id // empty')
+
+        # Pure function of the PR's CURRENT state — the reconcile sweep re-runs this
+        # identically, so it must not depend on which event fired.
+        case "$state" in
+          MERGED) status="Awaiting release" ;;
+          CLOSED) status="Ready" ;; # closed unmerged → the attempt was abandoned; back to actionable
+          OPEN)
+            if [ "$draft" = "true" ]; then
+              status="In progress"
+            elif [ "$review" = "APPROVED" ]; then
+              status="Done"
+            else
+              status="In review"
+            fi
+            ;;
+          *)
+            echo "::error::unexpected PR state '$state'"
+            exit 1
+            ;;
+        esac
+
+        if [ -z "$issue_id" ]; then
+          echo "PR #$PR closes no issue — nothing to derive." | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "has_issue=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # "activated" = the Task has genuinely started (any state past the pre-PR
+        # Backlog/Ready), which is when it earns a Start date. A reverted PR
+        # (closed-unmerged → Ready) is NOT activated, so it never back-stamps a date.
+        activated=false
+        case "$status" in
+          "In progress" | "In review" | "Done" | "Awaiting release") activated=true ;;
+        esac
+
+        {
+          echo "has_issue=true"
+          echo "issue_id=$issue_id"
+          echo "status=$status"
+          echo "activated=$activated"
+          echo "today=$(date -u +%Y-%m-%d)"
+        } >> "$GITHUB_OUTPUT"
+        echo "PR #$PR ($state, draft=$draft, review=${review:-none}) → \"$status\" on issue $issue_id." \
+          | tee -a "$GITHUB_STEP_SUMMARY"
+
+    # Write the derived Status. board-write mints the [Agent] token, resolves the item
+    # (adding it if absent), and compares before writing.
+    - name: Write Status
+      if: ${{ steps.derive.outputs.has_issue == 'true' }}
+      uses: ./generic-actions/board-write
+      with:
+        client_id: ${{ inputs.client_id }}
+        app_private_key: ${{ inputs.app_private_key }}
+        project_id: ${{ inputs.project_id }}
+        content_id: ${{ steps.derive.outputs.issue_id }}
+        field: Status
+        value: ${{ steps.derive.outputs.status }}
+
+    # Stamp Start date once, on first activity. only_if_empty keeps a re-run or the
+    # sweep from moving an already-set start date.
+    - name: Stamp Start date (once)
+      if: ${{ steps.derive.outputs.has_issue == 'true' && steps.derive.outputs.activated == 'true' }}
+      uses: ./generic-actions/board-write
+      with:
+        client_id: ${{ inputs.client_id }}
+        app_private_key: ${{ inputs.app_private_key }}
+        project_id: ${{ inputs.project_id }}
+        content_id: ${{ steps.derive.outputs.issue_id }}
+        field: Start date
+        value: ${{ steps.derive.outputs.today }}
+        only_if_empty: "true"


### PR DESCRIPTION
## Summary

The single-writer **Status deriver** for Stage 3 (a-novel-kit/.github#51). Two pieces:

1. **`derive-status`** — reads a PR's current state, resolves its linked Task (via `closingIssuesReferences`), computes the Task's board Status, and writes it through `board-write`. Also stamps the Task's Start date once, on first activity.
2. **`board-write` gains `only_if_empty`** — write only when the field is blank, so a re-run or the reconcile sweep can't overwrite a set-once field like Start date.

### The derivation (pure function of the PR's *current* state)

| PR state | → Status |
|---|---|
| open, draft | In progress |
| open, non-draft, not approved | In review |
| open, non-draft, approved | Done |
| merged | Awaiting release |
| closed, unmerged | Ready |

It keys off *state*, not the event that fired — which is what lets the reconcile sweep (#66) re-run the **identical** derivation to repair drift from dropped/cross-repo events. `derive-status` reads with the caller's default token (needs `contents:read` + `pull-requests:read`); the `[Agent]` token is minted only for the write, inside `board-write`, so the board stays single-writer.

## Test plan

`workflows` CI is prettier-only, so validated the non-trivial logic **live against real data** (composite step-wiring runs first in the caller, stack#172):

- [x] compute query on a real merged PR that links an issue → resolves state + closing-issue node id → maps to `Awaiting release` ✓
- [x] `only_if_empty` guard: an already-set Start date → no-op ✓
- [x] YAML parses; prettier clean; bash hand-reviewed.

## Rollout

`workflows`-side action; consumed locally by the reconcile sweep and by the `stack` governance caller (#172), which pins the eventual `workflows` release.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)