### PR TITLE
ci: lint composite action manifests for load-breaking ${{ }} contexts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,3 +26,33 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
+
+  # Guard against the v1.12.0 incident: a composite action's WHOLE manifest is
+  # expression-templated at load time — input descriptions and run: strings, bash
+  # comments included. The vars / secrets / needs / matrix / strategy contexts do not
+  # exist for composite actions, so a literal `${{ vars.X }}` anywhere in one — even
+  # as documentation — makes the action fail to LOAD, which took merge-gate offline
+  # org-wide until v1.12.1. Caller WORKFLOWS (.github/workflows/*) may use these; a
+  # composite action manifest may not. This job is a main.yaml job, so repocfg makes
+  # it a required check on this repo.
+  lint-action-manifests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: No composite-illegal ${{ }} contexts in action manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r f; do
+            # Only composite actions are affected; reusable workflows are not composite.
+            grep -qE 'using:[[:space:]]*"?composite' "$f" || continue
+            if grep -nE '\$\{\{[[:space:]]*(vars|secrets|needs|matrix|strategy)\.' "$f"; then
+              echo "::error file=$f::references a context unavailable to composite actions (vars/secrets/needs/matrix/strategy) — deliteralize it, e.g. write \`vars.X\` (plain text) instead of \`\${{ vars.X }}\`. See the v1.12.1 load-failure incident."
+              fail=1
+            fi
+          done < <(find . -type f -name action.yaml -not -path './node_modules/*')
+          if [ "$fail" -ne 0 ]; then exit 1; fi
+          echo "✓ no composite-illegal \${{ }} contexts in any action manifest."


### PR DESCRIPTION
Guards the **v1.12.0 incident** at author time. A composite action's *whole* manifest is expression-templated at **load** time — input `description`s and `run:` strings, bash comments included — and `vars` / `secrets` / `needs` / `matrix` / `strategy` don't exist for composite actions. So a literal `${{ vars.X }}` **anywhere** in one (even as documentation) makes the action **fail to load**. A `kill_switch` doc string exactly like that took `merge-gate` offline **org-wide** until v1.12.1.

Adds a `lint-action-manifests` job to `main.yaml` that scans every composite `action.yaml` for those contexts and fails with a pointer to deliteralize. Caller **workflows** legitimately use `${{ vars.* }}` (e.g. `main.yaml` itself) — the lint only touches `using: composite` manifests. As a `main.yaml` job it becomes a **required check** via repocfg, so it gates every PR here.

One of two guard-rail lints for this arc's two apply-time SEVs (the other, the ≤100-char label-description check, is stack#220).

## Test plan
- [x] passes on the current (v1.12.1-clean) manifests; correctly detects composite vs workflow
- [x] catches a synthetic `${{ vars.FOO }}` in a composite `action.yaml` (verified locally)
- [x] YAML parses; prettier clean
- [ ] review