### PR TITLE
feat(halt-guard): org kill-switch + per-Epic pause + blast-cap

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -61,12 +61,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/rollup-board@v1.11.0
+      - uses: a-novel-kit/workflows/generic-actions/rollup-board@v1.12.0
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
           project_id: ${{ inputs.project_id }}
           dry_run: ${{ inputs.rollup_dry_run }}
+          # Org-level HALT: the org variable, read from the reusable workflow's `vars` context
+          # (org variables are available to reusable workflows) and threaded into every action here
+          # (a composite action can't read `vars` itself). FAIL-SAFE semantics live in the actions:
+          # each is RUNNING only for an explicit off-token (empty/unset, 0, off, false, no, disabled)
+          # and ENGAGES for anything else — so an unset variable runs, and a fat-fingered value halts.
+          # Engaged → this writer no-ops.
+          kill_switch: ${{ vars.AGENT_KILL_SWITCH }}
 
   # Enumerate ALL the org's open PRs (paginated) → matrices for the two per-PR passes.
   enumerate:
@@ -143,7 +150,7 @@ jobs:
           permission-contents: read
           permission-issues: read
           permission-pull-requests: read
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.11.0
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.12.0
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -151,6 +158,8 @@ jobs:
           repo: ${{ matrix.pr.repo }}
           pull_request_number: ${{ matrix.pr.number }}
           github_token: ${{ steps.token.outputs.token }}
+          # Org-level HALT: engaged → this writer no-ops (no re-derive, no board write).
+          kill_switch: ${{ vars.AGENT_KILL_SWITCH }}
 
   # Staleness fail-safe: re-post merge-gate on each open epic-member PR — a sibling
   # changing in another repo emits no event to it. merge-gate mints its own org-wide
@@ -165,13 +174,16 @@ jobs:
       matrix:
         pr: ${{ fromJSON(needs.enumerate.outputs.epic_prs) }}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.11.0
+      - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.12.0
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
           repo: ${{ matrix.pr.repo }}
           pull_request_number: ${{ matrix.pr.number }}
           head_sha: ${{ matrix.pr.sha }}
+          # Org-level HALT: engaged → merge-gate HOLDs (posts failure) this idle PR too, so a PR that
+          # emits no event while halted is still stopped. A gate must post failure, never skip.
+          kill_switch: ${{ vars.AGENT_KILL_SWITCH }}
 
   # Partial-landing fail-safe: the SWEEP half of the epic-freeze detector. A single whole-org
   # invocation — it self-enumerates every active Epic and every open head, so it needs no
@@ -182,11 +194,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.11.0
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.12.0
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
           dry_run: ${{ inputs.detect_dry_run }}
+          # Org-level HALT (FAIL-SAFE, see the rollup job): engaged → the sweep skips all work
+          # (merge-gate HOLDs every PR via regate). The BLAST-CAP (max_freeze_repos) keeps its action
+          # default of 5 — an over-wide Epic is frozen ANYWAY (fail-safe) and merely flags the sweep RED.
+          kill_switch: ${{ vars.AGENT_KILL_SWITCH }}
 
   # Display-only read-model: rewrite each active Epic's derived status table into its issue body. A
   # single whole-org invocation — it self-enumerates active Epics and their siblings, so it needs no
@@ -202,3 +218,5 @@ jobs:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
           dry_run: ${{ inputs.render_dry_run }}
+          # Org-level HALT: engaged → this display-only writer no-ops (no Epic-body edits).
+          kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/generic-actions/approve-pr/action.yaml
+++ b/generic-actions/approve-pr/action.yaml
@@ -17,10 +17,40 @@ inputs:
   pull_request:
     required: true
     description: URL (or number) of the pull request to approve.
+  kill_switch:
+    required: false
+    default: ""
+    description: >
+      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      (a composite action cannot read the `vars` context itself). FAIL-SAFE: this action is RUNNING
+      only when the value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset,
+      0, off, false, no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt.
+      When engaged this mutating, human-triggered action aborts LOUD (exit 1) before minting or
+      approving anything — lift the org kill-switch deliberately before recording an approval.
 
 runs:
   using: composite
   steps:
+    # Org-level HALT (read FIRST, before the admin check or any mint): AGENT_KILL_SWITCH engaged →
+    # refuse to record an approval. A human-triggered mutation aborts loud so the operator sees the
+    # halt and lifts it deliberately rather than silently doing nothing.
+    - name: Halt guard (kill-switch)
+      shell: bash
+      env:
+        KILL_SWITCH: ${{ inputs.kill_switch }}
+      run: |
+        set -euo pipefail
+        # FAIL-SAFE: RUNNING only for an explicit off-token (empty/unset, 0, off, false, no,
+        # disabled); ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. A failing step
+        # stops the composite, so the admin check, mint, and approval never run.
+        case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+          "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
+          *)
+            echo "::error::AGENT_KILL_SWITCH engaged — [Agent] automation is halted org-wide; approvals are refused. Lift the org kill-switch (set it to an explicit off-token, e.g. \"off\", or unset it) to proceed."
+            exit 1
+            ;;
+        esac
+
     # Fail closed unless the actor who dispatched this is a repo admin —
     # workflow_dispatch is open to anyone with write access, so this check is what
     # keeps it admin-only. The collaborator-permission endpoint needs only
@@ -63,7 +93,7 @@ runs:
         token: ${{ steps.token.outputs.token }}
         persist-credentials: false
 
-    - uses: a-novel-kit/workflows/generic-actions/approve-bot@v1.11.0
+    - uses: a-novel-kit/workflows/generic-actions/approve-bot@v1.12.0
       with:
         pull_request: ${{ inputs.pull_request }}
         github_token: ${{ steps.token.outputs.token }}

--- a/generic-actions/board-write/action.yaml
+++ b/generic-actions/board-write/action.yaml
@@ -109,6 +109,10 @@ runs:
         # engages. This is the single privileged board mutator, and its guard + the mutation live in
         # THIS one step, so an `exit 0` here genuinely stops the write — every derived board write
         # fails safe (no mutation, changed=false) while the org is halted.
