### PR TITLE
docs: refocus comments on rationale and refine project docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Each action lives at `<group>/<name>/action.yaml`, grouped by the kind of work i
 
 ## Versioning
 
-The whole repository is released as a single unit: a single Git tag covers every action at once, with no per-action versions. Release tags follow the `v*` convention; pushing one triggers `publish-actions/auto-release`, which turns it into a GitHub Release with generated notes.
+The whole repository is released as a single unit: one `v*` Git tag covers every action at once, with no per-action versions. Releases are cut from the GitHub UI (Actions ▸ release ▸ pick a bump type), which runs `publish-actions/release-core` to compute the next tag, push it, and create the GitHub Release. The protected `release` environment gates who may publish.
 
 Because everything ships together, an action may depend on another in this repo — but reference it by its pinned tag (`a-novel-kit/workflows/<group>/<name>@<tag>`), never a relative path. That keeps a release internally consistent: every action in a release calls that same release's version of its siblings, rather than whatever currently sits on `master`.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | `derive-status`          | Derive a Task's board Status from its PR's current state (single writer).                                         |
 | `detect-partial-landing` | Freeze an epic's remaining siblings when a sibling drops out mid-landing (writer behind the `epic-freeze` check). |
 | `enable-auto-merge`      | Enable native auto-merge on a PR as the [Agent] App (queue-when-green).                                           |
-| `epic-membership`        | Resolve an Epic's authorized member set — open PRs labelled `epic:<N>`.                                           |
+| `epic-membership`        | Resolve an Epic's authorized member set — open PRs labeled `epic:<N>`.                                           |
 | `merge-gate`             | Required "may this PR merge?" check (epic-atomicity + draft/review).                                              |
 | `pull-bot`               | Mint a bot App token and check out the repo authenticated as it.                                                  |
 | `renovate`               | Run self-hosted Renovate as the bot.                                                                              |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | `derive-status`          | Derive a Task's board Status from its PR's current state (single writer).                                         |
 | `detect-partial-landing` | Freeze an epic's remaining siblings when a sibling drops out mid-landing (writer behind the `epic-freeze` check). |
 | `enable-auto-merge`      | Enable native auto-merge on a PR as the [Agent] App (queue-when-green).                                           |
-| `epic-membership`        | Resolve an Epic's authorized member set — open PRs labeled `epic:<N>`.                                           |
+| `epic-membership`        | Resolve an Epic's authorized member set — open PRs labeled `epic:<N>`.                                            |
 | `merge-gate`             | Required "may this PR merge?" check (epic-atomicity + draft/review).                                              |
 | `pull-bot`               | Mint a bot App token and check out the repo authenticated as it.                                                  |
 | `renovate`               | Run self-hosted Renovate as the bot.                                                                              |

--- a/README.md
+++ b/README.md
@@ -45,23 +45,24 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 
 ### `generic-actions`
 
-| Action                | Purpose                                                                    |
-| --------------------- | -------------------------------------------------------------------------- |
-| `approve-bot`         | Auto-approve a PR (skips if already approved); trusted users only.         |
-| `approve-pr`          | Admin-only: record an [Agent] approval on a PR (Gate-2 override).          |
-| `archive-board-items` | Archive the repo's "Awaiting release" board items on release.              |
-| `assign-bot`          | Assign the PR author to their own PR.                                      |
-| `auto-merge-bot`      | Enable auto-merge on a PR.                                                 |
-| `board-write`         | Set one single-select/date board field as [Agent] — the single write path. |
-| `check-changes`       | Detect uncommitted changes in a pathspec; optionally fail.                 |
-| `codecov`             | Upload the coverage artifact to Codecov.                                   |
-| `derive-status`       | Derive a Task's board Status from its PR's current state (single writer).  |
-| `enable-auto-merge`   | Enable native auto-merge on a PR as the [Agent] App (queue-when-green).    |
-| `epic-membership`     | Resolve an Epic's authorized member set — open PRs labelled `epic:<N>`.    |
-| `merge-gate`          | Required "may this PR merge?" check (epic-atomicity + draft/review).       |
-| `pull-bot`            | Mint a bot App token and check out the repo authenticated as it.           |
-| `renovate`            | Run self-hosted Renovate as the bot.                                       |
-| `rollup-board`        | Roll an epic's Status + Start date up from its children.                   |
+| Action                   | Purpose                                                                                                           |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `approve-bot`            | Auto-approve a PR (skips if already approved); trusted users only.                                                |
+| `approve-pr`             | Admin-only escape hatch: approve a PR as the [Agent] App (self-approval).                                         |
+| `archive-board-items`    | Archive the repo's "Awaiting release" board items on release.                                                     |
+| `assign-bot`             | Assign a PR to its author, or to the code owner when the author is a bot.                                         |
+| `auto-merge-bot`         | Enable auto-merge on a PR.                                                                                        |
+| `board-write`            | Set one single-select/date board field as [Agent] — the single write path.                                        |
+| `check-changes`          | Detect uncommitted changes in a pathspec; optionally fail.                                                        |
+| `codecov`                | Upload the coverage artifact to Codecov.                                                                          |
+| `derive-status`          | Derive a Task's board Status from its PR's current state (single writer).                                         |
+| `detect-partial-landing` | Freeze an epic's remaining siblings when a sibling drops out mid-landing (writer behind the `epic-freeze` check). |
+| `enable-auto-merge`      | Enable native auto-merge on a PR as the [Agent] App (queue-when-green).                                           |
+| `epic-membership`        | Resolve an Epic's authorized member set — open PRs labelled `epic:<N>`.                                           |
+| `merge-gate`             | Required "may this PR merge?" check (epic-atomicity + draft/review).                                              |
+| `pull-bot`               | Mint a bot App token and check out the repo authenticated as it.                                                  |
+| `renovate`               | Run self-hosted Renovate as the bot.                                                                              |
+| `rollup-board`           | Roll an epic's Status + Start date up from its children.                                                          |
 
 ### `github-pages-actions`
 
@@ -75,7 +76,7 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | ---------------- | -------------------------------------------------------------- |
 | `go-report-card` | Refresh the repo's [Go Report Card](https://goreportcard.com). |
 | `lint-go`        | Run `golangci-lint` (supports a non-root module dir).          |
-| `test-go`        | Run Go tests (race + coverage) via `gotestsum`.                |
+| `test-go`        | Run the workspace's Go tests with coverage via `gotestsum`.    |
 
 ### `node-actions`
 
@@ -89,10 +90,11 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 
 ### `publish-actions`
 
-| Action         | Purpose                                                |
-| -------------- | ------------------------------------------------------ |
-| `auto-release` | Turn a pushed tag into a GitHub release with notes.    |
-| `npm`          | Publish the workspace packages to the GitHub registry. |
+| Action         | Purpose                                                    |
+| -------------- | ---------------------------------------------------------- |
+| `auto-release` | Turn a pushed tag into a GitHub release with notes.        |
+| `npm`          | Publish the workspace packages to the GitHub registry.     |
+| `release-core` | Cut a release in CI: bump the version, tag, push, release. |
 
 ### Reusable workflows
 

