### PR TITLE
feat(detect-partial-landing): scope the sweep enqueue token to active-Epic repos (#263)

### DIFF
--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -162,8 +162,10 @@ runs:
     # Discover the repos with an OPEN epic:<N> PR — the bounded superset of this sweep's roll-forward
     # targets (a reenqueue target is a landable stray, i.e. an open Epic member). The enqueue token
     # below is scoped to exactly these, not org-wide, so a leak can't reach a repo that isn't mid-landing.
-    # Mirrors the run step's own `all_open` enumeration; the two can only diverge if a PR opens in the
-    # seconds between, and a reenqueue miss already self-heals (it logs "next sweep retries").
+    # Reads the same open-PR + label view the run step's enumeration does (labels first:100), so it is a
+    # superset of the reenqueue targets (a stray is an open Epic member). Residual divergence is only a PR
+    # opening in the seconds between (self-heals — the reenqueue logs "next sweep retries") or an org with
+    # >1000 open PRs (not realistic here). A partial page failure abandons the token, never a partial scope.
     - name: Discover active-Epic repos (scope for the enqueue token)
       id: scope
       if: ${{ steps.mode.outputs.mode == 'sweep' }}
@@ -178,12 +180,17 @@ runs:
         fi
         Q='query($q:String!,$cursor:String){ search(query:$q, type:ISSUE, first:100, after:$cursor){
           pageInfo{ hasNextPage endCursor }
-          nodes{ ... on PullRequest{ repository{ name } labels(first:20){ nodes{ name } } } } } }'
+          nodes{ ... on PullRequest{ repository{ name } labels(first:100){ nodes{ name } } } } } }'
         cursor=""; names=""; failed=0
         while :; do
           args=(-f query="$Q" -f q="org:${ORG} is:pr is:open")
           [ -n "$cursor" ] && args+=(-f cursor="$cursor")