+        # The org-Projects token is minted above, ahead of this guard, on purpose: nothing past the
+        # `exit 0` exercises it, so mint-vs-halt ordering is not blast radius here (token SCOPE, not
+        # mint timing, is the enforced bound) — and every action keeps one "mint per least-privilege,
+        # then halt-first" shape instead of duplicating this fail-safe parse pre-mint.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)

--- a/generic-actions/board-write/action.yaml
+++ b/generic-actions/board-write/action.yaml
@@ -54,6 +54,16 @@ inputs:
     required: false
     default: "false"
     description: When "true", log the change that would be made without writing it.
+  kill_switch:
+    required: false
+    default: ""
+    description: >
+      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
+      value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
+      no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged
+      this single board writer no-ops (no mutation, changed=false) and exits 0 — read FIRST, before
+      any write (the guard and the write share one step, so the exit is sufficient here).
 
 outputs:
   item_id:
@@ -90,8 +100,26 @@ runs:
         ADD_IF_MISSING: ${{ inputs.add_if_missing }}
         ONLY_IF_EMPTY: ${{ inputs.only_if_empty }}
         DRY_RUN: ${{ inputs.dry_run }}
+        KILL_SWITCH: ${{ inputs.kill_switch }}
       run: |
         set -euo pipefail
+
+        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
+        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
+        # engages. This is the single privileged board mutator, and its guard + the mutation live in
+        # THIS one step, so an `exit 0` here genuinely stops the write — every derived board write
+        # fails safe (no mutation, changed=false) while the org is halted.
+        case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+          "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
+          *)
+            echo "AGENT_KILL_SWITCH engaged — skipping board write for \"${FIELD}\" on ${CONTENT_ID} (org-wide halt)." | tee -a "$GITHUB_STEP_SUMMARY"
+            {
+              echo "item_id="
+              echo "changed=false"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+            ;;
+        esac
 
         for v in PROJECT_ID CONTENT_ID FIELD VALUE; do
           if [ -z "${!v:-}" ]; then

--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -39,6 +39,18 @@ inputs:
       Token for reading the PR + its closing issue. Defaults to the job's token (fine for
       a same-repo event); the reconcile sweep passes an org-wide [Agent] token so it can
       read a PR in another repo of the org.
+  kill_switch:
+    required: false
+    default: ""
+    description: >
+      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
+      value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
+      no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged
+      this writer no-ops (no PR read, no board write) and exits 0 — read FIRST. Because a composite
+      action has no early return (an `exit 0` in the guard step does NOT stop the later steps), the
+      guard emits a `halted` output and BOTH board-write steps are `if:`-gated on it. It is also
+      passed through to board-write, so the single board mutator self-guards regardless of caller.
 
 runs:
   using: composite
@@ -55,8 +67,27 @@ runs:
         OWNER: ${{ github.repository_owner }}
         REPO: ${{ inputs.repo }}
         PR: ${{ inputs.pull_request_number }}
+        KILL_SWITCH: ${{ inputs.kill_switch }}
       run: |
         set -euo pipefail