--- a/build-actions/docker-job/action.yaml
+++ b/build-actions/docker-job/action.yaml
@@ -21,7 +21,7 @@ inputs:
     description: Args to use for the test run of the image.
   timeout:
     required: false
-    description: Timeout (in deciseconds) for the container healthcheck.
+    description: Timeout (in deciseconds) for the container to finish running.
     default: "300"
   skip_healthcheck:
     required: false
@@ -32,7 +32,7 @@ inputs:
   context:
     required: false
     description: The context to use for the build.
-    # Build from the directory containing the Dockerfiles, to mimic the same behavior locally and from the CI.
+    # Default to the repository root so the build context matches local and CI builds.
     default: .
   secrets:
     description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)."

--- a/build-actions/docker/action.yaml
+++ b/build-actions/docker/action.yaml
@@ -29,7 +29,7 @@ inputs:
   context:
     required: false
     description: The context to use for the build.
-    # Build from the directory containing the Dockerfiles, to mimic the same behavior locally and from the CI.
+    # Default to the repository root so the build context matches local and CI builds.
     default: .
   secrets:
     description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)."

--- a/docs/migrations/v1.1.0.md
+++ b/docs/migrations/v1.1.0.md
@@ -13,7 +13,7 @@ working untouched. The one migration worth doing is **`app_id` → `client_id`**
 
 The bot-token actions — `generic-actions/pull-bot`, `node-actions/setup-node`, `publish-actions/npm`,
 `generic-actions/renovate`, and every `node-actions/*` — now accept a **`client_id`** input alongside
-the legacy `app_id`. When `client_id` is set, the token is minted from the App **client id** and no
+the legacy `app_id`. When `client_id` is set, the token is minted from the App **client ID** and no
 deprecation warning is printed; `app_id` still works but is deprecated.
 
 Migrate each caller:
@@ -45,4 +45,3 @@ when you're ready.
 
 - Rolling `client_id` out across every repo is tracked in
   [a-novel-kit/workflows#191](https://github.com/a-novel-kit/workflows/issues/191).
-- First guide written with the `prepare-release` skill.

--- a/generic-actions/approve-pr/action.yaml
+++ b/generic-actions/approve-pr/action.yaml
@@ -10,7 +10,7 @@ description: >
 inputs:
   client_id:
     required: true
-    description: Client id of a GitHub App with the contents read and pull-requests write permissions.
+    description: Client ID of a GitHub App with the contents read and pull-requests write permissions.
   app_private_key:
     required: true
     description: Private key (PEM) of that App.

--- a/generic-actions/board-write/action.yaml
+++ b/generic-actions/board-write/action.yaml
@@ -1,6 +1,6 @@
 name: board-write
 description: >
-  The write half of the board automation: set ONE field (single-select or date) on a
+  The write half of the board automation: set one field (single-select or date) on a
   Projects v2 board item, for a given issue or PR, as the [Agent] App. It resolves the
   field + option node-ids and the item — adding the item to the board if it isn't a
   member yet — and compares the current value before writing, so a re-run or an
@@ -35,7 +35,7 @@ inputs:
   value:
     required: true
     description: >
-      Target value. For a single-select field, the option NAME (e.g. "In progress").
+      Target value. For a single-select field, the option name (e.g. "In progress").
       For a date field, an ISO date (YYYY-MM-DD).
   add_if_missing:
     required: false
@@ -117,7 +117,7 @@ runs:
         fi
 
         # Build the GraphQL value fragment to write, and the sub-selection that reads
-        # the item's CURRENT value of this field (for the compare-before-write). Both
+        # the item's current value of this field (for the compare-before-write). Both
         # inlined values are safe to interpolate: a single-select option id is a GitHub
         # node id, and a date is format-checked below.
         case "$data_type" in
@@ -152,7 +152,7 @@ runs:
             ;;
         esac
 
-        # 2. Resolve the content's item in THIS project; add it if missing (a derived
+        # 2. Resolve the content's item in this project; add it if missing (a derived
         #    write on an un-boarded Task should board it, not vanish). Page through
         #    projectItems so a content that sits on many projects still matches —
         #    idempotence must not hinge on the first page holding the target board.

--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -1,8 +1,8 @@
 name: derive-status
 description: >
-  Derive a Task's board Status from its pull request's CURRENT state and write it as
+  Derive a Task's board Status from its pull request's current state and write it as
   the [Agent] App, so the board follows PR activity with a single writer. The mapping
-  is a pure function of the PR (draft / approved / merged / closed), NOT of the event
+  is a pure function of the PR (draft / approved / merged / closed), not of the event
   that fired — which is exactly why the reconcile sweep can re-run this same derivation
   to repair drift from dropped or cross-repo events. On first activity it also stamps
   the Task's Start date, once. The Task is resolved through the PR's closing-issue
@@ -94,7 +94,7 @@ runs:
           echo "::warning::PR #$PR closes $ref_count issues; deriving the lowest-numbered. The reconcile sweep covers the rest."
         fi
 
-        # Pure function of the PR's CURRENT state — the reconcile sweep re-runs this
+        # Pure function of the PR's current state — the reconcile sweep re-runs this
         # identically, so it must not depend on which event fired.
         case "$state" in
           MERGED) status="Awaiting release" ;;
@@ -122,7 +122,7 @@ runs:
 
         # "activated" = the Task has genuinely started (any state past the pre-PR
         # Backlog/Ready), which is when it earns a Start date. A reverted PR
-        # (closed-unmerged → Ready) is NOT activated, so it never back-stamps a date.
+        # (closed-unmerged → Ready) is not activated, so it never back-stamps a date.
         activated=false
         case "$status" in
           "In progress" | "In review" | "Done" | "Awaiting release") activated=true ;;
@@ -139,8 +139,8 @@ runs:
           | tee -a "$GITHUB_STEP_SUMMARY"
 
     # Write the derived Status. board-write mints the [Agent] token, resolves the item
-    # (adding it if absent), and compares before writing. Pinned external ref: a
-    # ./ path would resolve against the CONSUMER repo's workspace, not this repo.
+    # (adding it if absent), and compares before writing. This pins the external ref
+    # because a ./ path would resolve against the consumer repo's workspace, not this repo.
     - name: Write Status
       if: ${{ steps.derive.outputs.has_issue == 'true' }}
       uses: a-novel-kit/workflows/generic-actions/board-write@v1.10.0

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -1,38 +1,39 @@
 name: detect-partial-landing
 description: >
