### PR TITLE
perf(actions): derive golangci-lint version from repo + drop unused QEMU

### DIFF
--- a/build-actions/docker-job/action.yaml
+++ b/build-actions/docker-job/action.yaml
@@ -98,7 +98,6 @@ runs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ inputs.github_token }}
-    - uses: docker/setup-qemu-action@v4
     - uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}

--- a/build-actions/docker/action.yaml
+++ b/build-actions/docker/action.yaml
@@ -101,7 +101,6 @@ runs:
         username: ${{ github.actor }}
         password: ${{ inputs.github_token }}
     - uses: docker/setup-buildx-action@v4
-    - uses: docker/setup-qemu-action@v4
     - uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}

--- a/go-actions/lint-go/action.yaml
+++ b/go-actions/lint-go/action.yaml
@@ -18,5 +18,10 @@ runs:
         go-version-file: ${{ inputs.working-directory && format('{0}/go.mod', inputs.working-directory) || 'go.mod' }}
     - uses: golangci/golangci-lint-action@v9
       with:
-        version: latest
+        # Pinned, not `latest`: the action keys its download + analysis cache on
+        # the resolved version, so `latest` busts that cache fleet-wide whenever
+        # upstream releases, and a new linter can turn a green branch red with no
+        # repo change. Matches the version the services pin in golangci-lint.mod;
+        # Renovate bumps it.
+        version: v2.12.2
         working-directory: ${{ inputs.working-directory }}

--- a/go-actions/lint-go/action.yaml
+++ b/go-actions/lint-go/action.yaml
@@ -16,12 +16,24 @@ runs:
         # Go module is not at the repo root. An empty working-directory falls back
         # to the repo-root go.mod.
         go-version-file: ${{ inputs.working-directory && format('{0}/go.mod', inputs.working-directory) || 'go.mod' }}
+    # Resolve the golangci-lint version from the repo's own tool modfile, so CI
+    # lints with the exact version developers run locally (`go tool -modfile=
+    # golangci-lint.mod golangci-lint`). This is the single source of truth:
+    # Renovate bumps golangci-lint.mod and CI follows on the next run, with no
+    # version literal to keep in sync here — the workflow and the repo cannot
+    # drift, and `latest`'s fleet-wide cache-busting on every upstream release
+    # is avoided.
+    - id: golangci-version
+      shell: bash
+      run: |
+        dir='${{ inputs.working-directory }}'
+        version="$(cd "${dir:-.}" && go list -modfile=golangci-lint.mod -m -f '{{.Version}}' github.com/golangci/golangci-lint/v2)"
+        if [ -z "$version" ]; then
+          echo "::error::could not resolve golangci-lint version from golangci-lint.mod" >&2
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
     - uses: golangci/golangci-lint-action@v9
       with:
-        # Pinned, not `latest`: the action keys its download + analysis cache on
-        # the resolved version, so `latest` busts that cache fleet-wide whenever
-        # upstream releases, and a new linter can turn a green branch red with no
-        # repo change. Matches the version the services pin in golangci-lint.mod;
-        # Renovate bumps it.
-        version: v2.12.2
+        version: ${{ steps.golangci-version.outputs.version }}
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Summary

Two CI-hygiene changes (Build & CI performance, a-novel/.github#172):

1. **`go-actions/lint-go` derives the golangci-lint version from the consuming repo's `golangci-lint.mod`** (via `go list -modfile=…`) instead of hardcoding it or using `latest`. Single source of truth: CI lints with the exact version developers run locally, so the workflow and the repo can't drift. Renovate bumps only the `.mod` (an ordinary gomod dep) and the action picks it up automatically — no version literal here to keep in sync, so no Renovate rule is needed.
2. **Drop unused `setup-qemu`** from `build-actions/docker` + `docker-job` (no `platforms:` is ever set, so the binfmt install is pure waste).

Note: #1 makes `golangci-lint.mod` load-bearing for CI lint; all Go repos already have one. Ships as a minor.

Closes #278.

## Test plan

- [x] Consumer test (stack): lint-go resolves v2.12.2 from `cli/golangci-lint.mod` and lints green
- [x] buildx retained; QEMU removed; rebased on master (coexists with #291's skip_healthcheck); prettier clean
- [ ] workflows CI green