### PR TITLE
fix(release-train): drop stray `)` in the receipt-table rows

### DIFF
--- a/generic-actions/release-train/action.yaml
+++ b/generic-actions/release-train/action.yaml
@@ -533,7 +533,7 @@ runs:
             elif .status=="nochange" then "— nothing new"
             elif .status=="botched" then "⚠️ tag `"+.tag+"` without a Release — repair"
             elif .status=="parked" then "⏸️ parked (release-env approval)"
-            else "❌ "+.status end)) |")')
+            else "❌ "+.status end) |")')
         # Only a live run edits the human-authored Epic body; a dry-run rehearsal is side-effect-free.
         if [ "$dry" = "false" ]; then
           block=$(printf '<!-- release-train:receipts:start -->\n### 🚂 Release train — epic:#%s (%s)\n%s\n<!-- release-train:receipts:end -->' \


### PR DESCRIPTION
The receipt-table jq closes the `\(...)` interpolation and then emits a literal `) |`, so every row rendered `| repo | result**)** |`. Surfaced in the release-train drill receipt spliced into the Epic: `| spike-stage4-convoy | ✅ \`v0.1.0\`**)** |`.

One-char fix (`end)) |` → `end) |`). Verified the jq now renders `| repo | result |` for shipped/skipped/failed rows. Cosmetic, but it's the audit trail — good to ride the next workflows release.

## Test plan
- [x] jq renders clean rows for shipped/skipped/failed statuses
- [x] YAML + prettier + no composite-illegal `${{ }}`