### PR TITLE
docs(escalate): namespace push-webhook secret as ESCALATE_PUSH_WEBHOOK

### DIFF
--- a/generic-actions/escalate/action.yaml
+++ b/generic-actions/escalate/action.yaml
@@ -126,8 +126,8 @@ inputs:
     default: ""
     description: >
       Chat webhook URL for the SEV1 push channel — currently a Discord channel webhook. Wire it
-      from the caller as `push_webhook: secrets.PUSH_WEBHOOK`; empty (unset) makes the push channel
-      a no-op (the ticket is still filed). Only SEV1 in `state: open` ever posts here.
+      from the caller as `push_webhook: secrets.ESCALATE_PUSH_WEBHOOK`; empty (unset) makes the push
+      channel a no-op (the ticket is still filed). Only SEV1 in `state: open` ever posts here.
   dry_run:
     required: false
     default: "false"


### PR DESCRIPTION
## Summary

Future milestones may add other webhooks (different channels/purposes), so namespace the escalate SEV1 push secret with an `ESCALATE_` prefix: `ESCALATE_PUSH_WEBHOOK`.

Only the caller-side **secret name** changes. The action **input** stays generic (`push_webhook`) and its internal handling is untouched — this is a one-line doc-example fix so contributors wire the right org secret. The `#95` caller workflows will reference `secrets.ESCALATE_PUSH_WEBHOOK`.

Part of a-novel-kit/.github#95 · #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)