-          if ! data=$(gh api graphql "${args[@]}" 2>/dev/null); then failed=1; break; fi
+          # Require a well-formed page (data present, no errors) — same guard as the run step's
+          # search_prs — so a 200 carrying a partial data+errors payload abandons the token, not scopes it.
+          if ! data=$(gh api graphql "${args[@]}" 2>/dev/null) \
+            || ! printf '%s' "$data" | jq -e 'has("data") and (has("errors") | not)' >/dev/null 2>&1; then
+            failed=1; break
+          fi
           names+=$(printf '%s' "$data" | jq -r '
             .data.search.nodes[]? | select([.labels.nodes[]?.name] | any(test("^epic:[0-9]+$"))) | .repository.name')
           names+=$'\n'
@@ -197,7 +204,9 @@ runs:
           echo "::warning::active-Epic repo discovery failed — not minting the enqueue token this sweep (roll-forward waits for the next); freeze detection is unaffected."
           echo "repos=" >> "$GITHUB_OUTPUT"
         else
-          csv=$(printf '%s' "$names" | grep -v '^$' | sort -u | paste -sd, -)
+          # `sed '/^$/d'` (not `grep -v '^$'`): grep exits 1 when it drops EVERY line — the common
+          # no-active-Epic case — which under set -e/pipefail would abort the whole sweep. sed exits 0.
+          csv=$(printf '%s' "$names" | sed '/^$/d' | sort -u | paste -sd, -)
           echo "repos=${csv}" >> "$GITHUB_OUTPUT"
           echo "Enqueue-token scope (repos with an open Epic PR): ${csv:-<none>}"
         fi

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -131,9 +131,11 @@ runs:
           echo "detect-partial-landing: SWEEP mode."
         fi
 
-    # Least-privilege org-wide tokens: the sweep spans the whole org, so the single-repo GITHUB_TOKEN
-    # can't see sibling PRs; separate tokens keep each capability scoped. Org-wide (not per-repo) because
-    # a composite action can't loop `create-github-app-token` over repos discovered at runtime.
+    # Least-privilege tokens: the sweep spans the whole org, so the single-repo GITHUB_TOKEN can't see
+    # sibling PRs. The READ and CHECKS tokens are org-wide (the enumeration + the freeze posts span every
+    # repo); the WRITE (enqueue) token is SCOPED to just the active-Epic repos (the scope step below),
+    # since a roll-forward only ever touches a repo with an open Epic PR. A composite action can't loop
+    # create-github-app-token per-repo, but it CAN scope one token to a discovered repo SET.
     # These mints are deliberately NOT additionally gated on the kill-switch: a halted sweep no-ops
     # without exercising them (token SCOPE, not mint timing, is the enforced bound), a mint-free halt
     # is unachievable anyway (the per-PR HOLD below must mint checks:write to post `failure`), and
@@ -157,15 +159,61 @@ runs:
         owner: ${{ inputs.org }}
         permission-checks: write
 
-    # Sweep only — gating the mint (not just the call site) means a per-PR run never even acquires write.
+    # Discover the repos with an OPEN epic:<N> PR — the bounded superset of this sweep's roll-forward
+    # targets (a reenqueue target is a landable stray, i.e. an open Epic member). The enqueue token
+    # below is scoped to exactly these, not org-wide, so a leak can't reach a repo that isn't mid-landing.
+    # Mirrors the run step's own `all_open` enumeration; the two can only diverge if a PR opens in the
+    # seconds between, and a reenqueue miss already self-heals (it logs "next sweep retries").
+    - name: Discover active-Epic repos (scope for the enqueue token)
+      id: scope
+      if: ${{ steps.mode.outputs.mode == 'sweep' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.read.outputs.token }}
+        ORG: ${{ inputs.org }}
+      run: |
+        set -euo pipefail
+        if ! [[ "${ORG:-}" =~ ^[A-Za-z0-9-]+$ ]]; then
+          echo "::error::org must be a valid GitHub login (alphanumeric + hyphens), got \"${ORG:-}\""; exit 1
+        fi
+        Q='query($q:String!,$cursor:String){ search(query:$q, type:ISSUE, first:100, after:$cursor){
+          pageInfo{ hasNextPage endCursor }
+          nodes{ ... on PullRequest{ repository{ name } labels(first:20){ nodes{ name } } } } } }'
+        cursor=""; names=""; failed=0
+        while :; do
+          args=(-f query="$Q" -f q="org:${ORG} is:pr is:open")
+          [ -n "$cursor" ] && args+=(-f cursor="$cursor")
+          if ! data=$(gh api graphql "${args[@]}" 2>/dev/null); then failed=1; break; fi
+          names+=$(printf '%s' "$data" | jq -r '
+            .data.search.nodes[]? | select([.labels.nodes[]?.name] | any(test("^epic:[0-9]+$"))) | .repository.name')
+          names+=$'\n'
+          [ "$(printf '%s' "$data" | jq -r '.data.search.pageInfo.hasNextPage')" = "true" ] || break
+          cursor=$(printf '%s' "$data" | jq -r '.data.search.pageInfo.endCursor')
+        done
+        if [ "$failed" = 1 ]; then
+          # A discovery blip must not yield a PARTIAL scope (a reenqueue in an uncovered repo would 403) —
+          # abandon the enqueue token this sweep. Freeze detection (checks token) is unaffected, and the
+          # next sweep re-discovers and rolls the stray forward then.
+          echo "::warning::active-Epic repo discovery failed — not minting the enqueue token this sweep (roll-forward waits for the next); freeze detection is unaffected."
+          echo "repos=" >> "$GITHUB_OUTPUT"
+        else
+          csv=$(printf '%s' "$names" | grep -v '^$' | sort -u | paste -sd, -)
+          echo "repos=${csv}" >> "$GITHUB_OUTPUT"
+          echo "Enqueue-token scope (repos with an open Epic PR): ${csv:-<none>}"
+        fi
+
+    # Sweep only, and SCOPED to the active-Epic repos (steps.scope) — not org-wide. Gating the mint on a
+    # non-empty scope means a sweep with no open Epic PRs (nothing to roll forward) never acquires write,
+    # and a per-PR run never even reaches this step.
     - name: Mint enqueue token
       id: write
-      if: ${{ steps.mode.outputs.mode == 'sweep' }}
+      if: ${{ steps.mode.outputs.mode == 'sweep' && steps.scope.outputs.repos != '' }}
       uses: actions/create-github-app-token@v3
       with:
         client-id: ${{ inputs.client_id }}
         private-key: ${{ inputs.app_private_key }}
         owner: ${{ inputs.org }}
+        repositories: ${{ steps.scope.outputs.repos }}
         # `gh pr merge --auto` needs contents:write alongside pull-requests:write.
         permission-pull-requests: write
         permission-contents: write


### PR DESCRIPTION
Closes the deferred #245 follow-on: the sweep's **enqueue token** (`pull-requests`+`contents:write`, minted every ~15 min) was org-wide. Scope it to just the repos with an open `epic:<N>` PR — the bounded superset of the sweep's roll-forward targets (a reenqueue target is a landable stray = an open Epic member).

## Approach — bounded-scope, not a two-pass restructure

A new read-only **scope** step (`if: mode==sweep`) discovers the active-Epic repos via a paginated GraphQL search, and the enqueue mint scopes `repositories:` to them (gated on a non-empty scope — a sweep with no open Epic PRs never acquires write). **The detection / freeze / reenqueue loop is untouched**, so the only new failure mode is a rare discovery-gap reenqueue 403, which already self-heals ("next sweep retries"). Chosen over restructuring a 15-min action's core loop for the same org-wide→active-Epic reduction.

## Review

Adversarially reviewed (2 lenses). Coverage logic verified sound (the *only* `WRITE_TOKEN` uses are `reenqueue()` on open Epic members; freeze/queue targets use the org-wide checks token). Fixes applied + verified:
- **`set -e` abort** (blocker): `grep -v '^$'` on the empty case (no active Epic — the common state) aborted the whole sweep every 15 min → `sed '/^$/d'` (exits 0). Empirically confirmed.
- `labels(first:20)` → `first:100` (a >20-label PR can't hide its epic label → no persistent 403).
- Require a well-formed GraphQL page (data, no errors) before accepting — abandons the token on a partial payload rather than minting a partial scope.

## Test plan
- [x] YAML parses; 6 steps; no `${{ vars }}`; prettier clean
- [x] scope jq filter selects epic-PR repos, skips non-epic, dedupes (verified)
- [x] empty-scope CSV assembly exits 0 (no sweep abort) — verified under `set -euo pipefail`
- [ ] Copilot review
- [ ] live-drill on the spike (synthetic active Epic) before relying on it