### PR TITLE
feat(release-core): configurable multi-tag releases (root + sub-modules)

### DIFF
--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -1,10 +1,9 @@
 name: release core
 description: >
-  Cut a release in CI: bump the version (workspace-aware, no pnpm), refresh doc
-  version refs (prepublish:doc / `a-novel publish stamp`), commit, tag, push,
-  and create the GitHub Release — and output the computed version for the
-  downstream build/publish jobs. The release-type selector and the protected
-  `release` environment live in the caller (the per-repo release workflow).
+  Cut a release in CI: bump the version (package.json, workspace-aware), stamp
+  in-repo version refs, commit, push the tags (a root vX.Y.Z plus any sub-module
+  tags — see plan.cjs), and create the GitHub Release. The release-type selector
+  and the protected `release` environment live in the caller.
 
 inputs:
   release_type:
@@ -32,8 +31,11 @@ outputs:
     description: The bumped version (e.g. 1.2.3).
     value: ${{ steps.cut.outputs.version }}
   tag:
-    description: The release tag — vX.Y.Z, or <subdir>/vX.Y.Z for a sub-directory Go module.
+    description: The root release tag — always vX.Y.Z.
     value: ${{ steps.cut.outputs.tag }}
+  tags:
+    description: Every tag cut, newline-separated — root vX.Y.Z plus any <subdir>/vX.Y.Z sub-module tags.
+    value: ${{ steps.cut.outputs.tags }}
 
 runs:
   using: composite
@@ -94,8 +96,7 @@ runs:
       uses: actions/setup-go@v6
       with:
         go-version: stable
-        # Nothing in this repo's Go (if any) is built here — we only `go install`
-        # the a-novel CLI — so skip the module cache and its "no go.sum" warning.
+        # Only `go install` the a-novel CLI here; no build, so skip the cache.
         cache: false
     - name: Install a-novel CLI (for stamp)
       if: ${{ steps.stamp.outputs.needed == 'true' }}
@@ -125,68 +126,49 @@ runs:
         git config user.name "${APP_SLUG}[bot]"
         git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
 
-        # Bump the root + every workspace member package.json with a small Node
-        # script instead of `pnpm version`. In CI's cold pnpm store `pnpm version`
-        # runs pnpm's supply-chain verification ("Verifying lockfile against
-        # supply-chain policies") and fails the release whenever any transitive
-        # dep is younger than minimumReleaseAge — a race that has nothing to do
-        # with cutting a release, and the `--config.*` flags don't reach that
-        # path. A version bump needs no dependency resolution (a package's own
-        # version isn't recorded in the lockfile), so the script just rewrites the
-        # version field — no resolution, no supply-chain pass. See bump.cjs.
+        # Version bump (package.json, root + workspace members). Plain Node, not
+        # `pnpm version`, to skip pnpm's cold-store supply-chain pass. See bump.cjs.
         node "$GITHUB_ACTION_PATH/bump.cjs"
 
-        # Refresh vX.Y.Z references in docs/config to the new version, before the
-        # commit — `a-novel publish stamp`, invoked via the prepublish:doc script.
-        # Gated on the detector so a repo without that script never invokes pnpm.
-        #
-        # PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false stops pnpm from running an
-        # install before the script. The stamp only needs the a-novel CLI (already
-        # installed), never node_modules; that pre-run install would otherwise need
-        # npm-registry auth (private @a-novel deps -> 401) and re-run the
-        # supply-chain verification. It's an env var (not a --config flag) so the
-        # script's nested `pnpm` calls inherit it; npm_config_* is ignored by pnpm.
+        # Refresh doc version refs (a-novel publish stamp) where that script exists.
+        # The env var skips pnpm's pre-run install, which would need npm-registry auth.
         if [ "$STAMP_NEEDED" = "true" ]; then
           PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run prepublish:doc
         fi
 
         version=$(node -p "require('./package.json').version")
 