-  Stage-4 partial-landing detector — the writer behind the required `epic-freeze` check.
-  THE HAZARD: merge-gate releases an `epic:<N>` sibling set to land together, but once landing STARTS
-  a sibling can silently drop out of its merge queue (flaky check, timeout, speculative rebuild) while
-  the others keep merging — a PARTIAL landing that breaks atomicity (INV-1) and that merge-gate can't
-  see (the dropped sibling is still non-draft + approved). This action is the fail-safe that freezes
+  Partial-landing detector — the writer behind the required `epic-freeze` check. The hazard it
+  guards: merge-gate releases an `epic:<N>` sibling set to land together, but once landing starts a
+  sibling can silently drop out of its merge queue (flaky check, timeout, speculative rebuild) while
+  the others keep merging — a partial landing that breaks atomicity and that merge-gate can't see
+  (the dropped sibling is still non-draft and approved). This action is the fail-safe that freezes
   the remaining siblings when the gap is REST-confirmed real.
 
-  It runs in TWO MODES over ONE shared, PURE predicate (evaluate_epic — no posting/mutation) so the
-  two writers structurally cannot disagree. PER-PR: event-driven fast path; classifies the triggering
-  PR and posts epic-freeze on its head only; fails OPEN (success on any uncertainty) so a fresh head
-  is never stranded on "Expected". SWEEP (~15 min, level-triggered floor): enumerates active Epics
-  org-wide, rolls strays forward within grace, freezes REST-confirmed partials, and backstops every
-  open non-member head; fails CLOSED. Both re-derive ground truth each pass — no stored state to drift.
+  It runs in two modes over one shared, pure predicate (evaluate_epic — no posting or mutation) so
+  the two writers structurally cannot disagree. Per-PR is the event-driven fast path: it classifies
+  the triggering PR and posts epic-freeze on its head only, and fails open (success on any
+  uncertainty) so a fresh head is never stranded on "Expected". The sweep (a level-triggered floor,
+  roughly every 15 minutes) enumerates active Epics org-wide, rolls strays forward within grace,
+  freezes REST-confirmed partials, and backstops every open non-member head; it fails closed. Both
+  re-derive ground truth each pass, so there is no stored state to drift.
 
-  THE FREEZE IS A CHECK-RUN, not a status: an `epic-freeze` check-run (checks:write) posted
-  `conclusion: failure` — NEVER `neutral` (GitHub counts neutral as a passing required check) — on a
-  DIFFERENT context from `merge-gate` so the two required checks never clobber; posted on a live queue
-  head it dequeues the in-flight group. Default conclusion is `success`.
+  The freeze is a check-run, not a status: an `epic-freeze` check-run (checks:write) posted with
+  `conclusion: failure` — never `neutral`, which GitHub counts as a passing required check — on a
+  different context from `merge-gate` so the two required checks never clobber. Posted on a live
+  queue head it dequeues the in-flight group. The default conclusion is `success`.
 
-  RECOVER, don't roll back: the sweep re-enqueues a landable stray within grace (self-heals, no
-  freeze), freezes after grace, and unfreezes (re-posts `success`) once the Epic is whole. Unfreeze
-  NEVER re-enables auto-merge — dequeue disabled it on purpose so a frozen sibling can't thrash;
-  resuming a frozen landing is a human's call (a-novel-kit/workflows#235). Never reverts a merged PR.
-  `dry_run` defaults on: logs every intended freeze / unfreeze / re-enqueue without calling GitHub.
+  It recovers rather than rolls back: the sweep re-enqueues a landable stray within grace
+  (self-heals, no freeze), freezes after grace, and unfreezes (re-posts `success`) once the Epic is
+  whole. Unfreeze never re-enables auto-merge — dequeue disabled it on purpose so a frozen sibling
+  can't thrash; resuming a frozen landing is a human's call. It never reverts a merged PR. `dry_run`
+  defaults on: it logs every intended freeze, unfreeze, and re-enqueue without calling GitHub.
 
 inputs:
   client_id:
     required: true
     description: >
-      Client id of the [Agent] App. SWEEP mints THREE least-privilege org-wide tokens: issues+PR read,
-      checks:write, and PR+contents write (roll a stray forward). PER-PR mints only the first two — the
-      write token is gated to the sweep. The App identity fixes the check's integration id so a ruleset
-      can require it.
+      Client ID of the [Agent] App. The sweep mints three least-privilege org-wide tokens: issues +
+      PR read, checks:write, and PR + contents write (to roll a stray forward). Per-PR mints only the
+      first two — the write token is gated to the sweep. The App identity fixes the check's
+      integration ID so a ruleset can require it.
   app_private_key:
     required: true
     description: Private key (PEM) of that App.
@@ -40,34 +41,34 @@ inputs:
     required: false
     default: ${{ github.repository_owner }}
     description: >
