### PR TITLE
feat(build-actions): add skip_healthcheck to the docker action

### DIFF
--- a/build-actions/docker/action.yaml
+++ b/build-actions/docker/action.yaml
@@ -23,6 +23,12 @@ inputs:
     required: false
     description: Timeout (in deciseconds) for the container healthcheck.
     default: "300"
+  skip_healthcheck:
+    required: false
+    description: >
+      Skip the build-then-run smoke test (build + push only). Set true when the
+      image is exercised by a downstream job anyway, so the caller can drop the
+      service containers this smoke test would otherwise need.
   github_token:
     required: true
     description: The GitHub token to use for publication.
@@ -115,6 +121,7 @@ runs:
         secret-files: ${{ inputs.secret-files }}
         secrets: ${{ inputs.secrets }}
     - name: wait for container to be ready
+      if: ${{ inputs.skip_healthcheck != 'true' }}
       shell: bash
       run: |
         docker run -d --network="host" ${{ inputs.run_args }} --name test-container \


### PR DESCRIPTION
## Summary

Adds a `skip_healthcheck` input to `build-actions/docker`, mirroring the one `docker-job` already has. When `true`, the build-then-run smoke test (`docker run` + healthcheck wait) is skipped — the action just builds and pushes.

**Why:** a caller whose image is already booted and exercised by a downstream job doesn't need this action to smoke-test it too. The concrete case (a-novel/.github#172, A1 #1069): a service's `build-standalone-rest` boots a 3-container constellation just to smoke-test the standalone image, then `test-pkg-js` boots a 5-container constellation with that same image and runs real integration tests against it — validating its health far more thoroughly. With `skip_healthcheck: true` the build job can drop its `services:` block, removing a redundant constellation boot from the critical path.

Keystone for the service-side #1069 change (which adopts this after release).

## Test plan

- [ ] workflows CI green (action-manifest lint)
- [ ] Consumer test: a `build-*` job with `skip_healthcheck: true` and no `services:` builds+pushes and skips the run step