-        # Tag prefix: a sub-directory Go module releases as <dir>/vX.Y.Z (that is
-        # how Go resolves it); a root module or a JS-only repo uses plain vX.Y.Z.
-        # The pathspec also matches lookalikes (cargo.mod), so require an exact
-        # go.mod basename. No bash arrays here — keep it portable and testable.
-        gomods=$(git ls-files '*go.mod' | grep -E '(^|/)go\.mod$' || true)
-        count=$(printf '%s' "$gomods" | grep -c . || true)
-        prefix=""
-        if [ "$count" -gt 1 ]; then
-          echo "::error::multiple Go modules — no single release tag; tag manually:"
-          printf '%s\n' "$gomods"
-          exit 1
-        elif [ "$count" -eq 1 ]; then
-          d=$(dirname "$gomods")
-          [ "$d" != "." ] && prefix="$d/"
-        fi
-        tag="${prefix}v${version}"
+        # Stamp in-repo version refs and compute the tags (root vX.Y.Z plus any
+        # sub-module tags). Add an ecosystem in plan.cjs, never here.
+        tags=$(node "$GITHUB_ACTION_PATH/plan.cjs")
+        root_tag="v${version}"
 
         {
           echo "version=$version"
-          echo "tag=$tag"
+          echo "tag=$root_tag"
+          echo "tags<<__TAGS__"
+          printf '%s\n' "$tags"
+          echo "__TAGS__"
         } >> "$GITHUB_OUTPUT"
-        echo "Release **$tag** (bump: $RELEASE_TYPE)" | tee -a "$GITHUB_STEP_SUMMARY"
+        {
+          echo "Release **$version** (bump: $RELEASE_TYPE) — tags:"
+          printf '%s\n' "$tags" | sed 's/^/- `/; s/$/`/'
+        } | tee -a "$GITHUB_STEP_SUMMARY"
 
         if [ "$DRY_RUN" = "true" ]; then
-          echo "- [dry-run] bumped to $version; would tag \`$tag\`, push to \`$BRANCH\`, and release — no mutation." \
-            | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "[dry-run] no commit, tag, push, or release." | tee -a "$GITHUB_STEP_SUMMARY"
           git checkout -- . 2>/dev/null || true
           exit 0
         fi
 
         git add -A
         git commit -m "$version"
-        git tag "$tag"
         git push origin "HEAD:$BRANCH"
-        git push origin "refs/tags/$tag"
-        gh release create "$tag" --repo "$GITHUB_REPOSITORY" \
+        while IFS= read -r t; do
+          [ -n "$t" ] || continue
+          git tag "$t"
+          git push origin "refs/tags/$t"
+        done <<< "$tags"
+        gh release create "$root_tag" --repo "$GITHUB_REPOSITORY" \
           --title "${GITHUB_REPOSITORY#*/} ${version}" --generate-notes
-        echo "- ✓ released \`$tag\`" | tee -a "$GITHUB_STEP_SUMMARY"
+        echo "- ✓ released $(printf '%s\n' "$tags" | grep -c .) tag(s), root \`$root_tag\`" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/publish-actions/release-core/plan.cjs
+++ b/publish-actions/release-core/plan.cjs
@@ -1,0 +1,66 @@
+// Release planner: rewrite in-repo version references (stamps) and print the
+// tags to cut, one per line.
+//
+// package.json is the source of truth for the version (bump.cjs already bumped
+// it). On top of that, each ecosystem in LANGUAGES declares:
+//   • stamps  — {files, pattern, replace}: point in-repo version refs at the new version
+//   • subtags — dirs that get their own <dir>/vX.Y.Z tag (independently-resolved sub-modules)
+// A root vX.Y.Z tag is ALWAYS emitted, so a repo can never end up with only
+// sub-tags. Support a new ecosystem by appending one entry — no shell changes.
+
+const fs = require("fs");
+const cp = require("child_process");
+const path = require("path");
+
+const tracked = cp.execSync("git ls-files", { encoding: "utf8" }).split("\n").filter(Boolean);
+const version = JSON.parse(fs.readFileSync("package.json", "utf8")).version;
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const goMod = /(^|\/)go\.mod$/;
+const goMods = () => tracked.filter((f) => goMod.test(f));
+// This repo's own module root, e.g. github.com/a-novel-kit/stack.
+const goModulePath = `github.com/${process.env.GITHUB_REPOSITORY || ""}`;
+
+const LANGUAGES = [
+  {
+    name: "go",
+    // Each nested go.mod is resolved independently as <dir>/vX.Y.Z; a root go.mod
+    // (dir ".") shares the root tag.
+    subtags: () =>
+      goMods()
+        .map((f) => path.dirname(f))
+        .filter((d) => d !== "."),
+    stamps: [
+      {
+        // In-repo inter-module requires → the freshly-cut version. The (?![-.\d])
+        // guard leaves pseudo-versions (v0.0.0-<ts>-<sha>) and pre-releases alone.
+        files: goMods,
+        pattern: new RegExp(`(${esc(goModulePath)}\\S*\\s+)v\\d+\\.\\d+\\.\\d+(?![-.\\d])`, "g"),
+        replace: `$1v${version}`,
+      },
+    ],
+  },
+  {
+    // JS packages share the root tag; bump.cjs already stamped every package.json
+    // and prepublish:doc handles docs — nothing extra here.
+    name: "node",
+    subtags: () => [],
+    stamps: [],
+  },
+];
+
+for (const lang of LANGUAGES) {
+  for (const s of lang.stamps) {
+    for (const f of s.files()) {
+      const before = fs.readFileSync(f, "utf8");
+      const after = before.replace(s.pattern, s.replace);
+      if (after !== before) fs.writeFileSync(f, after);
+    }
+  }
+}
+
+const tags = new Set([`v${version}`]);
+for (const lang of LANGUAGES) {
+  for (const dir of lang.subtags()) tags.add(`${dir}/v${version}`);
+}
+process.stdout.write([...tags].join("\n"));


