### PR TITLE
feat(hotfix): hotfix workflow — cut + reconcile (#94)

### DIFF
--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -29,7 +29,7 @@ on:
           - sev1
         default: sev2
       dry_run:
-        description: Cut & report only — no tag, push, or release
+        description: No tag, release, reconcile PR, or cleanup Task — but a transient ephemeral branch is still pushed then deleted (the cut checks it out from the remote)
         required: false
         type: boolean
         default: true
@@ -90,19 +90,28 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          deadline=$((SECONDS + 1800)) # 30-minute cap → then abort (retry after the release)
+          deadline=$((SECONDS + 1800)) # 30-minute cap → then abort (retry after the release lands)
           while :; do
+            # Only an ACTIVELY-RUNNING release blocks: in_progress or queued. A release parked in
+            # `waiting` (pending its environment approval) is deliberately IGNORED — it may never be
+            # approved, and the emergency hotfix must not spin on an unapproved dispatch. A gh error →
+            # "err", retry (don't abort the emergency path on a transient API blip).
             active=$(gh run list --repo "$REPO" --workflow release.yaml --limit 30 \
-              --json status --jq '[.[] | select(.status | IN("in_progress","queued","waiting","requested","pending"))] | length')
-            [ "$active" -eq 0 ] && break
+              --json status --jq '[.[] | select(.status | IN("in_progress","queued"))] | length' 2>/dev/null || echo "err")
+            if [ "$active" = "0" ]; then
+              break
+            elif [ "$active" = "err" ]; then
+              echo "::warning::couldn't read in-flight release runs (gh error) — retrying in 30s."
+            else
+              echo "⏳ ${active} release run(s) actively in flight — waiting 30s before re-checking…"
+            fi
             if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "::error::a release has been in flight > 30m — aborting the hotfix; retry once it completes."
+              echo "::error::a release has been actively in flight (or its status unreadable) > 30m — aborting the hotfix; retry once it completes."
               exit 1
             fi
-            echo "⏳ $active in-flight release run(s) — waiting 30s before re-checking…"
             sleep 30
           done
-          echo "✓ no release in flight — proceeding." | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "✓ no release actively in flight — proceeding." | tee -a "$GITHUB_STEP_SUMMARY"
 
       # Resolve the baseline (latest live tag on the line), cut the ephemeral branch from it, apply
       # the fix, and capture fix-HEAD BEFORE the bump — that SHA range (baseline..fix_head) is what
@@ -144,6 +153,9 @@ jobs:
           # records the origin SHA, one of the signals the reconcile uses to prove the fix reached
           # master). Empty fix_ref = a drill that just re-cuts the baseline.
           if [ -n "${FIX_REF:-}" ]; then
+            # Reject a value git could parse as an option (leading dash) — fix_ref flows into git fetch
+            # + cherry-pick as a revision.
+            case "$FIX_REF" in -*) echo "::error::fix_ref must not begin with '-' (got \"$FIX_REF\")."; exit 1 ;; esac
             # Make sure the fix commits are present (a fix pushed to another branch isn't fetched by
             # the default checkout); harmless when FIX_REF is already reachable.
             git fetch origin "$FIX_REF" 2>/dev/null || true
@@ -184,7 +196,7 @@ jobs:
       # collapse into one marker. Only opened once the cut succeeded (nothing to reconcile otherwise).
       - name: Open cleanup Task
         id: cleanup_task
