### PR TITLE
fix(renovate): stop bumping audit-managed pnpm override values

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -130,6 +130,11 @@ runs:
               "matchManagers": ["npm"],
               "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
               "groupName": "javascript dependencies"
+            },
+            {
+              "description": "Leave pnpm audit-managed overrides to the audit action. node-actions/audit runs `pnpm audit --fix=override` daily and pins vulnerable transitive dependencies to the minimal patched version within each consumer's supported range. Renovate's npm manager otherwise re-reads the override value as an ordinary dependency and bumps it to the latest major, pushing the pin past the parent's compatibility ceiling (e.g. undici v8 breaks jsdom's private wrap-handler.js deep-import). Audit owns these values; Renovate must not touch them.",
+              "matchDepTypes": ["pnpm.overrides", "overrides"],
+              "enabled": false
             }
           ]
         # Authenticate npm installs against the private GitHub Packages registry.


### PR DESCRIPTION
## Summary

- Renovate's npm manager was re-reading the `pnpm audit --fix=override` security pins in `pnpm-workspace.yaml` as ordinary dependencies and bumping their **values** to the latest major, past the parent package's compatibility ceiling.
- This surfaced as three failing Renovate PRs across the org (`service-json-keys#788`, `service-narrative-engine#380`, `service-template#351`), all bumping the transitive `undici` override `^7.28.0 → ^8.0.0`, which broke `jsdom` in the `pkg/js` tests (`Cannot find module 'undici/lib/handler/wrap-handler.js'` — a path undici v8 removed).
- Fix: disable Renovate updates for the `overrides` depType so the daily `node-actions/audit` run stays the sole owner of those transitive security pins.

## Why this is correct

- `node-actions/audit` runs `pnpm audit --fix=override` on a daily cron and pins vulnerable transitive deps to the **minimal patched version within each consumer's supported range** (undici → `7.28.0`).
- undici `7.28.0` is already patched against **every** known 7.x advisory; the v8 line had its own HIGH advisories through `8.5.0`. So forcing v8 gave zero security benefit — only breakage.
- Renovate should own *direct* dependencies; audit owns the security floor of *transitive* pins. This change stops the two from colliding.

## What changed

One rule appended (last, so it wins on precedence) to `RENOVATE_PACKAGE_RULES` in `generic-actions/renovate/action.yaml`:

```json
{ "matchDepTypes": ["pnpm.overrides", "overrides"], "enabled": false }
```

## Self-healing

No version cap to maintain. When a parent (e.g. jsdom) adopts undici v8 on its own, pnpm resolves v8 naturally, the stale 7.x override selectors go inert, and audit tracks the v8 line — no manual step.

## Rollout

Takes effect per repo after this ships in a `workflows` release and each repo re-pins its `@vX.Y.Z` ref. The three stale v8 PRs are being closed separately; Renovate will not recreate them once the rule lands.

## Test plan

- [x] `action.yaml` parses as YAML and `RENOVATE_PACKAGE_RULES` parses as JSON (15 rules)
- [x] No `${{ vars/secrets/needs/matrix }}` in the new block (composite-manifest LOAD footgun)
- [x] `prettier --check` clean