+
+        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
+        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
+        # engages. When engaged, skip the derivation entirely (no PR read, no board write). A
+        # composite action has NO early return — an `exit 0` here does NOT stop the two board-write
+        # steps — so emit an explicit `halted` output and `if:`-gate EVERY subsequent mutating step on
+        # it. has_issue=false also skips them, but `halted` is the explicit, load-bearing gate.
+        case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+          "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
+          *)
+            echo "AGENT_KILL_SWITCH engaged — skipping board-status derivation (org-wide halt)." | tee -a "$GITHUB_STEP_SUMMARY"
+            {
+              echo "halted=true"
+              echo "has_issue=false"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+            ;;
+        esac
 
         if [ -z "${PR:-}" ]; then
           echo "::error::no PR number — run on a pull_request / pull_request_review event, or pass pull_request_number"
@@ -142,8 +173,10 @@ runs:
     # (adding it if absent), and compares before writing. This pins the external ref
     # because a ./ path would resolve against the consumer repo's workspace, not this repo.
     - name: Write Status
-      if: ${{ steps.derive.outputs.has_issue == 'true' }}
-      uses: a-novel-kit/workflows/generic-actions/board-write@v1.11.0
+      # Gated on `halted` too: a composite action has no early return, so the guard step's exit 0
+      # does not stop this mutating step — it must be skipped explicitly when the org is halted.
+      if: ${{ steps.derive.outputs.has_issue == 'true' && steps.derive.outputs.halted != 'true' }}
+      uses: a-novel-kit/workflows/generic-actions/board-write@v1.12.0
       with:
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
@@ -151,12 +184,14 @@ runs:
         content_id: ${{ steps.derive.outputs.issue_id }}
         field: Status
         value: ${{ steps.derive.outputs.status }}
+        kill_switch: ${{ inputs.kill_switch }}
 
     # Stamp Start date once, on first activity. only_if_empty keeps a re-run or the
     # sweep from moving an already-set start date.
     - name: Stamp Start date (once)
-      if: ${{ steps.derive.outputs.has_issue == 'true' && steps.derive.outputs.activated == 'true' }}
-      uses: a-novel-kit/workflows/generic-actions/board-write@v1.11.0
+      # Gated on `halted` too (see Write Status) — the guard's exit 0 cannot stop this later step.
+      if: ${{ steps.derive.outputs.has_issue == 'true' && steps.derive.outputs.activated == 'true' && steps.derive.outputs.halted != 'true' }}
+      uses: a-novel-kit/workflows/generic-actions/board-write@v1.12.0
       with:
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
@@ -165,3 +200,4 @@ runs:
         field: Start date
         value: ${{ steps.derive.outputs.today }}
         only_if_empty: "true"
+        kill_switch: ${{ inputs.kill_switch }}

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -134,6 +134,10 @@ runs:
     # Least-privilege org-wide tokens: the sweep spans the whole org, so the single-repo GITHUB_TOKEN
     # can't see sibling PRs; separate tokens keep each capability scoped. Org-wide (not per-repo) because
     # a composite action can't loop `create-github-app-token` over repos discovered at runtime.
+    # These mints are deliberately NOT additionally gated on the kill-switch: a halted sweep no-ops
+    # without exercising them (token SCOPE, not mint timing, is the enforced bound), a mint-free halt
+    # is unachievable anyway (the per-PR HOLD below must mint checks:write to post `failure`), and
+    # gating each mint would duplicate the fail-safe off-token parse into a separate pre-mint step.
     - name: Mint read token
       id: read
       uses: actions/create-github-app-token@v3

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -75,6 +75,39 @@ inputs:
     description: >
       When "true" (default), log every intended freeze / unfreeze / re-enqueue without calling GitHub.
       Set "false" to actually post check-runs and re-enqueue.
+  planning_repo:
+    required: false
+    default: .github
+    description: >
+      Repository (name only; owner is `org`) where Epic issues live — read to check an Epic's
+      `automation:paused` marker. Defaults to the org `.github` repo, where the planning Epics are
+      tracked.
+  max_freeze_repos:
+    required: false
+    default: "5"
+    description: >
+      BLAST-CAP (sweep only): the distinct-repo width at which a SINGLE Epic's freeze is flagged as
+      suspiciously wide. If an Epic's freeze target set (open sibling heads + live queue heads) spans
+      MORE than this many DISTINCT repos the sweep STILL posts that Epic's freeze on every target —
+      skipping it would leave a REST-confirmed partial landing un-frozen, which is fail-UNSAFE — but
+      it ALSO raises a LOUD alert (::error + a red sweep run) so a runaway / mis-scoped freeze is
+      investigated. Other Epics in the same sweep are unaffected. Per-PR mode freezes one repo, so the
+      cap never applies there. Empty/unset falls back to a hard internal default of 5. Must be a
+      positive integer.
+  kill_switch:
+    required: false
+    default: ""
+    description: >
+      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
+      value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
+      no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) ENGAGES the halt (a kill-switch
+      must fail toward halting). Read FIRST — the kill-switch is the hard, read-free halt (no token,
+      no API), unlike the per-Epic `automation:paused` pause, which is BEST-EFFORT (fail-open on a
+      label-read blip). When engaged: per-PR mode posts a `failure` HOLD on the head (a required-check
+      poster must never skip — a skipped/neutral required check passes OPEN); sweep mode skips all
+      work (no freeze posts, no roll-forward), since merge-gate independently HOLDs every PR org-wide
+      while halted.
 
 runs:
   using: composite
@@ -144,8 +177,11 @@ runs:
         WRITE_TOKEN: ${{ steps.write.outputs.token }}
         MODE: ${{ steps.mode.outputs.mode }}
         ORG: ${{ inputs.org }}
+        PLANNING_REPO: ${{ inputs.planning_repo }}
         GRACE_MINUTES: ${{ inputs.grace_minutes }}
+        MAX_FREEZE_REPOS: ${{ inputs.max_freeze_repos }}
         DRY_RUN: ${{ inputs.dry_run }}
+        KILL_SWITCH: ${{ inputs.kill_switch }}
         # Per-PR inputs + event payload (used only when MODE=per-pr). OWNER/REPO_FULL derive from `org`
         # (the single source of truth matching the minted tokens), not github.repository_owner.
         OWNER: ${{ inputs.org }}
@@ -174,6 +210,28 @@ runs:
           echo "::error::grace_minutes must be an integer, got \"${GRACE_MINUTES:-}\""
           exit 1
         fi
+        # planning_repo becomes an API path component (the Epic-pause read); require a bare repo name.
+        if ! [[ "${PLANNING_REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+          echo "::error::planning_repo must be a bare repository name (no owner/slash), got \"${PLANNING_REPO:-}\""
+          exit 1
+        fi
+        # max_freeze_repos (BLAST-CAP) feeds shell arithmetic + a `-gt` compare; require a positive int.
+        # Hard internal default 5 so an empty/unset value is safe rather than an error (mirrors the
+        # input default; the fallback covers a caller that threads an empty string through).
+        MAX_FREEZE_REPOS="${MAX_FREEZE_REPOS:-5}"
+        if ! [[ "${MAX_FREEZE_REPOS}" =~ ^[0-9]+$ ]] || [ "${MAX_FREEZE_REPOS}" -lt 1 ]; then
+          echo "::error::max_freeze_repos must be a positive integer, got \"${MAX_FREEZE_REPOS:-}\""
+          exit 1
+        fi
+
+        # Org-level HALT flag (read FIRST — resolved from an input, no token/API). FAIL-SAFE: RUNNING
+        # only for an explicit off-token (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE
+        # (a fat-fingered value or garbage) ENGAGES. Acted on at Dispatch below, after the helpers are
+        # defined so per-PR can reuse freeze_post (dry-run aware).
+        kill_engaged=true
+        case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+          "" | 0 | off | false | no | disabled) kill_engaged=false ;;
+        esac
         # Per-PR inputs become GraphQL args + API path components. Per-PR fails open on data
         # uncertainty by design, but a misconfigured input (a slash/space in `repo`, a bad SHA) must
         # fail loud, not silently post success — so validate them here. The sweep ignores these.
@@ -302,6 +360,16 @@ runs:
             [ "$attempt" -lt 3 ] && sleep 2
           done
           return 1
+        }
+
+        # Is Epic N paused? Reads the `automation:paused` marker on the Epic issue in the planning
+        # repo — a >= triage label, so a permission-gated per-Epic hold. Returns 0 = paused,
+        # 1 = not paused, 2 = read error (the caller then proceeds with normal detection — fail-open
+        # on pause; a real partial landing still gets caught).
+        epic_paused() { # $1 = epic number
+          local out
+          out=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" --jq '.labels[].name' 2>/dev/null) || return 2
+          printf '%s\n' "$out" | grep -qx 'automation:paused'
         }
 
         # ---- Post helpers (dry-run aware; the checks token posts) -------------------------
