### PR TITLE
chore(deps): bump managed workflows callers v1.12.0 → v1.12.1

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.12.1
         with:
           pull_request: ${{ inputs.pull_request }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/derive-status.yaml
+++ b/.github/workflows/derive-status.yaml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.12.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-freeze.yaml
+++ b/.github/workflows/epic-freeze.yaml
@@ -31,7 +31,7 @@ jobs:
     # a per-PR run can never re-enqueue.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.12.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -86,7 +86,7 @@ jobs:
           fi
           echo "@${ACTOR} is a repo admin; confirmation matches — proceeding with rollback of epic:#${EPIC} (dry_run=${DRY_RUN:-true})." | tee -a "$GITHUB_STEP_SUMMARY"
 
-      - uses: a-novel-kit/workflows/generic-actions/epic-rollback@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/epic-rollback@v1.12.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -37,7 +37,7 @@ jobs:
     # default token, so it needs no repository permissions of its own.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.12.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
@@ -67,7 +67,7 @@ jobs:
             echo "member=false" >> "$GITHUB_OUTPUT"
           fi
       - if: ${{ steps.member.outputs.member == 'true' }}
-        uses: a-novel-kit/workflows/generic-actions/enable-auto-merge@v1.12.0
+        uses: a-novel-kit/workflows/generic-actions/enable-auto-merge@v1.12.1
         with:
           pull_request_number: ${{ github.event.pull_request.number }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/rollup-board@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/rollup-board@v1.12.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -150,7 +150,7 @@ jobs:
           permission-contents: read
           permission-issues: read
           permission-pull-requests: read
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.12.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -174,7 +174,7 @@ jobs:
       matrix:
         pr: ${{ fromJSON(needs.enumerate.outputs.epic_prs) }}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.12.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.12.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/render-epic-status@v1.12.0
+      - uses: a-novel-kit/workflows/generic-actions/render-epic-status@v1.12.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}


### PR DESCRIPTION
The **caller-pin half** of the v1.12.1 recovery. #265 fixed the action manifests and released v1.12.1, but this repo's own `.github/workflows` callers still pin `generic-actions/*@v1.12.0` — the version that **fails to load** (the `${{ vars }}` bug). So `merge-gate@v1.12.0` errors on every PR in this repo, deadlocking it (including #264 and the Renovate bump PR, which is blocked by the same gate).

Bumps all **11** refs across 6 caller files to `@v1.12.1`. Diff is version-pins only.

## ⚠️ Admin-merge
Like #265, this can't pass its own `merge-gate` check (the gate is exactly what's broken at `@v1.12.0`). **Admin-merge it** to break the deadlock; then every workflows-repo PR (starting with #264, once rebased) goes green.

## Test plan
- [x] all `@v1.12.0` caller refs → `@v1.12.1`; grep confirms none remain
- [x] diff is version-pins only; prettier clean
- [ ] admin-merge → rebase #264 → `merge-gate` loads clean