-      Organisation login to sweep — the label search is scoped `org:<org>` and every token is installed
-      here. Used by both modes (per-PR resolves the Epic's siblings org-wide too). Defaults to the
-      workflow's org.
+      Organization login to sweep — the label search is scoped `org:<org>` and every token is
+      installed here. Used by both modes (per-PR resolves the Epic's siblings org-wide too). Defaults
+      to the workflow's org.
   repo:
     required: false
     default: ${{ github.event.repository.name }}
     description: >
-      PER-PR only. Repository (name only; owner is `org`) whose PR / merge-group to evaluate; ignored by
-      the sweep. Defaults to the triggering repo.
+      Per-PR only. Repository (name only; owner is `org`) whose PR / merge-group to evaluate; ignored
+      by the sweep. Defaults to the triggering repo.
   pull_request_number:
     required: false
     default: ${{ github.event.pull_request.number }}
     description: >
-      PER-PR only, and the MODE selector: non-empty (or a `merge_group` event) runs per-PR, otherwise
+      Per-PR only, and the mode selector: non-empty (or a `merge_group` event) runs per-PR, otherwise
       the sweep. Defaults to the triggering PR; empty on a sweep run.
   head_sha:
     required: false
     default: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
     description: >
-      PER-PR only. Head SHA to anchor the epic-freeze check to — the PR head, or the merge-queue group's
-      head on a `merge_group` event.
+      Per-PR only. Head SHA to anchor the epic-freeze check to — the PR head, or the merge-queue
+      group's head on a `merge_group` event.
   grace_minutes:
     required: false
     default: "45"
     description: >
-      Grace window (minutes) from the FIRST sibling's merge. Within it a stray open sibling is rolled
-      forward by the sweep, not frozen; only a stray still out past the window trips the freeze. A member
-      closed WITHOUT merging trips immediately regardless of grace. Must be an integer.
+      Grace window (minutes) from the first sibling's merge. Within it a stray open sibling is rolled
+      forward by the sweep, not frozen; only a stray still out past the window trips the freeze. A
+      member closed without merging trips immediately regardless of grace. Must be an integer.
   dry_run:
     required: false
     default: "true"
@@ -78,8 +79,9 @@ inputs:
 runs:
   using: composite
   steps:
-    # MODE, computed once before the tokens: per-PR iff a pull_request_number was supplied OR the event
-    # is a merge_group; else the sweep. Gating the write-token mint on this keeps per-PR to checks+reads.
+    # Mode, computed once before the tokens: per-PR if a pull_request_number was supplied or the event
+    # is a merge_group; else the sweep. Gating the write-token mint on this keeps per-PR to checks +
+    # reads.
     - name: Select mode (per-PR vs sweep)
       id: mode
       shell: bash
@@ -118,7 +120,7 @@ runs:
         owner: ${{ inputs.org }}
         permission-checks: write
 
-    # SWEEP ONLY — gating the mint (not just the call site) means a per-PR run never even acquires write.
+    # Sweep only — gating the mint (not just the call site) means a per-PR run never even acquires write.
     - name: Mint enqueue token
       id: write
       if: ${{ steps.mode.outputs.mode == 'sweep' }}
@@ -134,9 +136,9 @@ runs:
     - name: Detect + reconcile partial landings
       shell: bash
       env:
-        # Default GH_TOKEN = READ token (bare `gh` for every read helper); the checks / write tokens are
-        # applied INLINE at the two mutating call sites, so read helpers can't hold a write scope.
-        # WRITE_TOKEN is empty in per-PR mode (its mint step was skipped).
+        # Default GH_TOKEN is the read token (bare `gh` for every read helper); the checks and write
+        # tokens are applied inline at the two mutating call sites, so read helpers can't hold a write
+        # scope. WRITE_TOKEN is empty in per-PR mode (its mint step was skipped).
         GH_TOKEN: ${{ steps.read.outputs.token }}
         CHECKS_TOKEN: ${{ steps.checks.outputs.token }}
         WRITE_TOKEN: ${{ steps.write.outputs.token }}
@@ -144,7 +146,7 @@ runs:
         ORG: ${{ inputs.org }}
         GRACE_MINUTES: ${{ inputs.grace_minutes }}
         DRY_RUN: ${{ inputs.dry_run }}
-        # PER-PR inputs + event payload (used only when MODE=per-pr). OWNER/REPO_FULL derive from `org`
+        # Per-PR inputs + event payload (used only when MODE=per-pr). OWNER/REPO_FULL derive from `org`
         # (the single source of truth matching the minted tokens), not github.repository_owner.
         OWNER: ${{ inputs.org }}
         REPO: ${{ inputs.repo }}
@@ -154,7 +156,7 @@ runs:
         IN_QUEUE: ${{ github.event.merge_group.head_sha }}
         MG_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         # The triggering PR's own number + labels from the event payload (present on pull_request, empty
-        # on merge_group / sweep). Lets the standalone fast-path classify with NO API call.
+        # on merge_group / sweep). Lets the standalone fast-path classify with no API call.
         EVENT_PR: ${{ github.event.pull_request.number }}
         EVENT_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
       run: |
@@ -172,9 +174,9 @@ runs:
           echo "::error::grace_minutes must be an integer, got \"${GRACE_MINUTES:-}\""
           exit 1
         fi
-        # PER-PR inputs become GraphQL args + API path components. per-PR fails OPEN on data
-        # UNCERTAINTY by design, but a misconfigured input (a slash/space in `repo`, a bad SHA) must
-        # fail LOUD, not silently post success — so validate them here. The sweep ignores these.
+        # Per-PR inputs become GraphQL args + API path components. Per-PR fails open on data
+        # uncertainty by design, but a misconfigured input (a slash/space in `repo`, a bad SHA) must
+        # fail loud, not silently post success — so validate them here. The sweep ignores these.
         if [ "${MODE:-}" = "per-pr" ]; then
           if ! [[ "${REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "::error::repo must be a bare repository name (no owner/slash), got \"${REPO:-}\""
@@ -191,7 +193,7 @@ runs:
         fi
 
         # dry_run defaults on; only the literal "false" (any case) mutates. Lowercase via tr (portable),
-        # not ${VAR,,} (bash-4 only) — matches enable-auto-merge.
+        # not ${VAR,,} (bash-4 only).
         dry=$(printf '%s' "${DRY_RUN:-true}" | tr '[:upper:]' '[:lower:]')
 
         now_epoch=$(date -u +%s)
@@ -216,7 +218,7 @@ runs:
             mergeQueue(branch:$base){
               entries(first:100){ nodes{ pullRequest{ number } state headCommit{ oid } } } } } }'
 
-        # Direct PR labels read (PER-PR mode, merge_group / repost path — no event payload there).
+        # Direct PR labels read (per-PR mode, merge_group / repost path — no event payload there).
         PR_LABELS_Q='query($owner:String!,$repo:String!,$num:Int!){
           repository(owner:$owner,name:$repo){
             pullRequest(number:$num){ labels(first:100){ nodes{ name } } } } }'
@@ -287,8 +289,8 @@ runs:
           return 1
         }
 
-        # PER-PR: read one PR's labels by number (merge_group / repost path). Prints the label-name JSON
-        # array; returns 1 after retries (caller fails OPEN). A null pullRequest is treated as a failure.
+        # Per-PR: read one PR's labels by number (merge_group / repost path). Prints the label-name JSON
+        # array; returns 1 after retries (caller fails open). A null pullRequest is treated as a failure.
         fetch_pr_labels() { # $1 = pr number
           local data
           for attempt in 1 2 3; do
@@ -302,12 +304,12 @@ runs:
           return 1
         }
 
-        # ---- Post helpers (dry-run aware; the CHECKS token posts) -------------------------
+        # ---- Post helpers (dry-run aware; the checks token posts) -------------------------
 
         # Post an epic-freeze check-run (jq builds the payload so quotes / newlines can't break the JSON).
