### PR TITLE
fix(workflows): pin board-write ref in derive-status

### DIFF
--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -139,10 +139,11 @@ runs:
           | tee -a "$GITHUB_STEP_SUMMARY"
 
     # Write the derived Status. board-write mints the [Agent] token, resolves the item
-    # (adding it if absent), and compares before writing.
+    # (adding it if absent), and compares before writing. Pinned external ref: a
+    # ./ path would resolve against the CONSUMER repo's workspace, not this repo.
     - name: Write Status
       if: ${{ steps.derive.outputs.has_issue == 'true' }}
-      uses: ./generic-actions/board-write
+      uses: a-novel-kit/workflows/generic-actions/board-write@v1.8.0
       with:
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
@@ -155,7 +156,7 @@ runs:
     # sweep from moving an already-set start date.
     - name: Stamp Start date (once)
       if: ${{ steps.derive.outputs.has_issue == 'true' && steps.derive.outputs.activated == 'true' }}
-      uses: ./generic-actions/board-write
+      uses: a-novel-kit/workflows/generic-actions/board-write@v1.8.0
       with:
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}


### PR DESCRIPTION
## Summary

- `derive-status@v1.8.0` invokes its board-write sub-action as `uses: ./generic-actions/board-write` — inside a composite action, a `./` ref resolves against the **consumer's** workspace, so the step fails on every governed repo whose PR closes an issue (first seen on a-novel-kit/stack#181, run 28610842334). Renovate PRs pass because the step is skipped without a linked issue, which masked the regression at release time.
- Switches both call sites to the pinned external ref (`a-novel-kit/workflows/generic-actions/board-write@v1.8.0`), the form every other sibling-action call in this repo uses; `prepublish:doc` stamping keeps the version current on each release. Audited the rest of the repo: no other composite action uses a `./` ref (the `.github/workflows/` ones are fine — they run in this repo's own workspace).

Closes #237.

## Breaking changes

None.

## Test plan

- [x] `prettier@3.9.2 --check` clean (run from this repo)
- [ ] CI green
- [ ] Post-release: re-run the failed `derive` job on a consumer PR with a linked issue (e.g. a-novel-kit/stack#181) once the consumer pin is bumped