### PR TITLE
feat(derive-status): hotfix cleanup Task → Done on merge, not Awaiting-release

### DIFF
--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -97,7 +97,7 @@ runs:
         q='query($owner:String!,$repo:String!,$num:Int!){ repository(owner:$owner,name:$repo){
           pullRequest(number:$num){
             state isDraft reviewDecision
-            closingIssuesReferences(first:5){ nodes{ id number } } } } }'
+            closingIssuesReferences(first:5){ nodes{ id number labels(first:20){ nodes{ name } } } } } } }'
         # A not-found / inaccessible PR makes the GraphQL call error; catch that here so
         # it fails with a clear message rather than gh's raw error mid-pipeline.
         if ! pr=$(gh api graphql -f query="$q" -F owner="$OWNER" -F repo="$REPO" -F num="$PR"); then
@@ -121,6 +121,9 @@ runs:
         refs=$(echo "$pr" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes')
         ref_count=$(echo "$refs" | jq 'length')
         issue_id=$(echo "$refs" | jq -r 'sort_by(.number) | .[0].id // empty')
+        # Labels of the SELECTED closing issue — a hotfix cleanup Task carries `hotfix-reconcile`,
+        # which flips its terminal MERGED status from Awaiting-release to Done (see the MERGED case).
+        issue_labels=$(echo "$refs" | jq -c 'sort_by(.number) | (.[0].labels.nodes // []) | map(.name)')
         if [ "$ref_count" -gt 1 ]; then
           echo "::warning::PR #$PR closes $ref_count issues; deriving the lowest-numbered. The reconcile sweep covers the rest."
         fi
@@ -128,7 +131,16 @@ runs:
         # Pure function of the PR's current state — the reconcile sweep re-runs this
         # identically, so it must not depend on which event fired.
         case "$state" in
-          MERGED) status="Awaiting release" ;;
+          MERGED)
+            # A hotfix-reconcile cleanup Task is TERMINAL on merge — the forward-port landed, so the
+            # Task is Done. It is NOT awaiting a release (a hotfix cuts its own tag off the reconcile's
+            # baseline, so nothing else ships it), so skip the default Awaiting-release for it.
+            if printf '%s' "$issue_labels" | jq -e 'index("hotfix-reconcile")' >/dev/null 2>&1; then
+              status="Done"
+            else
+              status="Awaiting release"
+            fi
+            ;;
           CLOSED) status="Ready" ;; # closed unmerged → the attempt was abandoned; back to actionable
           OPEN)
             if [ "$draft" = "true" ]; then


### PR DESCRIPTION
Stage-5 (#94/#53) board special-case. A hotfix's per-hotfix **cleanup Task** (labeled `hotfix-reconcile`) is **terminal** the moment its `hotfix-reconcile/*` forward-port PR merges — the fix reached the default branch, and a hotfix cuts its own tag off the reconcile's baseline, so nothing else ships it. The default `MERGED → Awaiting release` mapping would strand it awaiting a release that never comes (and `archive-board-items` never clears it).

Fix: fetch the closing issue's labels in the derive query and map `MERGED → Done` when it carries `hotfix-reconcile`; every other merged PR keeps `Awaiting release`.

## Test plan
- [x] YAML parses; no `${{ vars }}`; prettier clean
- [x] jq special-case verified: `["hotfix-reconcile",…] → Done`; `["documentation"]`/`[] → Awaiting release`
- [ ] review + release (renovate re-pins the reconcile-board callers)