-        # Guard the POST explicitly — `set -e` is disabled inside a function called under `||`: in SWEEP a
-        # failed POST is a per-target `::warning::` and we continue; in PER-PR (single head) we surface it
-        # as a failed run (better red-and-retryable than a silent abort).
+        # Guard the post explicitly — `set -e` is disabled inside a function called under `||`: in the
+        # sweep a failed post is a per-target `::warning::` and we continue; in per-PR (single head) we
+        # surface it as a failed run (better red-and-retryable than a silent abort).
         post_check() { # $1=owner/repo $2=sha $3=conclusion $4=summary
           local payload
           payload=$(jq -n --arg sha "$2" --arg concl "$3" --arg summary "$4" \
@@ -336,7 +338,7 @@ runs:
         }
 
         # Re-enqueue a stray by enabling native auto-merge, idempotently (query first, enable only if
-        # off). Uses the WRITE token (sweep only); a failure is a warning and the next sweep retries.
+        # off). Uses the write token (sweep only); a failure is a warning and the next sweep retries.
         # `--squash` matches the org-wide squash-only merge method; a repo on merge/rebase would need it
         # to follow that method.
         reenqueue() { # $1=owner/repo $2=number
@@ -358,7 +360,7 @@ runs:
           fi
         }
 
-        # ---- evaluate_epic — the PURE, shared decision (no posting, no mutation) ----------
+        # ---- evaluate_epic — the pure, shared decision (no posting, no mutation) ----------
         # Sets EV_DECISION ∈ {clear, frozen, error} (+ EV_REASON when frozen) and the EV_* data both
         # wrappers post from. Never returns non-zero — any resolve/queue/REST error leaves
         # EV_DECISION=error (robust whether or not `set -e` is active). Shared by both writers, so the
@@ -370,7 +372,7 @@ runs:
           local EPIC="$1"
           local base_q="label:\"epic:${EPIC}\" org:${ORG}"
 
-          # WIDENED resolve, three passes: is:closed is:unmerged catches the closed-without-merge blind
+          # Widened resolve, three passes: is:closed is:unmerged catches the closed-without-merge blind
           # spot; is:merged and is:open complete the picture. Any failure → EV_DECISION stays error.
           local merged closed_unmerged open
           if ! merged=$(search_prs "is:pr is:merged $base_q"); then return 0; fi
@@ -382,7 +384,7 @@ runs:
           EV_CLOSED_COUNT=$(printf '%s' "$closed_unmerged" | jq 'length')
           EV_OPEN_COUNT=$(printf '%s' "$open" | jq 'length')
 
-          # LIVE queue membership for every distinct (repo, base) among the OPEN siblings. Ref names can't
+          # Live queue membership for every distinct (repo, base) among the open siblings. Ref names can't
           # contain spaces (git forbids them), so a space-joined pair splits safely; fd 4 keeps this
           # loop's input clear of the gh calls inside it.
           local queue='[]' repos_bases rb_repo rb_base owner_only repo_only entries
@@ -396,14 +398,14 @@ runs:
             queue=$(jq -s '.[0] + .[1]' <(printf '%s' "$queue") <(printf '%s' "$entries"))
           done 4< <(printf '%s\n' "$repos_bases")
 
-          # The org queue holds unrelated PRs too — keep only entries that ARE open siblings, so we never
+          # The org queue holds unrelated PRs too — keep only entries that are open siblings, so we never
           # dequeue a non-member.
           queue=$(printf '%s' "$queue" | jq -c --argjson open "$open" '
             [ .[] | . as $e
               | select( ($open | map(select(.repository.nameWithOwner == $e.repo and .number == $e.number)) | length) > 0 ) ]')
           EV_QUEUE="$queue"
 
-          # CANDIDATE strays = open siblings whose (repo, number) is NOT a live queue entry.
+          # Candidate strays = open siblings whose (repo, number) is not a live queue entry.
           local raw_strays
           raw_strays=$(printf '%s' "$open" | jq -c --argjson q "$queue" '
             [ .[] | . as $pr
@@ -430,8 +432,8 @@ runs:
           fi
           EV_STRAY_COUNT=$(printf '%s' "$EV_STRAYS" | jq 'length')
 
-          # GRACE window measured from the FIRST sibling merge (ISO-8601 UTC sorts chronologically, so
-          # `min` is earliest). Unparseable → be conservative: treat grace as NOT elapsed, so a stray
+          # Grace window measured from the first sibling merge (ISO-8601 UTC sorts chronologically, so
+          # `min` is earliest). Unparseable → be conservative: treat grace as not elapsed, so a stray
           # never trips on an unknown age.
           local first_merged_at first_epoch grace_elapsed=false
           first_merged_at=$(printf '%s' "$merged" | jq -r '[.[].mergedAt] | map(select(. != null)) | min // empty')
@@ -445,7 +447,7 @@ runs:
           echo "epic #$EPIC: merged=$EV_MERGED_COUNT closed_unmerged=$EV_CLOSED_COUNT open=$EV_OPEN_COUNT stray=$EV_STRAY_COUNT grace_elapsed=$grace_elapsed" \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
-          # PREDICATE: needs >=1 merged sibling (nothing has landed otherwise); then a closed-unmerged
+          # Predicate: needs >=1 merged sibling (nothing has landed otherwise); then a closed-unmerged
           # member trips immediately, a (REST-confirmed) stray only once grace has elapsed.
           local is_partial=false
           if [ "$EV_MERGED_COUNT" -ge 1 ]; then
@@ -461,7 +463,7 @@ runs:
             return 0
           fi
 
-          # PARTIAL candidate → fail-closed REST confirmation before a merge-blocking freeze.
+          # Partial candidate → fail-closed REST confirmation before a merge-blocking freeze.
           # (a) confirm at least one "merged" member really merged.
           local confirmed_merged=false m_repo m_num
           while read -r m_repo m_num <&4; do
@@ -498,13 +500,13 @@ runs:
           return 0
         }
 
-        # ---- SWEEP wrappers ---------------------------------------------------------------
+        # ---- Sweep wrappers ---------------------------------------------------------------
 
-        # CLEAR: roll landable strays forward while within grace (merged>=1 = a set actively landing; the
-        # clear decision guarantees grace has NOT elapsed for any stray), then post epic-freeze=success on
-        # every open sibling head. That success IS the default state of the required check AND the
-        # UNFREEZE: re-derived each sweep, it re-posts success on the same open-head set a prior freeze
-        # touched, clearing a stale freeze the instant the Epic is whole (latest-check-of-a-name wins).
+        # Clear: roll landable strays forward while within grace (merged>=1 = a set actively landing; the
+        # clear decision guarantees grace has not elapsed for any stray), then post epic-freeze=success on
+        # every open sibling head. That success is both the default state of the required check and the
+        # unfreeze: re-derived each sweep, it re-posts success on the same open-head set a prior freeze
+        # touched, clearing a stale freeze the instant the Epic is whole (latest check of a name wins).
         # Queue heads self-expire, so they need no success.
         sweep_post_clear() { # $1 = epic
           local epic="$1"
@@ -528,8 +530,8 @@ runs:
           done 5< <(printf '%s' "$EV_OPEN" | jq -r '.[] | "\(.repository.nameWithOwner) \(.headRefOid)"')
         }
 
-        # FROZEN: post epic-freeze=failure once per (repo, sha) over the DEDUPLICATED union of every open
-        # sibling's CURRENT head (blocks it entering the queue / merging) and every live queue entry's
+        # Frozen: post epic-freeze=failure once per (repo, sha) over the deduplicated union of every open
+        # sibling's current head (blocks it entering the queue / merging) and every live queue entry's
         # head (fails a required check there → dequeues the in-flight group). Re-derived each sweep, so
         # the freeze follows new commits and clears once whole.
         sweep_post_freeze() { # $1 = epic
@@ -559,8 +561,8 @@ runs:
           esac
         }
 
-        # STANDALONE backstop (universal satisfiability floor): after the epic loop, post
-        # epic-freeze=success on every open PR head that carries NO epic:<N> label — so a standalone PR
+        # Standalone backstop (universal satisfiability floor): after the epic loop, post
+        # epic-freeze=success on every open PR head that carries no epic:<N> label — so a standalone PR
         # whose `opened` webhook never fired is still covered and never strands on "Expected". Idempotent.
         standalone_sweep() {
           local standalone count s_repo s_sha
@@ -594,7 +596,7 @@ runs:
             [ .[] | (.labels.nodes // [])[].name | select(test("^epic:[0-9]+$")) | ltrimstr("epic:") ]
             | unique | .[]')
 
-          # Backstop FIRST: running it BEFORE the epic loop means any epic-pass success/failure posts LAST
+          # Backstop first: running it before the epic loop means any epic-pass success/failure posts last
           # and wins on a head both could touch (a lagging label index) — flipping a contested head to
           # fail-closed. Always runs, even with no active Epics.
           standalone_sweep
@@ -605,7 +607,7 @@ runs:
             local EPIC
             while IFS= read -r EPIC <&3; do
               [ -n "$EPIC" ] || continue
-              # Defence in depth: the number feeds a `label:"epic:<N>"` search qualifier.
+              # Defense in depth: the number feeds a `label:"epic:<N>"` search qualifier.
               if ! [[ "$EPIC" =~ ^[0-9]+$ ]]; then
                 echo "::warning::skipping non-numeric epic token \"$EPIC\""
                 continue
@@ -619,9 +621,9 @@ runs:
           echo "Partial-landing sweep complete." | tee -a "$GITHUB_STEP_SUMMARY"
         }
 
-        # ---- PER-PR wrapper ---------------------------------------------------------------
+        # ---- Per-PR wrapper ---------------------------------------------------------------
         # Classify the triggering PR (mirror of merge-gate's classify step) and post epic-freeze on its
-        # head ONLY. Fails OPEN (success on standalone and ANY uncertainty) — the satisfiability guarantor
+        # head only. Fails open (success on standalone and any uncertainty) — the satisfiability guarantor
         # for a fresh head with no prior check; a wrongly-open PR is double-backstopped by merge-gate
         # (independently required + fail-closed) and the next sweep. Only a REST-confirmed frozen Epic
         # posts failure.
@@ -655,9 +657,9 @@ runs:
           fi
 
           # This PR's labels (the membership authority). On the native pull_request event they are in the
-          # payload → classify with NO API call (the standalone fast-path can't be frozen by a GraphQL
+          # payload → classify with no API call (the standalone fast-path can't be frozen by a GraphQL
           # outage). merge_group / repost paths have no payload, so read via GraphQL; a read failure fails
-          # OPEN (post success) — merge-gate holds independently and the sweep re-derives.
+          # open (post success) — merge-gate holds independently and the sweep re-derives.
           local labels=""
           if [ -n "${EVENT_PR:-}" ] && [ "$classify_pr" = "${EVENT_PR}" ]; then
             labels=$(printf '%s' "${EVENT_LABELS:-[]}")
@@ -674,13 +676,13 @@ runs:
           epic=$(printf '%s' "$labels" | jq -r 'map(select(test("^epic:[0-9]+$")))[0] // empty' | grep -oE '[0-9]+' || true)
 
           if [ -z "$epic" ]; then
-            # STANDALONE fast-path → success.
+            # Standalone fast-path → success.
             freeze_post "$REPO_FULL" "$HEAD_SHA" "success" \
               "PR #${classify_pr} has no epic:<N> label — standalone, no partial-landing coordination. epic-freeze clear."
             return 0
           fi
 
-          # Epic member → evaluate the Epic and post on head_sha ONLY.
+          # Epic member → evaluate the Epic and post on head_sha only.
           echo "PR #${classify_pr} carries epic:${epic} — evaluating the Epic for a partial landing." | tee -a "$GITHUB_STEP_SUMMARY"
           evaluate_epic "$epic"
           case "$EV_DECISION" in
@@ -691,7 +693,7 @@ runs:
               freeze_post "$REPO_FULL" "$HEAD_SHA" "failure" \
                 "Epic #${epic} PARTIALLY LANDED (merged=${EV_MERGED_COUNT}, closed-unmerged=${EV_CLOSED_COUNT}, stray=${EV_STRAY_COUNT}): ${EV_REASON}. Holding this sibling to prevent further partial landing. Does NOT roll back merged PRs — human rollback is a-novel-kit/workflows#235." ;;
             *)
-              # Uncertainty (resolve/queue/REST) → fail OPEN. Double-backstopped by merge-gate + the next
+              # Uncertainty (resolve/queue/REST) → fail open. Double-backstopped by merge-gate + the next
               # sweep, which re-derives from scratch and freezes the true heads if it is real.
               freeze_post "$REPO_FULL" "$HEAD_SHA" "success" \
                 "Epic #${epic}: couldn't confirm partial-landing state (resolve/queue/REST uncertainty) — failing open (success). merge-gate holds independently and the reconcile sweep re-derives." ;;

--- a/generic-actions/enable-auto-merge/action.yaml
+++ b/generic-actions/enable-auto-merge/action.yaml
@@ -26,7 +26,7 @@ inputs:
     description: Number of the PR to enable auto-merge on.
   client_id:
     required: true
-    description: Client id of the [Agent] App (pull-requests + contents write on the target repo).
+    description: Client ID of the [Agent] App (pull-requests + contents write on the target repo).
   app_private_key:
     required: true
     description: Private key (PEM) of that App.
@@ -52,9 +52,8 @@ runs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ inputs.repo }}
         permission-pull-requests: write
-        # `gh pr merge --auto` needs contents:write too — the only proven `--auto` enqueue
-        # in this repo (governance/auto-approve-dependabot) mints both. A later spike may
-        # confirm pull-requests:write alone suffices and narrow this.
+        # contents:write is granted alongside pull-requests:write because the proven
+        # `gh pr merge --auto` enqueue pattern mints both.
         permission-contents: write
 
     - name: Enable auto-merge

--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -1,25 +1,25 @@
 name: epic-membership
 description: >
-  Resolve an Epic's authorized member set: the OPEN pull requests carrying the
-  `epic:<N>` label across the workflow's org. This is the membership AUTHORITY for the
+  Resolve an Epic's authorized member set: the open pull requests carrying the
+  `epic:<N>` label across the workflow's org. This is the membership authority for the
   cross-repo landing machinery. Authority is the label itself, because GitHub only lets
   a user with >= triage on a repo apply a label — so an `epic:<N>` label is a
   permission-gated assertion that a PR belongs to the Epic. A PR-body `Closes` keyword
-  is author-controlled and NOT gated, so the older `closingIssuesReferences → parent →
-  subIssues` walk is demoted to a discovery hint (a way to SUGGEST the label) and is no
-  longer trusted to define the set here.
+  is author-controlled and not gated, so the `closingIssuesReferences → parent →
+  subIssues` walk serves only as a discovery hint (a way to suggest the label), never as
+  the definition of the set here.
 
   Read-only: it queries the label set and emits it. It mutates nothing — no check post,
   no board write — so it takes no dry_run. The caller decides what to do with the set
   (and, on error, whether to hold or fail-open); this action just reports.
 
-  TODO (follow-up, intentionally NOT built here to keep the MVP small): membership
-  should be the ACTIVATION SNAPSHOT, not the live label set — a timeline-fold where a PR
+  TODO (follow-up, intentionally not built here to keep the MVP small): membership
+  should be the activation snapshot, not the live label set — a timeline-fold where a PR
   is a member iff its last `epic:<N>` label event at time <= the Epic's activation
   timestamp is `labeled` (a pure fold over GET issues/{n}/timeline). That freezes the
-  set so a PR labelled after the Epic starts landing joins the NEXT wave instead of
-  re-freezing an in-flight one, and a reopened/relabelled sibling can't resurrect a
-  finished Epic. The MVP below uses the CURRENT open-PR label set, which is correct for
+  set so a PR labeled after the Epic starts landing joins the next wave instead of
+  re-freezing an in-flight one, and a reopened/relabeled sibling can't resurrect a
+  finished Epic. The MVP below uses the current open-PR label set, which is correct for
   a single steady wave and is the input the snapshot fold will later consume.
 
 inputs:
@@ -40,7 +40,7 @@ outputs:
     description: >
       Compact JSON array of the authorized members, one object per open `epic:<N>` PR:
       {repo (nameWithOwner), number, headRefOid, isDraft, reviewDecision}. `[]` when the
-      Epic has no open labelled PRs.
+      Epic has no open labeled PRs.
     value: ${{ steps.resolve.outputs.members }}
   count:
     description: Integer count of members (length of the array).
@@ -92,8 +92,8 @@ runs:
         # matches the `epic:<N>` convention exactly (the colon needs the quotes);
         # `org:${OWNER}` scopes the walk to the workflow's org (the owner is an
         # Organization — a user account would need the `user:` qualifier instead).
-        # NOTE: GitHub's search index is eventually consistent, so a PR labelled or
-        # opened seconds ago may be missing from an otherwise-successful response (and a
+        # GitHub's search index is eventually consistent, so a PR labeled or opened
+        # seconds ago may be missing from an otherwise-successful response (and a
         # just-closed one briefly present); the caller must tolerate a transiently short
         # set. The timeline-fold follow-up above closes this window by reading the Epic
         # timeline live instead of the lagging index.
@@ -109,8 +109,8 @@ runs:
               repository{ nameWithOwner } } } } }'
 
         # Retry transient GraphQL failures a few times. Unlike merge-gate (which posts a