@@ -545,6 +613,20 @@ runs:
             + [ $queue[] | select(.headOid != null) | {repo: .repo, sha: .headOid} ] )
             | map(select(.sha != null))
             | unique_by(.repo + " " + .sha)')
+
+          # BLAST-CAP: a freeze spanning more than max_freeze_repos DISTINCT repos is almost certainly
+          # a runaway / mis-scoped Epic — but SKIPPING the post would leave a REST-confirmed partial
+          # landing un-frozen (fail-UNSAFE). So STILL post the freeze on every target (fail toward
+          # freezing), and only set the tripwire flag + raise a LOUD ::error so the sweep ends RED and
+          # a human investigates. This is a flag-and-continue tripwire: sweep_main exits non-zero AFTER
+          # the whole loop; it never aborts the sweep mid-epic, and other Epics are unaffected.
+          local distinct_repos
+          distinct_repos=$(printf '%s' "$targets" | jq -r '[.[].repo] | unique | length')
+          if [ "$distinct_repos" -gt "$MAX_FREEZE_REPOS" ]; then
+            blast_cap_tripped=true
+            echo "::error::BLAST-CAP: epic #$epic freeze spans ${distinct_repos} distinct repos (> max_freeze_repos=${MAX_FREEZE_REPOS}) — posting the freeze anyway (skipping it would leave a partial landing un-frozen), but flagging this sweep RED. Investigate a runaway / mis-scoped Epic; raise max_freeze_repos deliberately if the width is genuine." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
           local t_repo t_sha
           while read -r t_repo t_sha <&5; do
             [ -n "$t_repo" ] || continue
@@ -553,6 +635,13 @@ runs:
         }
 
         sweep_epic() { # $1 = epic
+          # Per-Epic pause: `automation:paused` on the Epic issue → leave this Epic entirely alone (no
+          # freeze, no roll-forward), so its landing is under manual control while OTHER Epics move. A
+          # read error (2) falls through to normal detection so a real partial landing is still caught.
+          if epic_paused "$1"; then
+            echo "epic #$1: automation:paused — skipping (no freeze / roll-forward this sweep)." | tee -a "$GITHUB_STEP_SUMMARY"
+            return 0
+          fi
           evaluate_epic "$1"
           case "$EV_DECISION" in
             clear)  sweep_post_clear "$1" ;;
@@ -583,6 +672,9 @@ runs:
         }
 
         sweep_main() {
+          # BLAST-CAP tripwire: set true by sweep_post_freeze when an Epic's freeze exceeds
+          # max_freeze_repos. Checked at the end so the whole sweep run ends RED — a loud alert.
+          blast_cap_tripped=false
           echo "Enumerating active Epics (distinct epic:<N> labels on open PRs, org=${ORG})…" | tee -a "$GITHUB_STEP_SUMMARY"
           if ! all_open=$(search_prs "org:${ORG} is:pr is:open"); then
             echo "::error::could not enumerate open PRs (GraphQL search failed after retries) — nothing done this sweep"
@@ -619,6 +711,14 @@ runs:
           fi
 
           echo "Partial-landing sweep complete." | tee -a "$GITHUB_STEP_SUMMARY"
+
+          # A tripped BLAST-CAP fails the sweep run RED — the loud alert — but only AFTER the whole
+          # loop, never mid-epic. The over-wide Epic WAS still frozen (fail-safe — a partial landing is
+          # never left open); its width is merely flagged for a human to investigate.
+          if [ "$blast_cap_tripped" = true ]; then
+            echo "::error::BLAST-CAP tripped this sweep — one or more Epics exceeded max_freeze_repos=${MAX_FREEZE_REPOS} (details above). They were frozen anyway (fail-safe); investigate a runaway / mis-scoped Epic."
+            exit 1
+          fi
         }
 
         # ---- Per-PR wrapper ---------------------------------------------------------------
@@ -682,6 +782,15 @@ runs:
             return 0
           fi
 
+          # Per-Epic pause: `automation:paused` on the Epic issue → don't evaluate partial-landing for
+          # it. merge-gate HOLDs a paused Epic's members independently, so fail open here (post success)
+          # to avoid stranding this head on "Expected". A read error (2) proceeds with normal detection.
+          if epic_paused "$epic"; then
+            freeze_post "$REPO_FULL" "$HEAD_SHA" "success" \
+              "Epic #${epic} is automation:paused — merge-gate holds it; epic-freeze not evaluating partial-landing while paused. epic-freeze clear."
+            return 0
+          fi
+
           # Epic member → evaluate the Epic and post on head_sha only.
           echo "PR #${classify_pr} carries epic:${epic} — evaluating the Epic for a partial landing." | tee -a "$GITHUB_STEP_SUMMARY"
           evaluate_epic "$epic"
@@ -699,6 +808,22 @@ runs:
                 "Epic #${epic}: couldn't confirm partial-landing state (resolve/queue/REST uncertainty) — failing open (success). merge-gate holds independently and the reconcile sweep re-derives." ;;
           esac
         }
