### PR TITLE
fix(ci): reconcile lockfile before pnpm format in audit action

### DIFF
--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -30,17 +30,20 @@ runs:
     - name: run audit
       shell: bash
       # --fix requires a mode since pnpm 11; "override" pins vulnerable
-      # transitive dependencies via package.json overrides without moving direct ones.
+      # transitive dependencies via pnpm-workspace.yaml overrides without moving direct ones.
       env:
-        # `pnpm audit --fix` writes new overrides then runs an install to apply
-        # them; under CI pnpm defaults that install to --frozen-lockfile, which
-        # then fails ERR_PNPM_LOCKFILE_CONFIG_MISMATCH against the just-changed
-        # overrides. Let the lockfile update here — it is committed below.
+        # Defensive: unfreeze any install pnpm triggers here — under CI the
+        # lockfile is frozen by default, and the overrides audit --fix writes
+        # make that mismatch the committed lockfile.
         npm_config_frozen_lockfile: "false"
       run: |
+        # `pnpm audit --fix` rewrites the overrides but leaves the lockfile stale.
+        # Reconcile it BEFORE `pnpm format`: pnpm 11 runs a verify-deps-before-run
+        # pre-hook on any `pnpm <script>`, which would otherwise spawn a *frozen*
+        # install and abort with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
         pnpm audit --fix=override
-        pnpm format
         pnpm i --no-frozen-lockfile
+        pnpm format
     - name: check diff
       id: check_diff
       shell: bash


### PR DESCRIPTION
## Summary

- The nightly `node-audit` job fails on every repo that actually has an advisory to fix — the 4 services + `nodelib` — while `golib`/`jwt`/`workflows` pass only because no overrides get added.
- Root cause is an ordering bug in `node-actions/audit`, not the advisories themselves. This reorders one line to fix it.

## Root cause

The action runs:

```
pnpm audit --fix=override   # rewrites overrides in pnpm-workspace.yaml, lockfile now stale
pnpm format                 # ← fails here
pnpm i --no-frozen-lockfile # never reached
```

`audit --fix` writes overrides but does **not** touch the lockfile. `pnpm format` is a `pnpm <script>`, so pnpm 11 runs its **verify-deps-before-run** pre-hook first (`runDepsStatusCheck` in the trace); it detects the override↔lockfile mismatch and spawns a **frozen** `pnpm install`, which aborts with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

The existing `npm_config_frozen_lockfile: "false"` env (added in #170) never reaches that pre-hook install, so it doesn't help — confirmed by `service-json-keys`, already pinned to `v1.13.0`, still failing.

## Fix

Reconcile the lockfile with `pnpm i --no-frozen-lockfile` **before** `pnpm format`; drop the now-redundant trailing install. One functional line moved.

## Test plan

Reproduced and validated locally (pnpm 11.10.0):

- [x] Injecting an override (as `audit --fix` does) then running a `pnpm <script>` reproduces `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` with the same `runDepsStatusCheck` frame as CI.
- [x] With `npm_config_frozen_lockfile=false` set, it still fails (proves the current guard is inert on this path).
- [x] Running `pnpm i --no-frozen-lockfile` **before** the script → passes.
- [ ] Post-release: bump the `node-actions/audit@` pin in the failing repos and confirm the next scheduled run (or a `workflow_dispatch`) goes green.

## Rollout

After merge + release (→ next tag), re-pin `node-actions/audit@` in each consumer's `.github/workflows/node-audit.yaml`: the 5 failing repos are urgent (services + `nodelib`); `golib`/`jwt` can follow. `workflows` uses local `./node-actions/audit` and picks up the fix automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)