### PR DESCRIPTION
`release-core` errored on any repo with >1 Go module ("multiple Go modules — no single release tag; tag manually"). There's no reason it can't push them all — so this makes it multi-tag and, more importantly, **configurable**.

## Design

`package.json` stays the single source of truth for the version (`bump.cjs`, unchanged). A new **`plan.cjs`** owns the configurable part — a `LANGUAGES` table where each ecosystem declares two things:

```js
{
  name: "go",
  subtags: () => …,          // dirs that get their own <dir>/vX.Y.Z tag
  stamps:  [{ files, pattern, replace }],  // rewrite in-repo version refs to the new version
}
```

- **`stamps`** — declarative `{files, pattern, replace}` regex rewrites for internal version references (the Go rule points this repo's own inter-module `require`s at the freshly-cut version).
- **`subtags`** — dirs that get their own `<dir>/vX.Y.Z` tag (each nested `go.mod`).
- A **root `vX.Y.Z` is always emitted**, so a repo can never end up with *only* sub-tags.

**Adding an ecosystem is one array entry** — the shell step stays dumb (bump → stamp+plan → tag every line). Comments throughout the action are trimmed per request.

New output **`tags`** (all tags, newline-separated); **`tag`** stays the root `vX.Y.Z`.

## ⚠️ Behaviour change — please confirm: `stack`

`stack` has a subdir `cli/go.mod`, so today it tags **`cli/vX.Y.Z` only**. With "root always + sub-tags" it now also gets a **root `vX.Y.Z`** (your intended "root tag always present").
- `cli/vX.Y.Z` **is still cut** → `go install …/stack/cli@…` resolution is unchanged.
- The GitHub Release + the `tag` output move to the **root** `vX.Y.Z`. `stack` doesn't npm-publish, so nothing downstream breaks.
- `golib` / `workflows` / `nodelib` (root or no go.mod) are **unchanged** → `vX.Y.Z`; `nodelib`'s npm publish still reads `tag` = root.

One deliberate call: a GitHub **Release** is created for the **root tag only**; sub-module tags are pushed bare (Go resolves tags, not Releases). Easy to loop later if you want per-module release pages.

## Test plan
Verified `plan.cjs` against every real repo shape + the stamp (synthetic git repos):
- [x] no go.mod (workflows/spike) → `v0.1.0`
- [x] root go.mod (golib) → `v0.1.0`
- [x] subdir `cli/go.mod` (stack) → `v0.1.0` + `cli/v0.1.0`
- [x] multi subdir → root + each `<dir>/v0.1.0`
- [x] go stamp: own `require v0.1.9 → v0.2.0`; **pseudo-version** (`v0.0.0-<ts>-<sha>`) and **external deps** left untouched; `module` directive untouched
- [x] YAML + prettier + `node --check` + composite-manifest lint (no illegal `${{ }}`)
- [ ] a real multi-module dry-run (none exists yet; the drill spike + single-module repos exercise the root path)