+
+        # ---- Org-level HALT (AGENT_KILL_SWITCH) — acted on FIRST at dispatch ---------------
+        # Per-PR is a required-check poster → HOLD (post failure), never skip (a skipped/neutral
+        # required check passes OPEN). Sweep is a recovery writer → skip all work: no freeze posts, no
+        # roll-forward. The halt is still complete because merge-gate independently HOLDs every PR
+        # org-wide (the regate sweep pass re-posts it on idle PRs). freeze_post is dry-run aware, so a
+        # halted per-PR run under dry_run only logs the intended HOLD.
+        if [ "$kill_engaged" = true ]; then
+          if [ "${MODE:-sweep}" = "per-pr" ]; then
+            freeze_post "$REPO_FULL" "$HEAD_SHA" "failure" \
+              "Automation halted org-wide by AGENT_KILL_SWITCH — holding this PR. Lift the org kill-switch to resume; the next event or reconcile sweep re-evaluates."
+          else
+            echo "AGENT_KILL_SWITCH engaged — skipping the partial-landing sweep (no freeze posts, no roll-forward). merge-gate HOLDs every PR org-wide meanwhile." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+          exit 0
+        fi
 
         # ---- Dispatch --------------------------------------------------------------------
         if [ "${MODE:-sweep}" = "per-pr" ]; then

--- a/generic-actions/enable-auto-merge/action.yaml
+++ b/generic-actions/enable-auto-merge/action.yaml
@@ -93,6 +93,10 @@ runs:
         # NOTE: this does NOT disarm auto-merge ALREADY armed on an idle ready PR before the halt —
         # merge-gate's red check still blocks it, but there is a brief latency window until the next
         # event / reconcile sweep re-posts that hold.
+        # The repo-scoped pr+contents:write token is minted above, ahead of this guard, on purpose:
+        # nothing past the `exit 0` exercises it, so mint-vs-halt ordering is not blast radius here
+        # (token SCOPE, not mint timing, is the enforced bound) — and every action keeps one "mint per
+        # least-privilege, then halt-first" shape instead of duplicating this fail-safe parse pre-mint.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)

--- a/generic-actions/enable-auto-merge/action.yaml
+++ b/generic-actions/enable-auto-merge/action.yaml
@@ -36,6 +36,18 @@ inputs:
     description: >
       When "true" (the default), log the intended enable without calling GitHub — the
       read-only-first mode. Set "false" to actually enable auto-merge.
+  kill_switch:
+    required: false
+    default: ""
+    description: >
+      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
+      value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
+      no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged
+      this writer no-ops (never arms auto-merge) and exits 0 — read FIRST, before enabling anything.
+      Engaging the switch does NOT retroactively disarm native auto-merge ALREADY armed on an idle
+      ready PR (merge-gate's red HOLD still blocks the merge, but there is a brief latency window
+      before the next event / reconcile sweep re-posts that hold).
 
 runs:
   using: composite
@@ -63,6 +75,7 @@ runs:
         REPO_FULL: ${{ github.repository_owner }}/${{ inputs.repo }}
         PR: ${{ inputs.pull_request_number }}
         DRY_RUN: ${{ inputs.dry_run }}
+        KILL_SWITCH: ${{ inputs.kill_switch }}
       run: |
         set -euo pipefail
 
@@ -71,6 +84,22 @@ runs:
           exit 1
         fi
         target="${REPO_FULL}#${PR}"
+
+        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
+        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
+        # engages. When engaged, do NOT arm auto-merge (no-op + exit 0; guard and the enable share one
+        # step, so the exit is sufficient). merge-gate independently HOLDs while halted, so an armed
+        # request could not merge anyway; not arming keeps the [Agent] from mutating during a halt.
+        # NOTE: this does NOT disarm auto-merge ALREADY armed on an idle ready PR before the halt —
+        # merge-gate's red check still blocks it, but there is a brief latency window until the next
+        # event / reconcile sweep re-posts that hold.
+        case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+          "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
+          *)
+            echo "AGENT_KILL_SWITCH engaged — not enabling auto-merge on ${target} (org-wide halt)." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+            ;;
+        esac
 
         # Idempotency by query, not by parsing an error string: is auto-merge already on?
         already=$(gh pr view "$PR" --repo "$REPO_FULL" --json autoMergeRequest \

--- a/generic-actions/epic-rollback/action.yaml
+++ b/generic-actions/epic-rollback/action.yaml
@@ -89,10 +89,54 @@ inputs:
     description: >
       When "true" (default), print the reconstructed ledger + the planned per-repo reverts + the
       planned board resets and do NO writes. Set "false" to actually open + land the reverts.
+  max_rollback_repos:
+    required: false
+    default: "5"
+    description: >
+      BLAST-CAP: the maximum number of distinct repos a single rollback may touch. If the
+      reconstructed ledger spans MORE than this many repos the action ABORTS LOUD (::error + exit 1)
+      before opening any revert — a rollback that wide is almost certainly a mis-scoped Epic. Aborting
+      is correct HERE (unlike the partial-landing freeze, which posts anyway): a rollback is
+      DESTRUCTIVE and opt-in, so failing toward NOT reverting is the safe direction. Checked in both
+      dry and live runs (the plan is still printed to the summary first). Raise it deliberately for a
+      genuinely large rollback. Empty/unset falls back to a hard internal default of 5. Must be a
+      positive integer.
+  kill_switch:
+    required: false
+    default: ""
+    description: >
+      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      (a composite action cannot read the `vars` context itself). FAIL-SAFE: this action is RUNNING
+      only when the value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset,
+      0, off, false, no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt
+      (a kill-switch must fail toward halting). When engaged this destructive, human-triggered action
+      aborts LOUD (exit 1) as its FIRST step, before the admin check or any mint — a failing step
+      stops the composite, so nothing later runs. Lift the org kill-switch deliberately before rolling
+      back.
 
 runs:
   using: composite
   steps:
+    # Org-level HALT (read FIRST, before the admin check or any token mint): AGENT_KILL_SWITCH
+    # engaged → refuse to run. A destructive rollback must be an explicit, un-halted decision, so
+    # this aborts loud rather than silently no-opping.
+    - name: Halt guard (kill-switch)
+      shell: bash
+      env:
+        KILL_SWITCH: ${{ inputs.kill_switch }}
+      run: |
+        set -euo pipefail
+        # FAIL-SAFE: RUNNING only for an explicit off-token (empty/unset, 0, off, false, no,
+        # disabled); ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. A failing step
+        # stops the composite, so no later step (admin check, mints, revert) runs.
+        case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+          "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
+          *)
+            echo "::error::AGENT_KILL_SWITCH engaged — [Agent] automation is halted org-wide; refusing to run epic-rollback. Lift the org kill-switch (set it to an explicit off-token, e.g. \"off\", or unset it) deliberately before rolling back."
+            exit 1
+            ;;
+        esac
+
     # Defense in depth: re-check the dispatcher is a repo admin HERE, as the action's first step —
     # the gate must not live ONLY in the caller's dispatch shell (a hand-written or drifted copy could
     # drop it). Copied from approve-pr/action.yaml: the collaborator-permission endpoint needs only
