### PR TITLE
feat(ci): surface cut version in the release run summary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,3 +67,9 @@ jobs:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
           project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
+
+
+      # Surface the cut version in the run summary so a release run is
+      # identifiable by version at a glance (run-name carries only the bump type).
+      - if: ${{ !inputs.dry_run }}
+        run:  echo "## 🚀 Released \`${{ steps.core.outputs.tag }}\` (${{ inputs.release_type }})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,8 +68,7 @@ jobs:
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
           project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
 
-
       # Surface the cut version in the run summary so a release run is
       # identifiable by version at a glance (run-name carries only the bump type).
       - if: ${{ !inputs.dry_run }}
-        run:  echo "## 🚀 Released \`${{ steps.core.outputs.tag }}\` (${{ inputs.release_type }})" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "## 🚀 Released \`${{ steps.core.outputs.tag }}\` (${{ inputs.release_type }})" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Surface the cut version in the release workflow's **run summary**, so a past release run is identifiable by version at a glance. The run-name only carries the bump type (`🚀 release patch`), and GitHub's `run-name` is evaluated once at start — it can't be updated mid-run once `release-core` computes the version — so the job summary is where the version can actually land.

## Change

- `release.yaml`: after a non-dry-run release, echo `## 🚀 Released <tag> (<type>)` to `$GITHUB_STEP_SUMMARY`.

## Note

This PR also serves as **Spike 0** (a-novel-kit/.github#240) — validating that native `auto-merge` can be **enabled while a required check is red** and lands cleanly once green (the March-2026 #190610 question). The first commit deliberately trips `lint-node` (a prettier nit); the fix follows.

## Test plan

- [ ] `lint-node` fails on the planted formatting nit
- [ ] `auto-merge` enables while the required check is red (does it park or 422?)
- [ ] fix pushed → `lint-node` green → auto-merge lands