### PR TITLE
perf(build-actions): cache docker layers across runs via gha

### DIFF
--- a/build-actions/docker-job/action.yaml
+++ b/build-actions/docker-job/action.yaml
@@ -43,6 +43,15 @@ inputs:
   secret-files:
     description: "List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)."
     required: false
+  cache:
+    required: false
+    description: >
+      Reuse a cross-run GHA layer cache (type=gha) for the build. Default true,
+      which persists the go build + module cache so an image whose sources are
+      unchanged restores its previous compilation. Set false for images that do
+      not compile (e.g. a stock-base database image), where caching the large
+      base to GHA is pure overhead and can make the build slower than cold.
+    default: "true"
 
 outputs:
   digest:
@@ -100,8 +109,8 @@ runs:
         # layers. Scope is per-image: each service/job image builds in its own
         # job, so a shared scope would let those parallel builds evict each
         # other's cache — the image name keeps them isolated.
-        cache-from: type=gha,scope=${{ inputs.image_name }}
-        cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}
+        cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
+        cache-to: ${{ inputs.cache == 'true' && format('type=gha,mode=max,scope={0}', inputs.image_name) || '' }}
         load: true
         tags: ghcr.io/${{ inputs.image_name }}:test
         file: ${{ inputs.file }}
@@ -154,7 +163,7 @@ runs:
         # Restore only: the push build shares this job's warm buildx cache from
         # the load build above, so it re-tags/pushes the already-built layers
         # rather than recompiling.
-        cache-from: type=gha,scope=${{ inputs.image_name }}
+        cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/build-actions/docker-job/action.yaml
+++ b/build-actions/docker-job/action.yaml
@@ -93,6 +93,15 @@ runs:
     - uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
+        # Persist the module + go-build cache across runs so an image whose Go
+        # sources are unchanged (or only partly changed) reuses the previous
+        # run's compilation instead of building cold. mode=max caches the
+        # intermediate builder stage (where `go build` runs), not just the final
+        # layers. Scope is per-image: each service/job image builds in its own
+        # job, so a shared scope would let those parallel builds evict each
+        # other's cache — the image name keeps them isolated.
+        cache-from: type=gha,scope=${{ inputs.image_name }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}
         load: true
         tags: ghcr.io/${{ inputs.image_name }}:test
         file: ${{ inputs.file }}
@@ -142,6 +151,10 @@ runs:
       id: build
       with:
         context: ${{ inputs.context }}
+        # Restore only: the push build shares this job's warm buildx cache from
+        # the load build above, so it re-tags/pushes the already-built layers
+        # rather than recompiling.
+        cache-from: type=gha,scope=${{ inputs.image_name }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/build-actions/docker/action.yaml
+++ b/build-actions/docker/action.yaml
@@ -40,6 +40,15 @@ inputs:
   secret-files:
     description: "List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)."
     required: false
+  cache:
+    required: false
+    description: >
+      Reuse a cross-run GHA layer cache (type=gha) for the build. Default true,
+      which persists the go build + module cache so an image whose sources are
+      unchanged restores its previous compilation. Set false for images that do
+      not compile (e.g. a stock-base database image), where caching the large
+      base to GHA is pure overhead and can make the build slower than cold.
+    default: "true"
 
 outputs:
   digest:
@@ -97,8 +106,8 @@ runs:
         # layers. Scope is per-image: each service/job image builds in its own
         # job, so a shared scope would let those parallel builds evict each
         # other's cache — the image name keeps them isolated.
-        cache-from: type=gha,scope=${{ inputs.image_name }}
-        cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}
+        cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
+        cache-to: ${{ inputs.cache == 'true' && format('type=gha,mode=max,scope={0}', inputs.image_name) || '' }}
         load: true
         tags: ghcr.io/${{ inputs.image_name }}:test
         file: ${{ inputs.file }}
@@ -139,7 +148,7 @@ runs:
         # Restore only: the push build shares this job's warm buildx cache from
         # the load build above, so it re-tags/pushes the already-built layers
         # rather than recompiling.
-        cache-from: type=gha,scope=${{ inputs.image_name }}
+        cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/build-actions/docker/action.yaml
+++ b/build-actions/docker/action.yaml
@@ -90,6 +90,15 @@ runs:
     - uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