@@ -169,6 +213,7 @@ runs:
         PROJECT_ID: ${{ inputs.project_id }}
         PLANNING_REPO: ${{ inputs.planning_repo }}
         DRY_RUN: ${{ inputs.dry_run }}
+        MAX_ROLLBACK_REPOS: ${{ inputs.max_rollback_repos }}
         ACTOR: ${{ github.actor }}
       run: |
         set -euo pipefail
@@ -189,10 +234,28 @@ runs:
           echo "::error::reason is required (it is the audit trail for the rollback)"
           exit 1
         fi
+        # BLAST-CAP bound feeds shell arithmetic + a `-gt` compare; require a positive integer.
+        # Hard internal default 5 so an empty/unset value is safe rather than an error.
+        MAX_ROLLBACK_REPOS="${MAX_ROLLBACK_REPOS:-5}"
+        if ! [[ "${MAX_ROLLBACK_REPOS}" =~ ^[0-9]+$ ]] || [ "${MAX_ROLLBACK_REPOS}" -lt 1 ]; then
+          echo "::error::max_rollback_repos must be a positive integer, got \"${MAX_ROLLBACK_REPOS:-}\""
+          exit 1
+        fi
 
         # dry_run defaults on; only the literal "false" (any case) mutates. Lowercase via tr
         # (portable), not ${VAR,,} (bash-4 only).
         dry=$(printf '%s' "${DRY_RUN:-true}" | tr '[:upper:]' '[:lower:]')
+
+        # ---- Per-Epic pause -------------------------------------------------------------------
+        # `automation:paused` on the Epic issue holds ALL [Agent] automation for that Epic. A
+        # destructive rollback must be an explicit, un-paused decision, so refuse to run while the
+        # Epic is paused. Read the Epic issue's labels (issues:read); a read error does NOT block
+        # (fail-open — the admin + typed-confirmation gate already fenced this dispatch).
+        paused_labels=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.labels[].name' 2>/dev/null || echo "")
+        if printf '%s\n' "$paused_labels" | grep -qx 'automation:paused'; then
+          echo "::error::epic:#${EPIC} is automation:paused — remove the \`automation:paused\` label from the Epic issue before rolling it back."
+          exit 1
+        fi
 
         # Marker file for the conflict-placeholder fallback (a ruleset may reject an empty commit).
         MARKER="ROLLBACK-HELD.md"
@@ -361,6 +424,17 @@ runs:
         task_ids=$(printf '%s' "$ledger" | jq -r '[.[].tasks[]] | unique | .[]')
         task_n=$(printf '%s' "$task_ids" | grep -c . || true)
         echo "### Board reset plan: ${task_n} rolled-back Task(s) → Status \"Ready\"" | tee -a "$GITHUB_STEP_SUMMARY"
+
+        # ---- BLAST-CAP (before ANY mutation, for both dry + real runs) --------------------------
+        # A rollback fans a DESTRUCTIVE revert across every repo in the ledger. Cap the distinct-repo
+        # target set: over the cap → ABORT LOUD rather than proceed, a guard against a runaway or
+        # mis-scoped rollback. The plan above is already in the summary, so the operator sees WHAT it
+        # would have touched; they raise max_rollback_repos deliberately if the width is genuine.
+        repo_n=$(printf '%s' "$repos" | grep -c . || true)
+        if [ "$repo_n" -gt "$MAX_ROLLBACK_REPOS" ]; then
+          echo "::error::BLAST-CAP: rollback of epic:#${EPIC} would touch ${repo_n} repos (> max_rollback_repos=${MAX_ROLLBACK_REPOS}) — aborting before any revert. A rollback this wide is almost certainly a mis-scoped Epic; investigate, or re-dispatch with a higher max_rollback_repos if it is genuinely intended." | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
 
         # ---- Multi-base assert (before ANY mutation, for both dry + real runs) -----------------
         # A repo's siblings must all target ONE base branch. Reverting an older-base sibling onto the

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -57,6 +57,30 @@ inputs:
     description: >
       Head SHA to anchor the check to. Defaults to the PR head (or the merge-queue group's
       head); the sweep passes the sibling PR's current head when re-posting.