-        # required check and so must fail-OPEN to avoid deadlocking the queue), this is a
-        # read helper with no side effect: if the set can't be resolved we FAIL with a
+        # required check and so must fail open to avoid deadlocking the queue), this is a
+        # read helper with no side effect: if the set can't be resolved we fail with a
         # clear message and let the caller choose hold-vs-fail-open with full context.
         fetch() { # $1=cursor  → prints the response JSON on success, nothing on failure
           # -f (raw string) for every variable: all three are GraphQL String, and -f

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -2,17 +2,17 @@ name: merge-gate
 description: >
   Posts the `merge-gate` check-run — the single "may this PR merge?" status — on the
   triggering pull request, or on the merge-queue group. It runs as the [Agent] App (not
-  the workflow's own identity) so the check's integration id is fixed regardless of what
+  the workflow's own identity) so the check's integration ID is fixed regardless of what
   decides the outcome, letting a ruleset require it by that id.
 
   Membership is the `epic:<N>` LABEL, not the PR's `Closes` keyword. A PR belongs to Epic
   N iff it carries the `epic:<N>` label — a label needs >= triage to apply, so it is a
   permission-gated assertion of membership, whereas a `Closes` keyword is author-controlled
-  and cannot be trusted to define the set. For a labelled PR this action resolves the
+  and cannot be trusted to define the set. For a labeled PR this action resolves the
   Epic's authorized open sibling PRs (via the epic-membership action) and passes only when
   EVERY member is merge-ready (non-draft + approved), so a set of concurrent cross-repo PRs
   lands together instead of partially. The `Closes` walk survives only as a discovery HINT:
-  for an unlabelled PR whose closing issue has a parent Epic, the action suggests adding the
+  for an unlabeled PR whose closing issue has a parent Epic, the action suggests adding the
   `epic:<N>` label but still treats the PR as standalone. A PR with no `epic:<N>` label is
   standalone and always passes (the fast path — classified from the event payload alone, so
   the flood of ordinary PRs never depends on an API call and can't be frozen by a blip).
@@ -35,9 +35,9 @@ inputs:
   client_id:
     required: true
     description: >
-      Client id of the [Agent] App. Needs checks:write (post the status), plus issues +
+      Client ID of the [Agent] App. Needs checks:write (post the status), plus issues +
       pull-requests read (read a PR's labels and its `Closes` hint, and to mint the nested
-      epic-membership token). The App identity is what fixes the check's integration id.
+      epic-membership token). The App identity is what fixes the check's integration ID.
   app_private_key:
     required: true
     description: Private key (PEM) of that App.
@@ -159,8 +159,8 @@ runs:
 
         # Which PR are we classifying? On a merge_group event the queued PR number is
         # encoded in the group ref (refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>); a
-        # batch names one PR and we evaluate that PR's Epic (full-batch attribution is a
-        # later spike). Off the queue it is the input PR number.
+        # batch names one PR and the gate evaluates only that PR's Epic. Off the queue it
+        # is the input PR number.
         if [ -n "${IN_QUEUE:-}" ]; then
           classify_pr=$(printf '%s' "${MG_HEAD_REF:-}" | grep -oE 'pr-[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
           if [ -z "$classify_pr" ]; then
@@ -212,7 +212,7 @@ runs:
         fi
 
         if [ -n "$epic" ]; then
-          # Labelled Epic member — hand off to epic-membership (the authority) + evaluate.
+          # Labeled Epic member — hand off to epic-membership (the authority) + evaluate.
           echo "PR #${classify_pr} carries \`epic:${epic}\` — resolving the authorized member set." | tee -a "$GITHUB_STEP_SUMMARY"
           emit "$epic"
           exit 0
@@ -251,7 +251,7 @@ runs:
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
 
-    # Recompute readiness over the member set and post the gate. Runs for the labelled-Epic
+    # Recompute readiness over the member set and post the gate. Runs for the labeled-Epic
     # path only; standalone / misconfig / hold cases were already posted by the classify step.
     - name: Evaluate readiness + post merge-gate
       if: ${{ steps.discover.outputs.epic_number != '' }}
@@ -279,7 +279,7 @@ runs:
 
         # epic-membership ran with continue-on-error: an EMPTY output means it FAILED to
         # resolve (transport / rate-limit after its own retries); a resolved-but-empty set
-        # is "[]". Either way we can't confirm readiness for a PR we KNOW is labelled
+        # is "[]". Either way we can't confirm readiness for a PR we KNOW is labeled
         # `epic:<N>` — it should appear in its own set, so "[]" means the label search index
         # is still lagging. HOLD (failure), never pass: an uncertain set that turns out
         # unready must not merge. The reconcile sweep re-runs and lands the set once ready.

--- a/generic-actions/pull-bot/action.yaml
+++ b/generic-actions/pull-bot/action.yaml
@@ -7,7 +7,7 @@ inputs:
     description: The GitHub App private key.
   client_id:
     required: false
-    description: GitHub App client id (recommended).
+    description: GitHub App client ID (recommended).
   fetch_depth:
     required: false
     description: Number of commits to fetch. 0 indicates all history for all branches and tags.
@@ -36,7 +36,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    # Mint the bot token from the App client id; passing no app-id avoids the
+    # Mint the bot token from the App client ID; passing no app-id avoids the
     # actions/create-github-app-token app-id deprecation warning.
     - name: get app token
       id: token_client

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -132,6 +132,6 @@ runs:
               "groupName": "javascript dependencies"
             }
           ]
-        # NPM internal registries.
+        # Authenticate npm installs against the private GitHub Packages registry.
         RENOVATE_DETECT_HOST_RULES_FROM_ENV: true
         RENOVATE_NPM_NPM_PKG_GITHUB_COM_TOKEN: ${{ inputs.github_token }}

--- a/github-pages-actions/publish-vuepress/action.yaml
+++ b/github-pages-actions/publish-vuepress/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
     - uses: actions/checkout@v7
       with:
-        # fetch all commits to get last updated time or other git log info
+        # Full history so VuePress can read each page's last-updated time from the git log.
         fetch-depth: 0
     - uses: pnpm/action-setup@v6
       with:
@@ -40,7 +40,6 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working_directory }}
       run: pnpm install --frozen-lockfile
