### PR TITLE
fix(ci): drop empty ${{ }} from the manifest-lint step (broke main.yaml load)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
   # Guard against the v1.12.0 incident: a composite action's WHOLE manifest is
   # expression-templated at load time — input descriptions and run: strings, bash
   # comments included. The vars / secrets / needs / matrix / strategy contexts do not
-  # exist for composite actions, so a literal `${{ vars.X }}` anywhere in one — even
+  # exist for composite actions, so a literal `vars.X` template expression anywhere in one — even
   # as documentation — makes the action fail to LOAD, which took merge-gate offline
   # org-wide until v1.12.1. Caller WORKFLOWS (.github/workflows/*) may use these; a
   # composite action manifest may not. This job is a main.yaml job, so repocfg makes
@@ -41,7 +41,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - name: No composite-illegal ${{ }} contexts in action manifests
+      - name: No composite-illegal expression contexts in action manifests
         shell: bash
         run: |
           set -euo pipefail
@@ -50,9 +50,9 @@ jobs:
             # Only composite actions are affected; reusable workflows are not composite.
             grep -qE 'using:[[:space:]]*"?composite' "$f" || continue
             if grep -nE '\$\{\{[[:space:]]*(vars|secrets|needs|matrix|strategy)\.' "$f"; then
-              echo "::error file=$f::references a context unavailable to composite actions (vars/secrets/needs/matrix/strategy) — deliteralize it, e.g. write \`vars.X\` (plain text) instead of \`\${{ vars.X }}\`. See the v1.12.1 load-failure incident."
+              echo "::error file=$f::references a context unavailable to composite actions (vars/secrets/needs/matrix/strategy) — deliteralize it: write the context as plain text (e.g. \`vars.X\`), never inside a template expression. See the v1.12.1 load-failure incident."
               fail=1
             fi
           done < <(find . -type f -name action.yaml -not -path './node_modules/*')
           if [ "$fail" -ne 0 ]; then exit 1; fi
-          echo "✓ no composite-illegal \${{ }} contexts in any action manifest."
+          echo "✓ no composite-illegal expression contexts in any action manifest."


### PR DESCRIPTION
**main.yaml has not run since #268 merged.** The `lint-action-manifests` job — the one meant to catch load-breaking `${{ }}` in composite manifests — put a literal `${{ }}` in its own **step name** and two `run:` echoes. GitHub evaluates `${{ }}` in step names and `run:` strings, and an **empty `${{ }}` is a syntax error**, so the whole workflow failed to compile → nothing ran (not even `lint-node`). Same class of bug the lint exists to catch, in the lint itself.

Fix: reword the step name + echoes to plain text (no adjacent `${{`). The grep **pattern** is untouched — its `\$\{\{` has backslashes that break the `${{` token, so GitHub's templater never sees it, and it still catches real violations.

The fix branch's `main.yaml` is valid, so CI runs on this PR (self-validating); merging repairs master.

## Test plan
- [x] YAML parses; prettier clean; only the legitimate `${{ }}` (concurrency, lint-node) remain
- [x] lint pattern still catches a synthetic `${{ secrets.Y }}` in a composite manifest; passes the clean current set
- [ ] confirm `main.yaml` runs green on this PR