+  planning_repo:
+    required: false
+    default: .github
+    description: >
+      Repository (name only; owner is the workflow's org) where Epic issues live — read to
+      check the Epic's `automation:paused` marker. Defaults to the org `.github` repo, where
+      the planning Epics are tracked.
+  kill_switch:
+    required: false
+    default: ""
+    description: >
+      Org-level HALT. The caller threads the org variable through as
+      `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`, because a composite action cannot read the
+      `vars` context itself. FAIL-SAFE semantics: the gate is RUNNING only when the value
+      (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, `0`, `off`, `false`,
+      `no`, or `disabled`; ANYTHING ELSE engages the halt. A fat-fingered `halt` / `engage` / garbage
+      value therefore HALTS (a kill-switch must fail TOWARD halting), and only an explicit off-token
+      or an unset variable runs. When engaged the gate posts a `failure` HOLD on every PR (never a
+      neutral/skip, which passes a required check open), so nothing merges org-wide until the switch
+      is lifted. Read FIRST, before any membership work — the kill-switch is the hard, read-free halt
+      (no token, no API), unlike the per-Epic `automation:paused` pause, which is BEST-EFFORT
+      (fail-open on a label-read blip). Engaging the switch does NOT retroactively disarm native
+      auto-merge already armed on an idle ready PR: merge-gate holds it (the required check goes red),
+      but there is a brief latency window before the next event / reconcile sweep re-posts the hold.
 
 runs:
   using: composite
@@ -89,6 +113,8 @@ runs:
         REPO_FULL: ${{ github.repository_owner }}/${{ inputs.repo }}
         OWNER: ${{ github.repository_owner }}
         REPO: ${{ inputs.repo }}
+        PLANNING_REPO: ${{ inputs.planning_repo }}
+        KILL_SWITCH: ${{ inputs.kill_switch }}
         HEAD_SHA: ${{ inputs.head_sha }}
         PR_NUMBER: ${{ inputs.pull_request_number }}
         IN_QUEUE: ${{ github.event.merge_group.head_sha }}
@@ -121,6 +147,46 @@ runs:
         # empty = terminal (this step already posted the check); non-empty = the Epic
         # number for the resolve + evaluate steps to gate against.
         emit() { echo "epic_number=$1" >> "$GITHUB_OUTPUT"; }
+
+        # ---- Org-level HALT: AGENT_KILL_SWITCH (read FIRST, before any membership work) ----
+        # The [Agent]'s emergency brake — and it must FAIL-SAFE, i.e. fail TOWARD halting. RUNNING
+        # only when the value (lowercased, whitespace-stripped) is an explicit off-token —
+        # empty/unset, 0, off, false, no, disabled; ANYTHING ELSE (a fat-fingered "halt"/"engage", or
+        # garbage) ENGAGES the halt. Threaded in as an input because a composite action cannot read
+        # the `vars` context — the caller passes ${{ vars.AGENT_KILL_SWITCH }}, so the value is
+        # resolved with NO token and NO API call before anything gates. A required-check gate must
+        # HOLD (post `failure`), never skip: a skipped or neutral required check passes OPEN. So when
+        # halted we post `failure` on the head (which also dequeues a live merge_group) and stop. This
+        # HOLD is posted BEFORE every success path (standalone fast-path, misconfig, merge_group
+        # re-affirm) because the whole org-wide halt rests on merge-gate holding EVERY PR — no success
+        # branch may run first.
+        case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+          "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
+          *)
+            post_check failure "Automation halted org-wide by AGENT_KILL_SWITCH — holding this PR. Lift the org kill-switch (set it to an explicit off-token, e.g. \"off\", or unset it) to resume; the next event or reconcile sweep re-evaluates."
+            emit ""
+            exit 0
+            ;;
+        esac
+
+        # planning_repo becomes an API path component (the Epic-pause read below); require a bare
+        # repo name so a stray value (owner/slash, whitespace, an injected path) can't redirect the
+        # request. Mirrors detect-partial-landing. Validated AFTER the read-free kill-switch so the
+        # halt always wins even when planning_repo is malformed.
+        if ! [[ "${PLANNING_REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+          echo "::error::planning_repo must be a bare repository name (no owner/slash), got \"${PLANNING_REPO:-}\""
+          exit 1
+        fi
+
+        # Is Epic N paused? Reads the `automation:paused` marker on the Epic issue in the planning
+        # repo — a >= triage label, so a permission-gated per-Epic hold. Returns 0 = paused,
+        # 1 = not paused, 2 = read error (the caller then falls through to normal readiness — fail-open
+        # on pause, since pause is an operator convenience and the readiness gate still applies).
+        epic_paused() { # $1 = epic number
+          local out
+          out=$(gh api "repos/${OWNER}/${PLANNING_REPO}/issues/$1" --jq '.labels[].name' 2>/dev/null) || return 2
+          printf '%s\n' "$out" | grep -qx 'automation:paused'
+        }
 
         # Read a PR's labels + its `Closes` parent (the discovery hint) in one query,
         # retrying transient GraphQL errors. Prints the response JSON on success;
@@ -212,6 +278,15 @@ runs:
         fi
 
         if [ -n "$epic" ]; then
+          # Per-Epic pause: `automation:paused` on the Epic issue HOLDS its members (post failure),
+          # leaving every OTHER Epic moving. Read FIRST here so a paused Epic never resolves/evaluates.
+          ps=0; epic_paused "$epic" || ps=$?
+          if [ "$ps" -eq 0 ]; then
+            post_check failure "Epic #${epic} is automation:paused — holding its members. Remove the \`automation:paused\` label from Epic #${epic} to resume atomic landing."
+            emit ""
+            exit 0
+          fi
+          [ "$ps" -eq 2 ] && echo "::warning::couldn't read Epic #${epic} pause state (planning-repo read failed) — proceeding with normal readiness evaluation."
           # Labeled Epic member — hand off to epic-membership (the authority) + evaluate.
           echo "PR #${classify_pr} carries \`epic:${epic}\` — resolving the authorized member set." | tee -a "$GITHUB_STEP_SUMMARY"
           emit "$epic"
@@ -245,7 +320,7 @@ runs:
       id: membership
       if: ${{ steps.discover.outputs.epic_number != '' }}
       continue-on-error: true
-      uses: a-novel-kit/workflows/generic-actions/epic-membership@v1.11.0
+      uses: a-novel-kit/workflows/generic-actions/epic-membership@v1.12.0
       with:
         epic_number: ${{ steps.discover.outputs.epic_number }}
         client_id: ${{ inputs.client_id }}

--- a/generic-actions/render-epic-status/action.yaml
+++ b/generic-actions/render-epic-status/action.yaml
@@ -110,6 +110,10 @@ runs:
         # engages. When engaged, render nothing (no Epic-body edits); the guard and the render share
         # THIS one step, so the exit is sufficient. Display-only, so a skipped render is cosmetic and
         # the next sweep re-derives once the switch is lifted.
+        # The issues:write token is minted above, ahead of this guard, on purpose: nothing past the
+        # `exit 0` exercises it, so mint-vs-halt ordering is not blast radius here (token SCOPE, not
+        # mint timing, is the enforced bound) — and every action keeps one "mint per least-privilege,
+        # then halt-first" shape instead of duplicating this fail-safe parse pre-mint.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)

--- a/generic-actions/render-epic-status/action.yaml
+++ b/generic-actions/render-epic-status/action.yaml
@@ -63,6 +63,17 @@ inputs:
     description: >
       When "true" (default), log the table each Epic would get and write nothing. Set "false" to
       splice it into the Epic issue body.
+  kill_switch:
+    required: false
+    default: ""
+    description: >
+      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
+      value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
+      no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged
+      this display-only writer no-ops (no Epic-body edits) and exits 0 — read FIRST. It gates
+      nothing, so the halt is purely to keep the [Agent] from editing issue bodies during an
+      org-wide stop.
 
 runs:
   using: composite
@@ -90,8 +101,22 @@ runs:
         PLANNING_REPO: ${{ inputs.planning_repo }}
         LOOKBACK_DAYS: ${{ inputs.lookback_days }}
         DRY_RUN: ${{ inputs.dry_run }}
+        KILL_SWITCH: ${{ inputs.kill_switch }}
       run: |
         set -euo pipefail
+
+        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
+        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
+        # engages. When engaged, render nothing (no Epic-body edits); the guard and the render share
+        # THIS one step, so the exit is sufficient. Display-only, so a skipped render is cosmetic and
+        # the next sweep re-derives once the switch is lifted.
+        case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+          "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
+          *)
+            echo "AGENT_KILL_SWITCH engaged — skipping Epic read-model render (org-wide halt)." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+            ;;
+        esac
 
         # ---- Validate the untrusted inputs before they reach a search grammar or a date argument.
         # org feeds `org:<ORG>` search qualifiers — require GitHub-login chars so a stray value can't

--- a/generic-actions/rollup-board/action.yaml
+++ b/generic-actions/rollup-board/action.yaml
@@ -29,6 +29,16 @@ inputs:
     description: >
       When "true" (default), log the rollups it would make without writing — the
       read-only first mode. Set "false" once the aggregation is trusted.
+  kill_switch:
+    required: false
+    default: ""
+    description: >
+      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
+      value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
+      no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged
+      this writer no-ops (no rollups) and exits 0 — read FIRST, before any board write (the guard and
+      the rollup share one step, so the exit is sufficient here).
 
 runs:
   using: composite
@@ -48,8 +58,22 @@ runs:
         GH_TOKEN: ${{ steps.token.outputs.token }}
         PROJECT_ID: ${{ inputs.project_id }}
         DRY_RUN: ${{ inputs.dry_run }}
+        KILL_SWITCH: ${{ inputs.kill_switch }}
       run: |
         set -euo pipefail
+
+        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
+        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
+        # engages. The guard and the Python mutation share THIS one step, so an `exit 0` here
+        # genuinely skips the rollup (no board writes) — no later step can run past it.
+        case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+          "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
+          *)
+            echo "AGENT_KILL_SWITCH engaged — skipping epic rollup (org-wide halt)." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+            ;;
+        esac
+
         python3 - <<'PY'
         import json, os, subprocess, sys
 

--- a/generic-actions/rollup-board/action.yaml
+++ b/generic-actions/rollup-board/action.yaml
@@ -66,6 +66,10 @@ runs:
         # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
         # engages. The guard and the Python mutation share THIS one step, so an `exit 0` here
         # genuinely skips the rollup (no board writes) — no later step can run past it.
+        # The org-Projects token is minted above, ahead of this guard, on purpose: nothing past the
+        # `exit 0` exercises it, so mint-vs-halt ordering is not blast radius here (token SCOPE, not
+        # mint timing, is the server-enforced bound) — and every action keeps one "mint per
+        # least-privilege, then halt-first" shape instead of duplicating this fail-safe parse pre-mint.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)


### PR DESCRIPTION
## Summary

#245 hardening — an org-level **kill-switch**, a **per-Epic pause**, and a freeze/rollback **blast-cap**, added to the Stage-4 governance actions.

- **Kill-switch** (`AGENT_KILL_SWITCH` org variable, threaded as a `kill_switch` input): **fail-SAFE** — RUNNING only for an explicit off-token (empty/unset · `0` · `off` · `false` · `no` · `disabled`); *anything else halts*. When engaged, merge-gate posts a `failure` HOLD on **every** PR (before any success path), writers no-op, auto-merge isn't armed.
- **Per-Epic pause** (`automation:paused` label on the Epic): holds that epic's automation, others keep moving. Best-effort (fail-open on a label-read blip; the kill-switch is the hard halt).
- **Blast-cap**: freeze fails **safe** (still freezes + alerts over the cap); rollback aborts over its cap (destructive). Sweep uses a tripwire (never aborts mid-epic).

## Known completeness gaps (documented follow-on)

The kill-switch covers the 9 epic-lifecycle actions. Two other [Agent] flows aren't yet guarded — **auto-approve-dependabot** (records an approval) and **archive-board-items** (board write during a release). Both are *mitigated*: merge-gate's universal HOLD blocks any merge during a halt, and archive only runs during a manually-dispatched release. I'll thread the guard into them as a scoped follow-on.

## Operator prereqs

1. Create the **`AGENT_KILL_SWITCH` org variable** in both orgs (until it exists it reads empty = running — the safe default).
2. Rides **v1.12.0** (with #230). Strict ordering: tag v1.12.0 (carrying these action guards) → `repo update` all repos → only then is the switch authoritative (older tags ignore the `kill_switch` input).

## Test plan
- [x] all actions YAML + `bash -n` clean, prettier-formatted
- [ ] Copilot review
- [ ] v1.12.0 release + repo update

Closes #245