-    # run build script
     - name: build VuePress site
       working-directory: ${{ inputs.working_directory }}
       shell: bash

--- a/go-actions/lint-go/action.yaml
+++ b/go-actions/lint-go/action.yaml
@@ -12,9 +12,9 @@ runs:
     - uses: actions/checkout@v7
     - uses: actions/setup-go@v6
       with:
-        # Resolve go.mod relative to working-directory so the action also works
-        # when the Go module is not at the repo root (e.g. a CLI under cli/).
-        # An empty working-directory keeps the previous behaviour exactly.
+        # Resolve go.mod relative to working-directory so the action works when the
+        # Go module is not at the repo root. An empty working-directory falls back
+        # to the repo-root go.mod.
         go-version-file: ${{ inputs.working-directory && format('{0}/go.mod', inputs.working-directory) || 'go.mod' }}
     - uses: golangci/golangci-lint-action@v9
       with:

--- a/go-actions/test-go/action.yaml
+++ b/go-actions/test-go/action.yaml
@@ -56,8 +56,9 @@ runs:
       shell: bash
       id: discover
       run: |
-        # List all modules using `go list -m`, and for each module, list every package.
-        # The extra `go list -m` steps is used to discover multiple modules when working with workspaces.
+        # Enumerate every package across every module. Iterating modules from
+        # `go list -m` (rather than a single `go list ./...`) is what makes this
+        # work in a Go workspace, where packages span more than one module.
         echo "$(for mod in $(go list -m); do go list ${mod//$(go list .)/.}/... ${{ inputs.filter_patterns }} ${{ inputs.filter_extra_patterns }}; done)" > modules.txt
         echo "MODULES=$(cat modules.txt | tr '\n' ' ')" >> $GITHUB_ENV
     - name: run tests

