### PR TITLE
feat(generic-actions): add enable-auto-merge action

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | `check-changes`       | Detect uncommitted changes in a pathspec; optionally fail.                 |
 | `codecov`             | Upload the coverage artifact to Codecov.                                   |
 | `derive-status`       | Derive a Task's board Status from its PR's current state (single writer).  |
+| `enable-auto-merge`   | Enable native auto-merge on a PR as the [Agent] App (queue-when-green).    |
 | `epic-membership`     | Resolve an Epic's authorized member set — open PRs labelled `epic:<N>`.    |
 | `merge-gate`          | Required "may this PR merge?" check (epic-atomicity + draft/review).       |
 | `pull-bot`            | Mint a bot App token and check out the repo authenticated as it.           |

--- a/generic-actions/enable-auto-merge/action.yaml
+++ b/generic-actions/enable-auto-merge/action.yaml
@@ -26,7 +26,7 @@ inputs:
     description: Number of the PR to enable auto-merge on.
   client_id:
     required: true
-    description: Client id of the [Agent] App (pull-requests write on the target repo).
+    description: Client id of the [Agent] App (pull-requests + contents write on the target repo).
   app_private_key:
     required: true
     description: Private key (PEM) of that App.
@@ -52,6 +52,10 @@ runs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ inputs.repo }}
         permission-pull-requests: write
+        # `gh pr merge --auto` needs contents:write too — the only proven `--auto` enqueue
+        # in this repo (governance/auto-approve-dependabot) mints both. A later spike may
+        # confirm pull-requests:write alone suffices and narrow this.
+        permission-contents: write
 
     - name: Enable auto-merge
       shell: bash
@@ -74,7 +78,10 @@ runs:
           -q '.autoMergeRequest != null')
 
         # DRY_RUN defaults on; only the literal "false" (any case) actually enables.
-        if [ "${DRY_RUN,,}" != "false" ]; then
+        # Lowercase with tr, not ${VAR,,} — the latter is a Bash 4+ expansion that fails
+        # on Bash 3.x (e.g. macOS runners).
+        dry=$(printf '%s' "${DRY_RUN:-true}" | tr '[:upper:]' '[:lower:]')
+        if [ "$dry" != "false" ]; then
           if [ "$already" = "true" ]; then
             echo "auto-merge already enabled on ${target} — would no-op (DRY RUN)." | tee -a "$GITHUB_STEP_SUMMARY"
           else

--- a/generic-actions/enable-auto-merge/action.yaml
+++ b/generic-actions/enable-auto-merge/action.yaml
@@ -1,0 +1,92 @@
+name: enable-auto-merge
+description: >
+  Enable native auto-merge on a pull request as the [Agent] App, so GitHub lands it once
+  every required check and approval is satisfied — the caller enables it once and walks
+  away instead of polling for green.
+
+  Enabling is safe while a required check is still RED: GitHub parks the request and
+  merges when the branch goes green (verified — enablePullRequestAutoMerge does not 422
+  on an unmet required check on our merge-queue repos). So a landing coordinator can
+  enable auto-merge once per sibling at ready-time and let the gate hold it.
+
+  Idempotent: if auto-merge is already enabled it is a no-op (decided by querying the
+  PR, not by parsing an error string). `--squash` is the only method the require-approval
+  ruleset allows; on a merge-queue repo the queue's own config takes over regardless, so
+  passing it is safe and explicit rather than a real method choice.
+
+inputs:
+  repo:
+    required: false
+    default: ${{ github.event.repository.name }}
+    description: >
+      Repository of the PR (name only; the owner is the workflow's org). Defaults to the
+      triggering repo; a cross-repo caller passes each sibling's repo.
+  pull_request_number:
+    required: true
+    description: Number of the PR to enable auto-merge on.
+  client_id:
+    required: true
+    description: Client id of the [Agent] App (pull-requests write on the target repo).
+  app_private_key:
+    required: true
+    description: Private key (PEM) of that App.
+  dry_run:
+    required: false
+    default: "true"
+    description: >
+      When "true" (the default), log the intended enable without calling GitHub — the
+      read-only-first mode. Set "false" to actually enable auto-merge.
+
+runs:
+  using: composite
+  steps:
+    # Scope the token to just the target repo (least privilege). The [Agent] App is
+    # installed org-wide, so a cross-repo caller can enable on any sibling's repo by
+    # passing its name here.
+    - name: Mint token
+      id: token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.client_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ inputs.repo }}
+        permission-pull-requests: write
+
+    - name: Enable auto-merge
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.token.outputs.token }}
+        REPO_FULL: ${{ github.repository_owner }}/${{ inputs.repo }}
+        PR: ${{ inputs.pull_request_number }}
+        DRY_RUN: ${{ inputs.dry_run }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${PR:-}" ]; then
+          echo "::error::pull_request_number is required"
+          exit 1
+        fi
+        target="${REPO_FULL}#${PR}"
+
+        # Idempotency by query, not by parsing an error string: is auto-merge already on?
+        already=$(gh pr view "$PR" --repo "$REPO_FULL" --json autoMergeRequest \
+          -q '.autoMergeRequest != null')
+
+        # DRY_RUN defaults on; only the literal "false" (any case) actually enables.
+        if [ "${DRY_RUN,,}" != "false" ]; then
+          if [ "$already" = "true" ]; then
+            echo "auto-merge already enabled on ${target} — would no-op (DRY RUN)." | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "would enable auto-merge on ${target} (DRY RUN)." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+          exit 0
+        fi
+
+        if [ "$already" = "true" ]; then
+          echo "auto-merge already enabled on ${target} — no-op." | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        gh pr merge "$PR" --repo "$REPO_FULL" --auto --squash
+        echo "auto-merge enabled on ${target}." | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Add the `enable-auto-merge` composite action — enable native auto-merge on a PR as the [Agent] App, so the Stage-4 landing flow enables it **once per sibling** and lets the gate hold it until green, rather than polling. Validated by Spike 0: `enablePullRequestAutoMerge` **parks** on a red required check (no #190610 422).

## Details

- **Least-privilege**: mints a token scoped to just the target `repo` (pull-requests:write); the org-wide App lets a cross-repo caller pass each sibling's repo.
- **Idempotent by query** — checks `autoMergeRequest` first, not by parsing an error string.
- Ships `dry_run: "true"` by default (the Stage-4 discipline: every mutation logs-first).
- `--squash` matches the require-approval ruleset's only allowed method; on a merge-queue repo the queue's own config takes over, so it's explicit-not-a-choice.

## Scope

Part of a-novel-kit/.github#233. The evaluator (#232) will nest this to enable auto-merge per ready sibling; this PR is the reusable enablement primitive.

## Test plan

- [x] YAML parse + prettier + `bash -n`
- [ ] live: `dry_run` logs the intended enable; `dry_run:false` enables + is a no-op on re-run