### PR TITLE
fix(halt-guard): drop ${{ vars }} from composite action manifests (v1.12.0 load failure)

### DIFF
--- a/generic-actions/approve-pr/action.yaml
+++ b/generic-actions/approve-pr/action.yaml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ""
     description: >
-      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      Org-level HALT, threaded from the caller as `kill_switch: vars.AGENT_KILL_SWITCH`
       (a composite action cannot read the `vars` context itself). FAIL-SAFE: this action is RUNNING
       only when the value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset,
       0, off, false, no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt.

--- a/generic-actions/board-write/action.yaml
+++ b/generic-actions/board-write/action.yaml
@@ -58,7 +58,7 @@ inputs:
     required: false
     default: ""
     description: >
-      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      Org-level HALT, threaded from the caller as `kill_switch: vars.AGENT_KILL_SWITCH`
       (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
       value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
       no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged

--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -43,7 +43,7 @@ inputs:
     required: false
     default: ""
     description: >
-      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      Org-level HALT, threaded from the caller as `kill_switch: vars.AGENT_KILL_SWITCH`
       (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
       value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
       no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -98,7 +98,7 @@ inputs:
     required: false
     default: ""
     description: >
-      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      Org-level HALT, threaded from the caller as `kill_switch: vars.AGENT_KILL_SWITCH`
       (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
       value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
       no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) ENGAGES the halt (a kill-switch

--- a/generic-actions/enable-auto-merge/action.yaml
+++ b/generic-actions/enable-auto-merge/action.yaml
@@ -40,7 +40,7 @@ inputs:
     required: false
     default: ""
     description: >
-      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      Org-level HALT, threaded from the caller as `kill_switch: vars.AGENT_KILL_SWITCH`
       (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
       value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
       no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged

--- a/generic-actions/epic-rollback/action.yaml
+++ b/generic-actions/epic-rollback/action.yaml
@@ -105,7 +105,7 @@ inputs:
     required: false
     default: ""
     description: >
-      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      Org-level HALT, threaded from the caller as `kill_switch: vars.AGENT_KILL_SWITCH`
       (a composite action cannot read the `vars` context itself). FAIL-SAFE: this action is RUNNING
       only when the value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset,
       0, off, false, no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -69,7 +69,7 @@ inputs:
     default: ""
     description: >
       Org-level HALT. The caller threads the org variable through as
-      `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`, because a composite action cannot read the
+      `kill_switch: vars.AGENT_KILL_SWITCH`, because a composite action cannot read the
       `vars` context itself. FAIL-SAFE semantics: the gate is RUNNING only when the value
       (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, `0`, `off`, `false`,
       `no`, or `disabled`; ANYTHING ELSE engages the halt. A fat-fingered `halt` / `engage` / garbage
@@ -153,7 +153,7 @@ runs:
         # only when the value (lowercased, whitespace-stripped) is an explicit off-token —
         # empty/unset, 0, off, false, no, disabled; ANYTHING ELSE (a fat-fingered "halt"/"engage", or
         # garbage) ENGAGES the halt. Threaded in as an input because a composite action cannot read
-        # the `vars` context — the caller passes ${{ vars.AGENT_KILL_SWITCH }}, so the value is
+        # the `vars` context — the caller passes vars.AGENT_KILL_SWITCH, so the value is
         # resolved with NO token and NO API call before anything gates. A required-check gate must
         # HOLD (post `failure`), never skip: a skipped or neutral required check passes OPEN. So when
         # halted we post `failure` on the head (which also dequeues a live merge_group) and stop. This

--- a/generic-actions/render-epic-status/action.yaml
+++ b/generic-actions/render-epic-status/action.yaml
@@ -67,7 +67,7 @@ inputs:
     required: false
     default: ""
     description: >
-      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      Org-level HALT, threaded from the caller as `kill_switch: vars.AGENT_KILL_SWITCH`
       (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
       value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
       no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged

--- a/generic-actions/rollup-board/action.yaml
+++ b/generic-actions/rollup-board/action.yaml
@@ -33,7 +33,7 @@ inputs:
     required: false
     default: ""
     description: >
-      Org-level HALT, threaded from the caller as `kill_switch: ${{ vars.AGENT_KILL_SWITCH }}`
+      Org-level HALT, threaded from the caller as `kill_switch: vars.AGENT_KILL_SWITCH`
       (a composite action cannot read the `vars` context itself). FAIL-SAFE: RUNNING only when the
       value (lowercased, whitespace-stripped) is an explicit off-token — empty/unset, 0, off, false,
       no, disabled; ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. When engaged


### PR DESCRIPTION
## 🚨 SEV hotfix — v1.12.0 governance actions fail to load

Every governance composite action shipped in **v1.12.0** fails to load once a caller pins `@v1.12.0`:

```
Unrecognized named-value: 'vars'. ... within expression: vars.AGENT_KILL_SWITCH
Failed to load .../merge-gate/action.yaml
```

### Root cause

GitHub templates the **entire** composite-action manifest at load time — input `description` fields *and* `run:` strings (including bash comments) are all expression-evaluated. The `vars` context is **not available to composite actions** (which is the whole reason the kill-switch is threaded as an `inputs.kill_switch`). The `kill_switch` input docs added in #262 embedded a **literal** `${{ vars.AGENT_KILL_SWITCH }}` to illustrate the caller syntax — so the parser tries to evaluate it and rejects `vars`, and the action won't load.

Latent until v1.12.0's pins went live; now `.github/workflows/merge-gate.yaml` pins `@v1.12.0`, so **the merge-gate required check errors on every PR → no PR merges org-wide** (both orgs), and the Renovate `workflows@v1.12.0` bump PRs fail for the same reason.

### Fix

Deliteralize all **10** occurrences across the **9** actions (`${{ vars.AGENT_KILL_SWITCH }}` → plain `vars.AGENT_KILL_SWITCH` text). Caller **workflows** are untouched — a *workflow* can read `${{ vars.* }}`; only *composite actions* cannot.

Audited every remaining `${{ }}` expression in the actions: only composite-legal contexts remain (`inputs`, `github`, `steps`, `toJSON`, `job.container`). No other latent load failure.

### ⚠️ Merge + release

- **Admin-merge required** — this PR can't pass its own `merge-gate` check (the gate is exactly what's broken).
- Then cut **v1.12.1** and `repo update` / let Renovate bump callers to `@v1.12.1`. That unblocks merges and turns the Renovate PRs green.
- Validation: once a caller references `@v1.12.1`, `merge-gate` loads (no `vars` error) — confirm on the first PR's checks.

## Test plan
- [x] all 10 `${{ vars.* }}` occurrences removed; grep confirms zero remaining
- [x] all action manifests parse (YAML); prettier clean
- [x] every remaining `${{ }}` context audited as composite-legal
- [ ] admin-merge → v1.12.1 → caller bump → merge-gate loads clean (operator)