--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: run audit
       shell: bash
       # --fix requires a mode since pnpm 11; "override" pins vulnerable
-      # transitive deps via package.json overrides without moving direct deps.
+      # transitive dependencies via package.json overrides without moving direct ones.
       env:
         # `pnpm audit --fix` writes new overrides then runs an install to apply
         # them; under CI pnpm defaults that install to --frozen-lockfile, which

--- a/publish-actions/npm/action.yaml
+++ b/publish-actions/npm/action.yaml
@@ -14,7 +14,7 @@ inputs:
     description: The GitHub App private key.
   client_id:
     required: false
-    description: GitHub App client id (recommended).
+    description: GitHub App client ID (recommended).
   ref:
     required: false
     description: >

--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -3,8 +3,7 @@ description: >
   Cut a release in CI: bump the version (workspace-aware, no pnpm), refresh doc
   version refs (prepublish:doc / `a-novel publish stamp`), commit, tag, push,
   and create the GitHub Release — and output the computed version for the
-  downstream build/publish jobs. Replaces the local `a-novel publish version`
-  and the tag-push `auto-release`. The release-type selector and the protected
+  downstream build/publish jobs. The release-type selector and the protected
   `release` environment live in the caller (the per-repo release workflow).
 
 inputs:
@@ -14,7 +13,7 @@ inputs:
   client_id:
     required: true
     description: >
-      [Agent] App client id. Needs contents:write plus a branch/tag-protection bypass,
+      [Agent] App client ID. Needs contents:write plus a branch/tag-protection bypass,
       since the bump commit lands on the protected default branch and the tag is
       protected (v*).
   app_private_key:

--- a/publish-actions/release-core/bump.cjs
+++ b/publish-actions/release-core/bump.cjs
@@ -11,8 +11,7 @@
 // pass. This also sidesteps `pnpm version`'s clean-tree requirement.
 //
 // Reads RELEASE_TYPE (patch|minor|major) from the env; writes the new version
-// to stdout. Bumps the root and every workspace member to one version, matching
-// the old `pnpm version --recursive`.
+// to stdout. Bumps the root and every workspace member to a single version.
 const fs = require("fs");
 const cp = require("child_process");
 


### PR DESCRIPTION
## Summary

Sweeps in-code comments and the project docs (README/CONTRIBUTING) against the sharpened documentation contract: **rationale over restatement**, plain voice, comments paced as navigation. Removes copy-pasted spec text in favor of concise prose plus the authoritative link, adds missing docs on exported symbols, and corrects claims that had drifted from the code.

## Scope

Comments and documentation only — **no code changed** (verified: code tokens are identical after ignoring comments and whitespace across every `.go`/`.ts`/`.proto` file). Excluded: `.github/**` (managed by `a-novel repo update`), `builds/**` (deployment infra), generated/test files, `CODE_OF_CONDUCT`/`LICENSE`.

## Test plan

- [x] Repo formatter is a no-op after the sweep
- [x] Comment-only gate passes
- [ ] CI green