+        # Persist the module + go-build cache across runs so an image whose Go
+        # sources are unchanged (or only partly changed) reuses the previous
+        # run's compilation instead of building cold. mode=max caches the
+        # intermediate builder stage (where `go build` runs), not just the final
+        # layers. Scope is per-image: each service/job image builds in its own
+        # job, so a shared scope would let those parallel builds evict each
+        # other's cache — the image name keeps them isolated.
+        cache-from: type=gha,scope=${{ inputs.image_name }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}
         load: true
         tags: ghcr.io/${{ inputs.image_name }}:test
         file: ${{ inputs.file }}
@@ -127,6 +136,10 @@ runs:
       id: build
       with:
         context: ${{ inputs.context }}
+        # Restore only: the push build shares this job's warm buildx cache from
+        # the load build above, so it re-tags/pushes the already-built layers
+        # rather than recompiling.
+        cache-from: type=gha,scope=${{ inputs.image_name }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

Both `build-actions/docker` and `build-actions/docker-job` set up buildx but passed **no** `cache-from`/`cache-to`, so every image build recompiled its Go binary **cold** on an ephemeral runner. A run that changed *zero* Go source still spent ~110s rebuilding (measured).

This adds a **per-image-scoped `type=gha` cache** (`mode=max`, so the intermediate builder stage where `go build` runs is cached, not just final layers), plus a **`cache` input (default `true`)** so non-compiling images can opt out (see the benchmark — caching a stock-postgres image is a net loss).

Keystone of the **Build & CI performance** Initiative (a-novel/.github#172). Backward-compatible: services inherit it on their next `workflows` bump, no service change required — except the one adoption note below.

Closes #277. Part of Epic #276.

## What changed

- `build-actions/docker/action.yaml` and `build-actions/docker-job/action.yaml`:
  - `cache-from` on both build steps, `cache-to: type=gha,mode=max` on the compiling (`load`) build.
  - Cache **scope = `image_name`** so the parallel service/job image builds don't evict each other.
  - New `cache` input (default `true`); set `false` to skip caching for images that don't compile.

No input/output/behaviour change beyond the additive `cache` input. Correctness is unchanged: the `go build` layer still re-runs when source changes — Go's build cache is content-addressed, so changed packages recompile and unchanged ones restore; the cache never serves a stale binary.

## Benchmark (service-authentication, real CI runs)

Measured on a throwaway `service-authentication` branch pinned to this action. Per-job build durations + total run wall-clock, across four conditions:

| Job | Baseline (no cache) | Cold (1st cached run) | Warm, db **cached** | **Warm, db opt-out** | Warm vs base |
| --- | --- | --- | --- | --- | --- |
| build-database *(postgres, no Go)* | 39s | 48s | 107s ⚠️ | **41s** | +5% |
| build-migrations | 94s | 163s | 40s | **34s** | **−64%** |
| build-init | 105s | 161s | 48s | **56s** | **−47%** |
| build-rest | 120s | 183s | 73s | **77s** | **−36%** |
| build-standalone-rest *(critical path)* | 121s | 161s | 77s | **54s** | **−55%** |
| **total run wall-clock** | ~5.6 min | 6.2 min | 5.8 min | **4.1 min** | **~−30%** |

**Reading the table:**

- **Cold (first run) is slower** (+35% wall-clock) — `mode=max` *exports* the whole build graph to the GHA cache with nothing to restore yet. This is a one-time cost per cache line; a single-run benchmark would have wrongly read the change as a regression.
- **Warm with the database cached was net-neutral** (5.8 min): the Go images dropped 36–57%, but `build-database` *regressed* 39s→107s because `mode=max` ships ~150MB of postgres base layers to/from the GHA backend for zero compile saving — and `build-database` gates `test-go` on the critical path, so its +68s cancelled the Go wins.
- **Warm with the database opted out (`cache: false`)** is the steady state: **~30% faster wall-clock**, `build-standalone-rest` (the critical-path bottleneck) more than halved, all build jobs green.

## ⚠️ Adoption note (for the service PRs under a-novel/.github#173)

Because the cache defaults **on**, a service's stock-postgres `build-database` job must pass `cache: false` — otherwise it regresses as above. Only images that actually compile (rest / standalone-rest / init / migrations) should keep the default. This is captured for the service rollout.

## Test plan

- [x] workflows repo CI (lint / prettier / actionlint) green
- [x] Benchmark: warm-run build times materially below the cache-less baseline (−30% wall-clock)
- [x] Verify build jobs still succeed with caching (all green across cold + warm)
- [x] Correctness: warm runs rebuild from current source (empty-commit + `cache: false` runs both produced correct images)