-        if: ${{ steps.cut.outcome == 'success' }}
+        if: ${{ success() && steps.cut.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -213,7 +225,7 @@ jobs:
       # branch is deleted (it fetches the fix commits from it).
       - name: Reconcile fix to the default branch
         id: reconcile
-        if: ${{ steps.cut.outcome == 'success' }}
+        if: ${{ success() && steps.cut.outcome == 'success' }}
         uses: ./generic-actions/hotfix-reconcile
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
@@ -224,6 +236,20 @@ jobs:
           line: ${{ inputs.line }}
           cleanup_task: ${{ steps.cleanup_task.outputs.number }}
           dry_run: ${{ inputs.dry_run }}
+
+      # If the reconcile short-circuited (the fix was ALREADY on the default branch, patch-id match),
+      # no PR closes the cleanup Task — so close it here, or the watchdog would later escalate a hotfix
+      # that did reach master. reconcile has no issues:write; the git token (this job) does.
+      - name: Close cleanup Task (already reconciled)
+        if: ${{ success() && steps.reconcile.outputs.already_on_master == 'true' && steps.cleanup_task.outputs.number != '' && steps.cleanup_task.outputs.number != '0' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.cleanup_task.outputs.number }}
+        run: |
+          gh issue close "$NUM" --repo "$REPO" --reason completed \
+            --comment "The fix was already on the default branch (patch-id match) — no reconcile PR was needed."
+          echo "Closed cleanup Task #${NUM} (fix already on the default branch)." | tee -a "$GITHUB_STEP_SUMMARY"
 
       # Any failure in the hotfix path pulls a human in — the emergency path must be loud, never silent.
       # Passes the dispatch severity; a wired ESCALATE_PUSH_WEBHOOK pages SEV1. dry-run just logs it.

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -57,6 +57,9 @@ jobs:
       fix_head: ${{ steps.prepare.outputs.fix_head }}
       version: ${{ steps.cut.outputs.version }}
       tag: ${{ steps.cut.outputs.tag }}
+      cleanup_task: ${{ steps.cleanup_task.outputs.number }}
+      reconcile_pr: ${{ steps.reconcile.outputs.pr_url }}
+      reconcile_conflicted: ${{ steps.reconcile.outputs.conflicted }}
     steps:
       # Bot-authenticated full checkout: the baseline tag, the fix, and the ephemeral-branch push all
       # need the bot's rights + complete history and tags. release-core-hotfix re-checks-out the
@@ -70,6 +73,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           permission-contents: write
+          permission-issues: write # open the per-hotfix cleanup Task
       - uses: actions/checkout@v7
         with:
           token: ${{ steps.token.outputs.token }}
@@ -140,6 +144,9 @@ jobs:
           # records the origin SHA, one of the signals the reconcile uses to prove the fix reached
           # master). Empty fix_ref = a drill that just re-cuts the baseline.
           if [ -n "${FIX_REF:-}" ]; then
+            # Make sure the fix commits are present (a fix pushed to another branch isn't fetched by
+            # the default checkout); harmless when FIX_REF is already reachable.
+            git fetch origin "$FIX_REF" 2>/dev/null || true
             git cherry-pick -x "$FIX_REF"
             echo "Applied fix \`$FIX_REF\`." | tee -a "$GITHUB_STEP_SUMMARY"
           else
@@ -148,6 +155,11 @@ jobs:
 
           fix_head=$(git rev-parse HEAD)
           git push origin "$ephemeral"
+
+          # Restore the main workspace to the triggering commit so the local `./` actions (the cut,
+          # reconcile, and escalate steps) resolve from the CURRENT ref — not the old baseline this
+          # step checked out. release-core-hotfix re-checks-out the ephemeral branch from the remote.
+          git checkout --force "$GITHUB_SHA" >/dev/null 2>&1
 
           {
             echo "baseline=$baseline"
@@ -166,14 +178,72 @@ jobs:
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
           dry_run: ${{ inputs.dry_run }}
 
-      # TODO(hotfix reconcile — next layer): cherry-pick -x the baseline..fix_head range onto master
-      # via a squash hotfix-reconcile/* PR (epic-rollback conflict-degrade skeleton), machine-verify
-      # it reached master (patch-id / -x trailer / Closes #cleanup-task), open the per-hotfix cleanup
-      # Task, and escalate on failure. The ephemeral branch (the fix, pre-bump) is intentionally kept
-      # until the reconcile records fix_head; that layer deletes it once reconciled.
+      # The per-hotfix cleanup Task: a durable, escalatable marker that the fix MUST reach the default
+      # branch. The reconcile PR `Closes` it; if it lingers open the fix never reconciled and the
+      # watchdog escalates. Per-hotfix identity (the version in the title) so concurrent hotfixes don't
+      # collapse into one marker. Only opened once the cut succeeded (nothing to reconcile otherwise).
+      - name: Open cleanup Task
+        id: cleanup_task
+        if: ${{ steps.cut.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          LINE: ${{ inputs.line }}
+          VERSION: ${{ steps.cut.outputs.version }}
+          BASELINE: ${{ steps.prepare.outputs.baseline }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[dry-run] would open a hotfix-reconcile cleanup Task for v${VERSION}." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "number=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh label create hotfix-reconcile --repo "$REPO" --force \
+            --color FBCA04 --description "Tracks a hotfix's forward-port to the default branch." >/dev/null 2>&1 || true
+          body=$(printf 'The **v%s** hotfix (patched from `%s`) must be forward-ported to the default branch, or a later minor cut from it would silently reintroduce the fixed bug.\n\nA `hotfix-reconcile/*` PR `Closes` this Task when the fix lands. While this Task stays open the hotfix has NOT reconciled — the watchdog escalates a rotting reconcile.' "$VERSION" "$BASELINE")
+          url=$(gh issue create --repo "$REPO" --label hotfix-reconcile \
+            --title "Reconcile hotfix v${VERSION} to the default branch" --body "$body")
+          num=$(printf '%s' "$url" | grep -oE '[0-9]+$')
+          echo "Opened cleanup Task #${num} (${url})." | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "number=$num" >> "$GITHUB_OUTPUT"
 
-      # Until the reconcile layer lands, clean up the ephemeral branch here so a drill leaves no trace
-      # (the tag, if cut, preserves the commit). always() so an earlier failure still cleans up.
+      # Forward-port the fix diff (never the bump) to the default branch — a squash hotfix-reconcile/*
+      # PR that Closes the cleanup Task, degrading a conflict to a draft PR. Runs BEFORE the ephemeral
+      # branch is deleted (it fetches the fix commits from it).
+      - name: Reconcile fix to the default branch
+        id: reconcile
+        if: ${{ steps.cut.outcome == 'success' }}
+        uses: ./generic-actions/hotfix-reconcile
+        with:
+          client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+          app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
+          source_ref: ${{ steps.prepare.outputs.ephemeral }}
+          baseline: ${{ steps.prepare.outputs.baseline }}
+          fix_head: ${{ steps.prepare.outputs.fix_head }}
+          line: ${{ inputs.line }}
+          cleanup_task: ${{ steps.cleanup_task.outputs.number }}
+          dry_run: ${{ inputs.dry_run }}
+
+      # Any failure in the hotfix path pulls a human in — the emergency path must be loud, never silent.
+      # Passes the dispatch severity; a wired ESCALATE_PUSH_WEBHOOK pages SEV1. dry-run just logs it.
+      - name: Escalate on failure
+        if: ${{ failure() }}
+        uses: ./generic-actions/escalate
+        with:
+          client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+          app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
+          project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
+          severity: ${{ inputs.severity }}
+          summary: "hotfix v${{ inputs.line }}.x failed"
+          dedup_key: "hotfix-failed:${{ github.repository }}:${{ inputs.line }}"
+          repo: ${{ github.repository }}
+          mention: ${{ vars.SEV1_MENTION }}
+          push_webhook: ${{ secrets.ESCALATE_PUSH_WEBHOOK }}
+          dry_run: ${{ inputs.dry_run }}
+
+      # Clean up the ephemeral branch — AFTER the reconcile fetched its commits. The tag (if cut)
+      # preserves the fix commit. always() so an earlier failure still cleans up.
       - name: Clean up ephemeral branch
         if: ${{ always() && steps.prepare.outputs.ephemeral != '' }}
         env:

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -1,0 +1,184 @@
+name: hotfix
+
+# Patch an ALREADY-RELEASED line without touching the default branch. Dispatched from the UI (like
+# release.yaml — the protected `release` environment is the human "who may publish" gate), it cuts
+# an ephemeral branch from the latest live tag on the target X.Y line, applies the fix, and cuts a
+# vX.Y.(Z+1) tag via release-core-hotfix. The fix is then reconciled to master (added on this branch
+# next); this first layer is the cut path, drillable in dry-run.
+#
+# Kill-switch note: a hotfix is deliberately NOT gated on the org kill switch. The kill switch pauses
+# normal automation; the emergency PATCH path must stay open (it's human-gated by `release` + admin).
+on:
+  workflow_dispatch:
+    inputs:
+      line:
+        description: 'X.Y line to patch (e.g. "1.4") — baseline auto-resolves to its latest live tag'
+        required: true
+        type: string
+      fix_ref:
+        description: "Git revision carrying the fix (a commit SHA, or an A..B range) to cherry-pick onto the baseline; empty = re-cut the baseline (drill)"
+        required: false
+        type: string
+        default: ""
+      severity:
+        description: Escalation severity if the hotfix fails
+        required: false
+        type: choice
+        options:
+          - sev2
+          - sev1
+        default: sev2
+      dry_run:
+        description: Cut & report only — no tag, push, or release
+        required: false
+        type: boolean
+        default: true
+
+run-name: "🚑 hotfix v${{ inputs.line }}.x${{ inputs.dry_run && ' (dry-run)' || '' }}"
+
+# hotfix-vs-hotfix: serialize on this repo (a second hotfix waits, never races). hotfix-vs-release
+# is handled at runtime by the lock step below (asymmetric — release.yaml stays lock-free so
+# release-vs-release keeps its deliberate collision-fail). cancel-in-progress:false = queue, don't
+# cancel a hotfix mid-flight.
+concurrency:
+  group: hotfix-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  hotfix:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write # push the ephemeral branch + tag
+      actions: read # the lock step reads in-flight release runs
+    outputs:
+      baseline: ${{ steps.prepare.outputs.baseline }}
+      ephemeral: ${{ steps.prepare.outputs.ephemeral }}
+      fix_head: ${{ steps.prepare.outputs.fix_head }}
+      version: ${{ steps.cut.outputs.version }}
+      tag: ${{ steps.cut.outputs.tag }}
+    steps:
+      # Bot-authenticated full checkout: the baseline tag, the fix, and the ephemeral-branch push all
+      # need the bot's rights + complete history and tags. release-core-hotfix re-checks-out the
+      # ephemeral branch itself later with its own token.
+      - name: Mint git token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Asymmetric lock: wait out any in-flight release before cutting a hotfix, so the two never
+      # interleave. Only the hotfix waits — release.yaml never locks, so release-vs-release keeps its
+      # collision-fail. Best-effort ordering (a hotfix and a release compute different tags, so they
+      # can't collide); a small post-wait race is acceptable.
+      - name: Acquire lock (wait for in-flight release)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 1800)) # 30-minute cap → then abort (retry after the release)
+          while :; do
+            active=$(gh run list --repo "$REPO" --workflow release.yaml --limit 30 \
+              --json status --jq '[.[] | select(.status | IN("in_progress","queued","waiting","requested","pending"))] | length')
+            [ "$active" -eq 0 ] && break
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::a release has been in flight > 30m — aborting the hotfix; retry once it completes."
+              exit 1
+            fi
+            echo "⏳ $active in-flight release run(s) — waiting 30s before re-checking…"
+            sleep 30
+          done
+          echo "✓ no release in flight — proceeding." | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Resolve the baseline (latest live tag on the line), cut the ephemeral branch from it, apply
+      # the fix, and capture fix-HEAD BEFORE the bump — that SHA range (baseline..fix_head) is what
+      # reconciles to master (the fix diff only, never the bump). Push the branch so release-core-
+      # hotfix can check it out.
+      - name: Prepare ephemeral branch
+        id: prepare
+        env:
+          LINE: ${{ inputs.line }}
+          FIX_REF: ${{ inputs.fix_ref }}
+        run: |
+          set -euo pipefail
+
+          # Validate the line (guards the glob/grep below against a malformed or injected value) and
+          # escape its dots so the grep can't match a stray character (e.g. line 1.4 vs a tag v1x4.0).
+          if ! printf '%s' "$LINE" | grep -qE '^[0-9]+\.[0-9]+$'; then
+            echo "::error::line must be MAJOR.MINOR (e.g. 1.4), got \"$LINE\"."
+            exit 1
+          fi
+          line_re=$(printf '%s' "$LINE" | sed 's/\./\\./g')
+
+          # Baseline = highest vLINE.PATCH release tag (exclude sub-module tags <dir>/v… and pre-releases).
+          baseline=$(git tag -l "v${LINE}.*" | grep -E "^v${line_re}\.[0-9]+$" | sort -V | tail -1 || true)
+          if [ -z "$baseline" ]; then
+            echo "::error::no released tag on line v${LINE}.x — nothing to hotfix."
+            exit 1
+          fi
+          ephemeral="hotfix/v${LINE}.x"
+          echo "Baseline: \`$baseline\` → ephemeral branch \`$ephemeral\`." | tee -a "$GITHUB_STEP_SUMMARY"
+
+          git config user.name "${{ steps.token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+          # A leftover ephemeral branch from an aborted run would block a fresh cut — remove it first.
+          git push origin --delete "$ephemeral" 2>/dev/null || true
+          git checkout -b "$ephemeral" "$baseline"
+
+          # Apply the fix. A single SHA or an A..B range both work with cherry-pick -x (the -x trailer
+          # records the origin SHA, one of the signals the reconcile uses to prove the fix reached
+          # master). Empty fix_ref = a drill that just re-cuts the baseline.
+          if [ -n "${FIX_REF:-}" ]; then
+            git cherry-pick -x "$FIX_REF"
+            echo "Applied fix \`$FIX_REF\`." | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No fix_ref — drill mode (re-cutting the baseline)." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+          fix_head=$(git rev-parse HEAD)
+          git push origin "$ephemeral"
+
+          {
+            echo "baseline=$baseline"
+            echo "ephemeral=$ephemeral"
+            echo "fix_head=$fix_head"
+          } >> "$GITHUB_OUTPUT"
+
+      # Cut the hotfix release from the ephemeral branch (patch bump, tag-only, --latest=false). In
+      # dry-run it bumps + reports without tagging/pushing.
+      - name: Cut hotfix
+        id: cut
+        uses: ./publish-actions/release-core-hotfix
+        with:
+          ref: ${{ steps.prepare.outputs.ephemeral }}
+          client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+          app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
+          dry_run: ${{ inputs.dry_run }}
+
+      # TODO(hotfix reconcile — next layer): cherry-pick -x the baseline..fix_head range onto master
+      # via a squash hotfix-reconcile/* PR (epic-rollback conflict-degrade skeleton), machine-verify
+      # it reached master (patch-id / -x trailer / Closes #cleanup-task), open the per-hotfix cleanup
+      # Task, and escalate on failure. The ephemeral branch (the fix, pre-bump) is intentionally kept
+      # until the reconcile records fix_head; that layer deletes it once reconciled.
+
+      # Until the reconcile layer lands, clean up the ephemeral branch here so a drill leaves no trace
+      # (the tag, if cut, preserves the commit). always() so an earlier failure still cleans up.
+      - name: Clean up ephemeral branch
+        if: ${{ always() && steps.prepare.outputs.ephemeral != '' }}
+        env:
+          EPHEMERAL: ${{ steps.prepare.outputs.ephemeral }}
+        run: |
+          git push origin --delete "$EPHEMERAL" 2>/dev/null \
+            && echo "Deleted ephemeral branch \`$EPHEMERAL\`." | tee -a "$GITHUB_STEP_SUMMARY" \
+            || echo "Ephemeral branch \`$EPHEMERAL\` already gone."

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,9 @@ on:
       - "**"
     branches:
       - "**"
+      # The transient ephemeral hotfix branches (pushed then deleted by hotfix.yaml, incl. dry-run
+      # drills) never become PRs, so there's nothing to lint — skip them to avoid churn runs.
+      - "!hotfix/**"
 
 # Cancel an in-progress lint run when a newer commit lands on the same ref —
 # the superseded run's result is never useful. Safe here because this workflow

--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 
 ### `publish-actions`
 
-| Action         | Purpose                                                    |
-| -------------- | ---------------------------------------------------------- |
-| `auto-release` | Turn a pushed tag into a GitHub release with notes.        |
-| `npm`          | Publish the workspace packages to the GitHub registry.     |
-| `release-core` | Cut a release in CI: bump the version, tag, push, release. |
+| Action                | Purpose                                                                                        |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| `auto-release`        | Turn a pushed tag into a GitHub release with notes.                                            |
+| `npm`                 | Publish the workspace packages to the GitHub registry.                                         |
+| `release-core`        | Cut a release in CI: bump the version, tag, push, release.                                     |
+| `release-core-hotfix` | Cut a hotfix release from an ephemeral branch off a release tag (patch, tag-only, not-latest). |
 
 ### Reusable workflows
 

--- a/generic-actions/hotfix-reconcile/action.yaml
+++ b/generic-actions/hotfix-reconcile/action.yaml
@@ -133,7 +133,15 @@ runs:
         # baseline..fix_head '+' (not upstream) or '-' (already upstream, by patch-id). Zero '+' → the
         # fix is already reconciled (e.g. a re-run after the PR merged, or the fix also went to master
         # directly) → close the loop without a redundant PR.
-        pending=$(git -C "$dir" cherry "origin/${default_branch}" "$FIX_HEAD" "$BASELINE" 2>/dev/null | grep -c '^+' || true)
+        # Capture git-cherry's output and check its EXIT explicitly — piping straight into grep would
+        # swallow a real error (unresolvable baseline/fix_head) as "0 pending" and skip the reconcile
+        # on a genuine failure (fails open on the emergency path).
+        if ! cherry_out=$(git -C "$dir" cherry "origin/${default_branch}" "$FIX_HEAD" "$BASELINE" 2>&1); then
+          echo "::error::git cherry failed (baseline/fix_head unresolvable?): ${cherry_out}"
+          rm -rf "$dir"
+          exit 1
+        fi
+        pending=$(printf '%s\n' "$cherry_out" | grep -c '^+' || true)
         if [ "$pending" -eq 0 ]; then
           echo "Fix is already on \`${default_branch}\` (patch-id match) — no reconcile PR needed." | tee -a "$GITHUB_STEP_SUMMARY"
           rm -rf "$dir"
@@ -144,21 +152,26 @@ runs:
         branch="hotfix-reconcile/v${LINE}-${CLEANUP_TASK}"
         git -C "$dir" switch -c "$branch" "origin/${default_branch}" >/dev/null 2>&1
 
+        # The full range, for the draft-PR body when we degrade (so the human knows EVERY commit to
+        # finish, not just the one that stopped it). Computed before the cherry-pick mutates the tree.
+        range_commits=$(git -C "$dir" log --oneline --reverse "${BASELINE}..${FIX_HEAD}" 2>/dev/null | sed 's/^/- /')
+
         # Cherry-pick the fix range (fix diff only — the bump is excluded by construction, it is past
         # fix_head). -x records "(cherry picked from …)" — one of the reached-master signals. On a
-        # conflict, DON'T abort: stage the markers and commit them so a human resolves in the PR.
+        # conflict, DON'T abort: stage whatever's there and commit it so a human resolves in the PR.
         conflicted=false
         if git -C "$dir" cherry-pick -x "${BASELINE}..${FIX_HEAD}" >/dev/null 2>&1; then
           conflicted=false
         else
           conflicted=true
           conflict_paths=$(git -C "$dir" diff --name-only --diff-filter=U | tr '\n' ' ')
-          # Commit the conflict markers as-is (the human resolves them in the PR), then abandon any
-          # remaining commits in the range — the draft PR tells the human to finish the port by hand.
+          # Commit whatever the cherry-pick left — conflict markers (unmerged paths) OR nothing (an
+          # already-applied intermediate commit stops it "empty"). --allow-empty so the empty case
+          # can't hard-fail under set -e. Then abandon the remaining range; the draft PR lists it all.
           git -C "$dir" add -A
-          git -C "$dir" commit --quiet --no-edit \
-            -m "hotfix reconcile v${LINE} (UNRESOLVED CONFLICTS — resolve before merge)" \
-            -m "cherry-pick -x ${BASELINE}..${FIX_HEAD} conflicted on: ${conflict_paths}"
+          git -C "$dir" commit --quiet --allow-empty --no-edit \
+            -m "hotfix reconcile v${LINE} (INCOMPLETE — resolve/finish before merge)" \
+            -m "cherry-pick -x ${BASELINE}..${FIX_HEAD} stopped on: ${conflict_paths:-<already-applied / empty>}"
           git -C "$dir" cherry-pick --quit >/dev/null 2>&1 || true
         fi
 
@@ -172,8 +185,8 @@ runs:
         git -C "$dir" push --quiet -u origin "$branch"
 
         if [ "$conflicted" = true ]; then
-          body=$(printf 'Forward-ports the **v%s** hotfix fix diff to `%s`, but `git cherry-pick -x %s..%s` **CONFLICTED** — the conflict markers are committed as-is on this branch.\n\n**Resolve by hand:** check out `%s`, fix the `<<<<<<<` markers (paths: %s), re-run any dropped commits from the range if needed, push, and mark this PR ready. Then squash-merge.\n\nCloses #%s' \
-            "$LINE" "$default_branch" "$BASELINE" "${FIX_HEAD:0:12}" "$branch" "${conflict_paths:-—}" "$CLEANUP_TASK")
+          body=$(printf 'Forward-ports the **v%s** hotfix fix diff to `%s`, but `git cherry-pick -x %s..%s` did not complete cleanly — whatever applied is committed as-is on this branch (conflict markers where paths conflicted: %s), and the rest of the range was NOT applied.\n\n**Resolve by hand:** check out `%s`, finish porting every commit in the range below (resolving any `<<<<<<<` markers), push, mark this PR ready, then squash-merge.\n\nCommits in the range:\n%s\n\nCloses #%s' \
+            "$LINE" "$default_branch" "$BASELINE" "${FIX_HEAD:0:12}" "${conflict_paths:-—}" "$branch" "${range_commits:-—}" "$CLEANUP_TASK")
           pr_url=$(gh pr create --repo "$REPO" --base "$default_branch" --head "$branch" --draft \
             --title "[CONFLICTS] hotfix reconcile v${LINE} → ${default_branch}" --body "$body")
           echo "::warning::reconcile CONFLICTED — opened DRAFT PR for manual resolution: ${pr_url}"

--- a/generic-actions/hotfix-reconcile/action.yaml
+++ b/generic-actions/hotfix-reconcile/action.yaml
@@ -1,0 +1,190 @@
+name: hotfix-reconcile
+description: >
+  Forward-port a hotfix's FIX DIFF (never the version bump) from a hotfix tag onto the default
+  branch — the load-bearing guarantee against a "forgotten back-merge" that lets a later vX.Y+1.0,
+  cut from master, silently reintroduce the bug. Given the baseline tag and the ephemeral branch's
+  fix-HEAD, it cherry-picks the range `baseline..fix_head` onto a fresh branch off the default
+  branch and opens a SQUASH `hotfix-reconcile/*` PR that `Closes` the hotfix's cleanup Task.
+
+  It reuses epic-rollback's clone → open-PR → never-force-reset skeleton, but degrades DIFFERENTLY:
+  on a cherry-pick conflict it COMMITS THE CONFLICT MARKERS into the branch and opens a DRAFT PR for
+  a human to resolve in place (epic-rollback commits an empty held placeholder instead). The
+  reconcile PR is deliberately LABEL-CLEAN — never `epic:<N>` — so the merge-gate treats it as an
+  ordinary standalone PR (benign pass) and never PARKS it; an unreconciled hotfix does not worsen as
+  master moves, so freezing the repo would be harmful friction. Enforcement is the escalating cleanup
+  Task + watchdog (built alongside), not a merge-blocking check.
+
+  "Reached master" is machine-verified downstream by an ORDERED FALLBACK — patch-id (`git cherry`,
+  survives a clean single-commit squash) → the `-x` trailer (carried into the squash body) → the
+  PR's `Closes #<cleanup-task>` (the only signal robust to BOTH a squash AND a conflict resolution).
+  This action's job is to open that PR correctly; the watchdog checks that it landed. If the fix is
+  ALREADY on the default branch (patch-id match), it short-circuits — no PR.
+
+inputs:
+  client_id:
+    required: true
+    description: >
+      [Agent] App client id. Mints one token scoped (repositories:) to THIS repo with contents:write
+      (push the reconcile branch) + pull-requests:write (open the PR).
+  app_private_key:
+    required: true
+    description: The [Agent] App private key (PEM) — the AGENT_BOT_PRIVATE_KEY org secret.
+  source_ref:
+    required: true
+    description: >
+      The ephemeral hotfix branch carrying the fix (e.g. hotfix/vX.Y.x). Its commits are fetched so
+      the range baseline..fix_head can be cherry-picked; it must still exist when this runs (the
+      caller deletes it only after).
+  baseline:
+    required: true
+    description: The baseline release tag the hotfix was cut from (range start, exclusive) — e.g. v1.4.5.
+  fix_head:
+    required: true
+    description: >
+      SHA of the fix tip on the ephemeral branch (range end, inclusive) — captured BEFORE the version
+      bump, so the reconcile carries the fix diff only, never the bump commit.
+  line:
+    required: true
+    description: The X.Y line (e.g. "1.4"), used only to name the reconcile branch + PR.
+  cleanup_task:
+    required: true
+    description: >
+      Number of the hotfix's cleanup Task issue in THIS repo. The PR `Closes #<cleanup_task>` — the
+      authoritative "reached master" signal that survives both a squash and a conflict resolution.
+  dry_run:
+    required: false
+    default: "false"
+    description: When "true", report what would be reconciled without pushing a branch or opening a PR.
+
+outputs:
+  already_on_master:
+    description: '"true" if the fix was already on the default branch (patch-id match) — no PR opened.'
+    value: ${{ steps.reconcile.outputs.already_on_master }}
+  conflicted:
+    description: '"true" if the cherry-pick conflicted — a DRAFT PR with conflict markers was opened.'
+    value: ${{ steps.reconcile.outputs.conflicted }}
+  pr_url:
+    description: URL of the reconcile PR (empty if already on master or dry-run).
+    value: ${{ steps.reconcile.outputs.pr_url }}
+  pr_number:
+    description: Number of the reconcile PR (empty if already on master or dry-run).
+    value: ${{ steps.reconcile.outputs.pr_number }}
+
+runs:
+  using: composite
+  steps:
+    # Scoped to THIS repo: push the reconcile branch (contents) and open the PR (pull-requests).
+    # No kill-switch guard — the hotfix path (this included) is exempt (the emergency STOP must not
+    # disable the emergency PATH).
+    - name: Mint reconcile token
+      id: token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.client_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+        permission-contents: write
+        permission-pull-requests: write
+
+    - name: Reconcile fix to the default branch
+      id: reconcile
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.token.outputs.token }}
+        APP_SLUG: ${{ steps.token.outputs.app-slug }}
+        REPO: ${{ github.repository }}
+        SOURCE_REF: ${{ inputs.source_ref }}
+        BASELINE: ${{ inputs.baseline }}
+        FIX_HEAD: ${{ inputs.fix_head }}
+        LINE: ${{ inputs.line }}
+        CLEANUP_TASK: ${{ inputs.cleanup_task }}
+        DRY_RUN: ${{ inputs.dry_run }}
+      run: |
+        set -euo pipefail
+
+        # cleanup_task feeds `Closes #<n>` — must be a bare integer (a stray value could break the
+        # closing keyword or the PR body).
+        if ! printf '%s' "$CLEANUP_TASK" | grep -qE '^[0-9]+$'; then
+          echo "::error::cleanup_task must be an integer, got \"$CLEANUP_TASK\"."
+          exit 1
+        fi
+
+        default_branch=$(gh api "repos/${REPO}" -q .default_branch)
+        emit() { # $1 already_on_master $2 conflicted $3 pr_url $4 pr_number
+          {
+            echo "already_on_master=$1"; echo "conflicted=$2"
+            echo "pr_url=$3"; echo "pr_number=$4"
+          } >> "$GITHUB_OUTPUT"
+        }
+
+        # Clone the default branch (full history so baseline + fix commits are reachable), token in
+        # the throwaway clone's remote URL only (the epic-rollback / pull-bot pattern).
+        dir=$(mktemp -d)
+        git clone --quiet --branch "$default_branch" \
+          "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$dir"
+        git -C "$dir" config user.name "${APP_SLUG}[bot]"
+        git -C "$dir" config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+        # Bring in the fix commits + the baseline tag so the range resolves.
+        git -C "$dir" fetch --quiet origin "$SOURCE_REF"
+        git -C "$dir" fetch --quiet origin "refs/tags/${BASELINE}:refs/tags/${BASELINE}" 2>/dev/null || true
+
+        # Short-circuit: is the fix already on the default branch? `git cherry` marks each commit in
+        # baseline..fix_head '+' (not upstream) or '-' (already upstream, by patch-id). Zero '+' → the
+        # fix is already reconciled (e.g. a re-run after the PR merged, or the fix also went to master
+        # directly) → close the loop without a redundant PR.
+        pending=$(git -C "$dir" cherry "origin/${default_branch}" "$FIX_HEAD" "$BASELINE" 2>/dev/null | grep -c '^+' || true)
+        if [ "$pending" -eq 0 ]; then
+          echo "Fix is already on \`${default_branch}\` (patch-id match) — no reconcile PR needed." | tee -a "$GITHUB_STEP_SUMMARY"
+          rm -rf "$dir"
+          emit true false "" ""
+          exit 0
+        fi
+
+        branch="hotfix-reconcile/v${LINE}-${CLEANUP_TASK}"
+        git -C "$dir" switch -c "$branch" "origin/${default_branch}" >/dev/null 2>&1
+
+        # Cherry-pick the fix range (fix diff only — the bump is excluded by construction, it is past
+        # fix_head). -x records "(cherry picked from …)" — one of the reached-master signals. On a
+        # conflict, DON'T abort: stage the markers and commit them so a human resolves in the PR.
+        conflicted=false
+        if git -C "$dir" cherry-pick -x "${BASELINE}..${FIX_HEAD}" >/dev/null 2>&1; then
+          conflicted=false
+        else
+          conflicted=true
+          conflict_paths=$(git -C "$dir" diff --name-only --diff-filter=U | tr '\n' ' ')
+          # Commit the conflict markers as-is (the human resolves them in the PR), then abandon any
+          # remaining commits in the range — the draft PR tells the human to finish the port by hand.
+          git -C "$dir" add -A
+          git -C "$dir" commit --quiet --no-edit \
+            -m "hotfix reconcile v${LINE} (UNRESOLVED CONFLICTS — resolve before merge)" \
+            -m "cherry-pick -x ${BASELINE}..${FIX_HEAD} conflicted on: ${conflict_paths}"
+          git -C "$dir" cherry-pick --quit >/dev/null 2>&1 || true
+        fi
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "[dry-run] would open a $([ "$conflicted" = true ] && echo 'DRAFT (conflicts) ')reconcile PR \`$branch\` → \`$default_branch\`, Closes #${CLEANUP_TASK}." | tee -a "$GITHUB_STEP_SUMMARY"
+          rm -rf "$dir"
+          emit false "$conflicted" "" ""
+          exit 0
+        fi
+
+        git -C "$dir" push --quiet -u origin "$branch"
+
+        if [ "$conflicted" = true ]; then
+          body=$(printf 'Forward-ports the **v%s** hotfix fix diff to `%s`, but `git cherry-pick -x %s..%s` **CONFLICTED** — the conflict markers are committed as-is on this branch.\n\n**Resolve by hand:** check out `%s`, fix the `<<<<<<<` markers (paths: %s), re-run any dropped commits from the range if needed, push, and mark this PR ready. Then squash-merge.\n\nCloses #%s' \
+            "$LINE" "$default_branch" "$BASELINE" "${FIX_HEAD:0:12}" "$branch" "${conflict_paths:-—}" "$CLEANUP_TASK")
+          pr_url=$(gh pr create --repo "$REPO" --base "$default_branch" --head "$branch" --draft \
+            --title "[CONFLICTS] hotfix reconcile v${LINE} → ${default_branch}" --body "$body")
+          echo "::warning::reconcile CONFLICTED — opened DRAFT PR for manual resolution: ${pr_url}"
+        else
+          body=$(printf 'Forward-ports the **v%s** hotfix fix diff (range `%s..%s`, the fix only — never the bump) to `%s` via `git cherry-pick -x`.\n\nThis is the regression guard for the fix-on-tag hotfix: without it a later minor cut from `%s` would silently reintroduce the bug. Squash-merge when green.\n\nCloses #%s' \
+            "$LINE" "$BASELINE" "${FIX_HEAD:0:12}" "$default_branch" "$default_branch" "$CLEANUP_TASK")
+          pr_url=$(gh pr create --repo "$REPO" --base "$default_branch" --head "$branch" \
+            --title "hotfix reconcile v${LINE} → ${default_branch}" --body "$body")
+          echo "Opened reconcile PR: ${pr_url}" | tee -a "$GITHUB_STEP_SUMMARY"
+        fi
+        rm -rf "$dir"
+
+        pr_number=$(printf '%s' "$pr_url" | grep -oE '[0-9]+$')
+        emit false "$conflicted" "$pr_url" "$pr_number"

--- a/publish-actions/release-core-hotfix/action.yaml
+++ b/publish-actions/release-core-hotfix/action.yaml
@@ -68,11 +68,17 @@ runs:
 
     # Bot-authenticated checkout of the EPHEMERAL branch (FORK 2 vs release-core: `ref` is an input,
     # not github.ref_name); full history + tags so the baseline assert and the tag resolve.
+    # CRITICAL: check out into a SUB-PATH, never the root. A root checkout would clobber
+    # $GITHUB_WORKSPACE with the old-baseline tree — breaking this action's OWN sibling read of
+    # ../release-core/*.cjs (absent on old lines) AND any local `./` action a caller runs AFTER the
+    # cut (the reconcile / escalate steps). With a sub-path the root workspace stays on the caller's
+    # ref, so $GITHUB_ACTION_PATH/../release-core resolves to the CURRENT scripts.
     - name: Checkout
       uses: actions/checkout@v7
       with:
         token: ${{ steps.token.outputs.token }}
         ref: ${{ inputs.ref }}
+        path: __hotfix
         fetch-depth: 0
         fetch-tags: true
 
@@ -84,9 +90,11 @@ runs:
       shell: bash
       run: corepack enable
 
-    # Only repos that stamp docs (a prepublish:doc script) need the a-novel CLI.
+    # Only repos that stamp docs (a prepublish:doc script) need the a-novel CLI. Read the EPHEMERAL
+    # tree's package.json (working-directory), not the root workspace's.
     - name: Detect prepublish:doc
       id: stamp
+      working-directory: __hotfix
       shell: bash
       run: |
         if node -e "process.exit(require('./package.json').scripts?.['prepublish:doc']?0:1)" 2>/dev/null; then
@@ -107,8 +115,11 @@ runs:
         go install github.com/a-novel-kit/stack/cli/cmd/a-novel@latest
         echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+    # working-directory: __hotfix — bump/plan/git all operate on the EPHEMERAL tree. $GITHUB_ACTION_PATH
+    # stays absolute (this action's dir in the untouched root), so $RC/*.cjs are the CURRENT scripts.
     - name: Cut hotfix
       id: cut
+      working-directory: __hotfix
       shell: bash
       env:
         GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -118,9 +129,10 @@ runs:
       run: |
         set -euo pipefail
 
-        # release-core owns bump.cjs / plan.cjs; reuse them from the sibling action dir UNCHANGED
-        # (the whole workflows repo is checked out under $GITHUB_ACTION_PATH's parent, so the sibling
-        # is present). A hotfix is always a patch bump of its line.
+        # release-core owns bump.cjs / plan.cjs; reuse them UNCHANGED from this action's sibling dir
+        # via the ABSOLUTE $GITHUB_ACTION_PATH (immune to the __hotfix working-directory), so the
+        # CURRENT scripts run regardless of what tree the ephemeral checkout holds. A hotfix is
+        # always a patch bump of its line.
         RC="$GITHUB_ACTION_PATH/../release-core"
         export RELEASE_TYPE=patch
 
@@ -129,10 +141,15 @@ runs:
 
         # HARD-ASSERT the ephemeral branch is cut from a real release: bump.cjs derives the next
         # version from package.json at this ref, so the baseline vX.Y.Z it patches from MUST be a
-        # released tag — otherwise the branch was cut from the wrong place and the tag would be bogus.
+        # released tag AND this HEAD must descend from it — otherwise the branch was cut from the
+        # wrong place and the tag would be bogus.
         baseline=$(node -p "require('./package.json').version")
         if ! git rev-parse -q --verify "refs/tags/v${baseline}" >/dev/null; then
           echo "::error::baseline v${baseline} (this ref's package.json version) is not a released tag — a hotfix must be cut from a release tag, not an arbitrary commit."
+          exit 1
+        fi
+        if ! git merge-base --is-ancestor "refs/tags/v${baseline}" HEAD; then
+          echo "::error::HEAD does not descend from baseline v${baseline} — the ephemeral branch was not cut from that release tag."
           exit 1
         fi
 

--- a/publish-actions/release-core-hotfix/action.yaml
+++ b/publish-actions/release-core-hotfix/action.yaml
@@ -1,0 +1,196 @@
+name: release core (hotfix)
+description: >
+  Cut a HOTFIX release from an already-released line — the exception-path sibling of release-core.
+  It reuses release-core's bump.cjs + plan.cjs UNCHANGED (the version math and tag plan are
+  identical) but drops the three default-branch assumptions baked into release-core: the
+  default-branch guard, the default-branch checkout, and the push-to-the-default-branch. Instead it
+  checks out an ephemeral branch that was cut from a release TAG (carrying the fix on top of the
+  baseline), patch-bumps to vX.Y.(Z+1), and pushes ONLY the tag — the ephemeral branch is thrown
+  away by the caller (the tag preserves the commit). The tag is created with --latest=false so a
+  patch to an OLD line can't steal "Latest" from a newer release.
+
+  Kept a SEPARATE action (not a flag on release-core) on purpose — blast-radius discipline: a change
+  to the exception path must not be able to break the everyday release path. The bump is a plain
+  `patch` here (a hotfix is always a patch of its line); the reconcile-to-master, the ephemeral
+  branch lifecycle, the lock, and the human gate all live in the caller (hotfix.yaml).
+
+inputs:
+  ref:
+    required: true
+    description: >
+      The ephemeral hotfix branch to cut from (e.g. hotfix/vX.Y.x), already carrying the fix on top
+      of the baseline release tag. bump.cjs derives the version from THIS ref's package.json, so it
+      must descend from a real release tag — hard-asserted below (the baseline vX.Y.Z tag must exist).
+  client_id:
+    required: true
+    description: >
+      [Agent] App client ID. Needs contents:write plus a tag-protection bypass, since the vX.Y.(Z+1)
+      tag is protected (v*). Unlike release-core it never pushes a branch, so no branch-protection
+      bypass is exercised.
+  app_private_key:
+    required: true
+    description: The [Agent] App private key (PEM) — the AGENT_BOT_PRIVATE_KEY org secret.
+  dry_run:
+    required: false
+    default: "false"
+    description: >
+      When "true", bump and report the version/tags but do NOT commit, tag, push, or release — the
+      working tree is reverted. Lets a hotfix be rehearsed before the bot has push rights.
+
+outputs:
+  version:
+    description: The bumped hotfix version (e.g. 1.4.6).
+    value: ${{ steps.cut.outputs.version }}
+  tag:
+    description: The root hotfix tag — always vX.Y.Z.
+    value: ${{ steps.cut.outputs.tag }}
+  tags:
+    description: Every tag cut, newline-separated — root vX.Y.Z plus any <subdir>/vX.Y.Z sub-module tags.
+    value: ${{ steps.cut.outputs.tags }}
+
+runs:
+  using: composite
+  steps:
+    # No default-branch guard (FORK 1 vs release-core): a hotfix is cut from an ephemeral branch off
+    # a release tag, never from the default branch. The "cut from a real release" invariant is
+    # enforced below by asserting the baseline tag exists, not by pinning the ref to a branch name.
+
+    # Token that can push the tag + create the release. Scoped to this repo and contents only.
+    - name: Mint push token
+      id: token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.client_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+        permission-contents: write
+
+    # Bot-authenticated checkout of the EPHEMERAL branch (FORK 2 vs release-core: `ref` is an input,
+    # not github.ref_name); full history + tags so the baseline assert and the tag resolve.
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        token: ${{ steps.token.outputs.token }}
+        ref: ${{ inputs.ref }}
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Setup node
+      uses: actions/setup-node@v6
+      with:
+        node-version: lts/*
+    - name: Enable pnpm
+      shell: bash
+      run: corepack enable
+
+    # Only repos that stamp docs (a prepublish:doc script) need the a-novel CLI.
+    - name: Detect prepublish:doc
+      id: stamp
+      shell: bash
+      run: |
+        if node -e "process.exit(require('./package.json').scripts?.['prepublish:doc']?0:1)" 2>/dev/null; then
+          echo "needed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "needed=false" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Setup Go
+      if: ${{ steps.stamp.outputs.needed == 'true' }}
+      uses: actions/setup-go@v6
+      with:
+        go-version: stable
+        cache: false
+    - name: Install a-novel CLI (for stamp)
+      if: ${{ steps.stamp.outputs.needed == 'true' }}
+      shell: bash
+      run: |
+        go install github.com/a-novel-kit/stack/cli/cmd/a-novel@latest
+        echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+    - name: Cut hotfix
+      id: cut
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.token.outputs.token }}
+        APP_SLUG: ${{ steps.token.outputs.app-slug }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        STAMP_NEEDED: ${{ steps.stamp.outputs.needed }}
+      run: |
+        set -euo pipefail
+
+        # release-core owns bump.cjs / plan.cjs; reuse them from the sibling action dir UNCHANGED
+        # (the whole workflows repo is checked out under $GITHUB_ACTION_PATH's parent, so the sibling
+        # is present). A hotfix is always a patch bump of its line.
+        RC="$GITHUB_ACTION_PATH/../release-core"
+        export RELEASE_TYPE=patch
+
+        git config user.name "${APP_SLUG}[bot]"
+        git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+
+        # HARD-ASSERT the ephemeral branch is cut from a real release: bump.cjs derives the next
+        # version from package.json at this ref, so the baseline vX.Y.Z it patches from MUST be a
+        # released tag — otherwise the branch was cut from the wrong place and the tag would be bogus.
+        baseline=$(node -p "require('./package.json').version")
+        if ! git rev-parse -q --verify "refs/tags/v${baseline}" >/dev/null; then
+          echo "::error::baseline v${baseline} (this ref's package.json version) is not a released tag — a hotfix must be cut from a release tag, not an arbitrary commit."
+          exit 1
+        fi
+
+        # Patch-bump package.json (root + workspace members).
+        node "$RC/bump.cjs"
+        version=$(node -p "require('./package.json').version")
+
+        # Refresh doc version refs where a prepublish:doc script exists (env skips pnpm's pre-run
+        # install, which would need npm-registry auth).
+        if [ "$STAMP_NEEDED" = "true" ]; then
+          PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run prepublish:doc
+        fi
+
+        # Stamp in-repo version refs and compute the tags (root vX.Y.Z plus any sub-module tags).
+        tags=$(node "$RC/plan.cjs")
+        root_tag="v${version}"
+
+        # Tag-monotonicity: refuse if ANY computed tag already exists (a stale-baseline cut, or a
+        # re-run). Check ALL of them up front so we never push a partial set then fail.
+        while IFS= read -r t; do
+          [ -n "$t" ] || continue
+          if git rev-parse -q --verify "refs/tags/$t" >/dev/null; then
+            echo "::error::tag $t already exists — refusing to overwrite (stale baseline or a re-run?)."
+            exit 1
+          fi
+        done <<< "$tags"
+
+        {
+          echo "version=$version"
+          echo "tag=$root_tag"
+          echo "tags<<__TAGS__"
+          printf '%s\n' "$tags"
+          echo "__TAGS__"
+        } >> "$GITHUB_OUTPUT"
+        {
+          echo "Hotfix **$version** (patch of v${baseline}) — tags:"
+          printf '%s\n' "$tags" | sed 's/^/- `/; s/$/`/'
+        } | tee -a "$GITHUB_STEP_SUMMARY"
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "[dry-run] no commit, tag, push, or release." | tee -a "$GITHUB_STEP_SUMMARY"
+          git checkout -- . 2>/dev/null || true
+          exit 0
+        fi
+
+        # Commit the bump, then push ONLY the tags (FORK 3 vs release-core: no `git push HEAD:branch`
+        # — the ephemeral branch is disposable and the caller deletes it; the tag preserves the
+        # bump commit). Each tag points at the bump commit and carries it to the remote.
+        git add -A
+        git commit -m "$version"
+        while IFS= read -r t; do
+          [ -n "$t" ] || continue
+          git tag "$t"
+          git push origin "refs/tags/$t"
+        done <<< "$tags"
+
+        # --latest=false (FORK 3 cont.): a patch to an old line must NOT become the repo's "Latest"
+        # release over a newer version. release-core lets GitHub pick latest; a hotfix never can.
+        gh release create "$root_tag" --repo "$GITHUB_REPOSITORY" \
+          --title "${GITHUB_REPOSITORY#*/} ${version}" --generate-notes --latest=false
+        echo "- ✓ hotfix released $(printf '%s\n' "$tags" | grep -c .) tag(s), root \`$root_tag\` (not latest)" | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
> **Draft — first building block of the Stage 5 hotfix workflow (a-novel-kit/.github#94).** Held in draft on purpose: this action reuses `release-core`'s scripts through a sibling path (`$GITHUB_ACTION_PATH/../release-core/bump.cjs`) that CI can't exercise until a caller drives it. The `hotfix.yaml` caller (next commit on this branch) will **dry-run-drill it in CI**, at which point this goes ready-for-review — so a released hotfix action is never one the first real emergency is the first to run.

## Summary

`release-core-hotfix` — the exception-path sibling of `release-core`. It reuses `bump.cjs` + `plan.cjs` **unchanged** but drops the three default-branch assumptions so a patch can be cut from a release **tag**:

- **checks out an ephemeral branch** (a `ref` input) instead of the default branch, and drops the default-branch guard — replaced by a **hard assert that the baseline is a real released tag** (`v<package.json version>` must exist), so a hotfix can never be cut from an arbitrary commit;
- **pushes only the tag**, never a branch (the ephemeral branch is disposable; the caller deletes it, and the tag preserves the bump commit);
- **`--latest=false`** so a patch to an old line can't steal "Latest" from a newer release.

`RELEASE_TYPE` is a fixed `patch` (a hotfix is always a patch of its line). A **tag-monotonicity guard** refuses to overwrite any existing tag. Kept a *separate* action, not a flag on `release-core`, for blast-radius isolation — a change here can't break the everyday release path.

## Test plan

- [x] Manifest lint (no composite-illegal contexts), prettier, YAML valid, `bash -n`
- [x] Local functional test against the **real** `bump.cjs`/`plan.cjs` via the sibling path: happy dry-run (1.4.5→1.4.6, tags computed, tree reverted), baseline-missing → exit 1, tag-monotonicity → exit 1
- [ ] **CI dry-run drill via `hotfix.yaml`** (this branch, next) — validates the sibling-path reuse in the real Actions runtime before ready-for-review

Part of a-novel-kit/.github#94 · #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)