### PR TITLE
refactor(governance): extract 5 workflows into reusable *-run.yaml engines

### DIFF
--- a/.github/workflows/auto-approve-dependabot-run.yaml
+++ b/.github/workflows/auto-approve-dependabot-run.yaml
@@ -1,0 +1,93 @@
+name: auto-approve-dependabot (reusable)
+
+# The REUSABLE auto-approve-dependabot engine (workflow_call): every governed repo's thin
+# `auto-approve-dependabot.yaml` caller (repocfg-provisioned) calls this with its org creds. Runs in
+# the CALLER's context — it approves + queues the caller repo's trusted dependency-bot PRs.
+on:
+  workflow_call:
+    inputs:
+      client_id:
+        description: The [Agent] bot App client id — mints the approval token (a distinct identity whose review counts toward the required-approval rule).
+        required: true
+        type: string
+      dependency_bot_login:
+        description: Login of the trusted dependency bot (e.g. the org Renovate bot) whose PRs are auto-approved.
+        required: true
+        type: string
+      dependabot_security_login:
+        description: Login of the Dependabot security-updates bot whose PRs are auto-approved.
+        required: true
+        type: string
+    secrets:
+      bot_private_key:
+        description: The [Agent] bot App private key (PEM) — signs the approval token.
+        required: true
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == inputs.dependency_bot_login ||
+      github.event.pull_request.user.login == inputs.dependabot_security_login
+    # Every step runs on the minted App token; the default token is unused.
+    permissions: {}
+    steps:
+      # Approve as the App — a distinct identity from the bot author, and one whose
+      # review reliably counts toward the required-approval rule (a workflow's own
+      # token does not).
+      - name: Mint approval token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ inputs.client_id }}
+          private-key: ${{ secrets.bot_private_key }}
+          # No `owner`: approving + merging this one PR needs nothing org-wide, so
+          # the token stays scoped to the current repository (omitting `owner` +
+          # `repositories` scopes it there). Contrast the Projects-scoped actions.
+          permission-contents: write
+          permission-pull-requests: write
+
+      # A human push to the branch means the change needs real review, so approve
+      # only when every commit is the bot's own. Unknown authors count as non-bot,
+      # so the guard fails closed.
+      - name: Confirm every commit is the bot's
+        id: guard
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PR: ${{ github.event.pull_request.html_url }}
+          BOT: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          authors=$(gh pr view "$PR" --json commits \
+            -q '[.commits[].authors[].login // "unknown"] | unique | sort | join(",")')
+          if [ "$authors" != "$BOT" ]; then
+            echo "::notice::Not auto-approving — commits by '${authors:-unknown}', expected only '$BOT'."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # approve-bot runs `gh pr checkout`, so a base checkout must exist first.
+      - name: Check out
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.token.outputs.token }}
+          persist-credentials: false
+
+      - name: Approve
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: a-novel-kit/workflows/generic-actions/approve-bot@v1.17.0
+        with:
+          pull_request: ${{ github.event.pull_request.html_url }}
+          github_token: ${{ steps.token.outputs.token }}
+
+      # Put the approved PR in the merge queue so it merges hands-off. The queue
+      # re-validates the required checks on the group and owns the merge method;
+      # pass `--squash` (the org's only allowed method) so the command is explicit
+      # for any repo without a queue too — where there is a queue it just logs that
+      # the strategy is queue-controlled.
+      - name: Enable auto-merge
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PR: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR" --auto --squash

--- a/.github/workflows/epic-rollback-run.yaml
+++ b/.github/workflows/epic-rollback-run.yaml
@@ -1,0 +1,106 @@
+name: epic-rollback (reusable)
+
+# The REUSABLE epic-rollback engine (workflow_call): every governed repo's thin `epic-rollback.yaml`
+# admin-dispatch caller (repocfg-provisioned) calls this with its org creds + the operator's dispatch
+# inputs. Runs in the CALLER's context; nested actions are remote-pinned (`./` would resolve to the
+# caller, not here). Destructive escape hatch — the admin gate + typed confirmation live in the job.
+on:
+  workflow_call:
+    inputs:
+      epic_number:
+        description: The Epic number N to roll back (numeric).
+        required: true
+        type: string
+      confirm:
+        description: Type "revert-epic-<N>" exactly (e.g. revert-epic-42) to confirm you are reverting MERGED code.
+        required: true
+        type: string
+      reason:
+        description: Why INV-1 is violated (goes into the audit trail + the rollback-epic body).
+        required: true
+        type: string
+      dry_run:
+        description: "true (default) = print the plan only; false = actually open + land the reverts."
+        required: false
+        type: string
+        default: "true"
+      max_rollback_repos:
+        description: BLAST-CAP — abort if the rollback would touch more than this many distinct repos (default 5). Raise it deliberately for a genuinely wide rollback.
+        required: false
+        type: string
+        default: "5"
+      client_id:
+        description: The [Agent] bot App client id.
+        required: true
+        type: string
+      project_id:
+        description: Node id of the org "Tasks" board (PVT_…) — the rollback drives board state here.
+        required: true
+        type: string
+      kill_switch:
+        description: Org-level HALT token (FAIL-SAFE — RUNNING only for an explicit off-token; anything else engages). Threaded from the org variable.
+        required: false
+        type: string
+        default: ""
+    secrets:
+      app_private_key:
+        description: The [Agent] bot App private key (PEM).
+        required: true
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    # The default token is used only for the admin check (Metadata:read, always present); the
+    # rollback action mints its own least-privilege [Agent] tokens for every read and write.
+    permissions:
+      contents: read
+    steps:
+      # Fail closed unless the dispatcher is a repo admin, AND the epic number is numeric, AND
+      # the typed confirmation matches exactly. workflow_dispatch is open to any write user, so
+      # this gate is what keeps a destructive rollback admin-only + fat-finger-proof.
+      - name: Require admin + numeric epic + typed confirmation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          EPIC: ${{ inputs.epic_number }}
+          CONFIRM: ${{ inputs.confirm }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          # Admin gate (copied from a-novel-kit/workflows' generic-actions/approve-pr/action.yaml):
+          # `|| echo ""` keeps a failed lookup from tripping `set -e` — an empty permission falls
+          # through and fails closed.
+          perm=$(gh api "repos/${REPO_FULL}/collaborators/${ACTOR}/permission" -q '.permission' 2>/dev/null || echo "")
+          if [ "$perm" != "admin" ]; then
+            echo "::error::epic-rollback is admin-only; @${ACTOR} has permission '${perm:-none}'."
+            exit 1
+          fi
+          # Numeric validation before the number ever reaches the `label:"epic:<N>"` search grammar.
+          if ! [[ "${EPIC:-}" =~ ^[0-9]+$ ]]; then
+            echo "::error::epic_number must be an integer, got \"${EPIC:-}\"."
+            exit 1
+          fi
+          # Typed confirmation — defeats a fat-finger on a destructive op.
+          if [ "${CONFIRM:-}" != "revert-epic-${EPIC}" ]; then
+            echo "::error::confirmation mismatch — type \"revert-epic-${EPIC}\" exactly to proceed."
+            exit 1
+          fi
+          echo "@${ACTOR} is a repo admin; confirmation matches — proceeding with rollback of epic:#${EPIC} (dry_run=${DRY_RUN:-true})." | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - uses: a-novel-kit/workflows/generic-actions/epic-rollback@v1.17.0
+        with:
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.app_private_key }}
+          epic_number: ${{ inputs.epic_number }}
+          reason: ${{ inputs.reason }}
+          dry_run: ${{ inputs.dry_run }}
+          # BLAST-CAP: abort before any revert if the ledger spans more than this many repos.
+          max_rollback_repos: ${{ inputs.max_rollback_repos }}
+          # Org-level HALT (FAIL-SAFE — RUNNING only for an explicit off-token: empty/unset, 0, off,
+          # false, no, disabled; ANYTHING ELSE, incl. a fat-fingered value, engages) → the action
+          # aborts loud as its first step, before any mint. Threaded from the org variable (a
+          # composite action can't read `vars` itself).
+          kill_switch: ${{ inputs.kill_switch }}
+          # The org "Tasks" board id, inlined per-org the same way derive-status passes it.
+          project_id: ${{ inputs.project_id }}

--- a/.github/workflows/hotfix-run.yaml
+++ b/.github/workflows/hotfix-run.yaml
@@ -1,0 +1,291 @@
+name: hotfix (reusable)
+
+# The REUSABLE hotfix engine (workflow_call): every governed repo's thin `hotfix.yaml` dispatch caller
+# (repocfg-provisioned) calls this with its org creds. Runs in the CALLER's context — it patches the
+# caller repo. Nested actions are remote-pinned (`./` in a reusable resolves to the caller, not here).
+#
+# Patch an ALREADY-RELEASED line without touching the default branch. Dispatched from the UI (like
+# release.yaml — the protected `release` environment is the human "who may publish" gate), it cuts
+# an ephemeral branch from the latest live tag on the target X.Y line, applies the fix, and cuts a
+# vX.Y.(Z+1) tag via release-core-hotfix. The fix is then reconciled to master (added on this branch
+# next); this first layer is the cut path, drillable in dry-run.
+#
+# Kill-switch note: a hotfix is deliberately NOT gated on the org kill switch. The kill switch pauses
+# normal automation; the emergency PATCH path must stay open (it's human-gated by `release` + admin).
+on:
+  workflow_call:
+    inputs:
+      line:
+        description: 'X.Y line to patch (e.g. "1.4") — baseline auto-resolves to its latest live tag'
+        required: true
+        type: string
+      fix_ref:
+        description: "Git revision carrying the fix (a commit SHA, or an A..B range) to cherry-pick onto the baseline; empty = re-cut the baseline (drill)"
+        required: false
+        type: string
+        default: ""
+      severity:
+        description: Escalation severity if the hotfix fails (sev2 / sev1)
+        required: false
+        type: string
+        default: sev2
+      dry_run:
+        description: When true, no tag/release/reconcile PR/cleanup Task — only a transient ephemeral branch
+        required: false
+        type: boolean
+        default: true
+      client_id:
+        description: The [Agent] bot App client id.
+        required: true
+        type: string
+      project_id:
+        description: Node id of the org "Tasks" board (PVT_…) — escalate drives the failure ticket's Status here.
+        required: true
+        type: string
+      mention:
+        description: Threaded to escalate as the SEV1/SEV2 @mention (e.g. vars.SEV1_MENTION).
+        required: false
+        type: string
+        default: ""
+    secrets:
+      app_private_key:
+        description: The [Agent] bot App private key (PEM).
+        required: true
+      push_webhook:
+        description: Threaded to escalate as the SEV1 push webhook (empty = push channel off).
+        required: false
+
+jobs:
+  hotfix:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write # push the ephemeral branch + tag
+      actions: read # the lock step reads in-flight release runs
+    outputs:
+      baseline: ${{ steps.prepare.outputs.baseline }}
+      ephemeral: ${{ steps.prepare.outputs.ephemeral }}
+      fix_head: ${{ steps.prepare.outputs.fix_head }}
+      version: ${{ steps.cut.outputs.version }}
+      tag: ${{ steps.cut.outputs.tag }}
+      cleanup_task: ${{ steps.cleanup_task.outputs.number }}
+      reconcile_pr: ${{ steps.reconcile.outputs.pr_url }}
+      reconcile_conflicted: ${{ steps.reconcile.outputs.conflicted }}
+    steps:
+      # Bot-authenticated full checkout: the baseline tag, the fix, and the ephemeral-branch push all
+      # need the bot's rights + complete history and tags. release-core-hotfix re-checks-out the
+      # ephemeral branch itself later with its own token.
+      - name: Mint git token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ inputs.client_id }}
+          private-key: ${{ secrets.app_private_key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write # open the per-hotfix cleanup Task
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Asymmetric lock: wait out any in-flight release before cutting a hotfix, so the two never
+      # interleave. Only the hotfix waits — release.yaml never locks, so release-vs-release keeps its
+      # collision-fail. Best-effort ordering (a hotfix and a release compute different tags, so they
+      # can't collide); a small post-wait race is acceptable.
+      - name: Acquire lock (wait for in-flight release)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 1800)) # 30-minute cap → then abort (retry after the release lands)
+          while :; do
+            # Only an ACTIVELY-RUNNING release blocks: in_progress or queued. A release parked in
+            # `waiting` (pending its environment approval) is deliberately IGNORED — it may never be
+            # approved, and the emergency hotfix must not spin on an unapproved dispatch. A gh error →
+            # "err", retry (don't abort the emergency path on a transient API blip).
+            active=$(gh run list --repo "$REPO" --workflow release.yaml --limit 30 \
+              --json status --jq '[.[] | select(.status | IN("in_progress","queued"))] | length' 2>/dev/null || echo "err")
+            if [ "$active" = "0" ]; then
+              break
+            elif [ "$active" = "err" ]; then
+              echo "::warning::couldn't read in-flight release runs (gh error) — retrying in 30s."
+            else
+              echo "⏳ ${active} release run(s) actively in flight — waiting 30s before re-checking…"
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::a release has been actively in flight (or its status unreadable) > 30m — aborting the hotfix; retry once it completes."
+              exit 1
+            fi
+            sleep 30
+          done
+          echo "✓ no release actively in flight — proceeding." | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Resolve the baseline (latest live tag on the line), cut the ephemeral branch from it, apply
+      # the fix, and capture fix-HEAD BEFORE the bump — that SHA range (baseline..fix_head) is what
+      # reconciles to master (the fix diff only, never the bump). Push the branch so release-core-
+      # hotfix can check it out.
+      - name: Prepare ephemeral branch
+        id: prepare
+        env:
+          LINE: ${{ inputs.line }}
+          FIX_REF: ${{ inputs.fix_ref }}
+        run: |
+          set -euo pipefail
+
+          # Validate the line (guards the glob/grep below against a malformed or injected value) and
+          # escape its dots so the grep can't match a stray character (e.g. line 1.4 vs a tag v1x4.0).
+          if ! printf '%s' "$LINE" | grep -qE '^[0-9]+\.[0-9]+$'; then
+            echo "::error::line must be MAJOR.MINOR (e.g. 1.4), got \"$LINE\"."
+            exit 1
+          fi
+          line_re=$(printf '%s' "$LINE" | sed 's/\./\\./g')
+
+          # Baseline = highest vLINE.PATCH release tag (exclude sub-module tags <dir>/v… and pre-releases).
+          baseline=$(git tag -l "v${LINE}.*" | grep -E "^v${line_re}\.[0-9]+$" | sort -V | tail -1 || true)
+          if [ -z "$baseline" ]; then
+            echo "::error::no released tag on line v${LINE}.x — nothing to hotfix."
+            exit 1
+          fi
+          ephemeral="hotfix/v${LINE}.x"
+          echo "Baseline: \`$baseline\` → ephemeral branch \`$ephemeral\`." | tee -a "$GITHUB_STEP_SUMMARY"
+
+          git config user.name "${{ steps.token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+          # A leftover ephemeral branch from an aborted run would block a fresh cut — remove it first.
+          git push origin --delete "$ephemeral" 2>/dev/null || true
+          git checkout -b "$ephemeral" "$baseline"
+
+          # Apply the fix. A single SHA or an A..B range both work with cherry-pick -x (the -x trailer
+          # records the origin SHA, one of the signals the reconcile uses to prove the fix reached
+          # master). Empty fix_ref = a drill that just re-cuts the baseline.
+          if [ -n "${FIX_REF:-}" ]; then
+            # Reject a value git could parse as an option (leading dash) — fix_ref flows into git fetch
+            # + cherry-pick as a revision.
+            case "$FIX_REF" in -*) echo "::error::fix_ref must not begin with '-' (got \"$FIX_REF\")."; exit 1 ;; esac
+            # Make sure the fix commits are present (a fix pushed to another branch isn't fetched by
+            # the default checkout); harmless when FIX_REF is already reachable.
+            git fetch origin "$FIX_REF" 2>/dev/null || true
+            git cherry-pick -x "$FIX_REF"
+            echo "Applied fix \`$FIX_REF\`." | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No fix_ref — drill mode (re-cutting the baseline)." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+          fix_head=$(git rev-parse HEAD)
+          git push origin "$ephemeral"
+
+          # Restore the main workspace to the triggering commit so the local `./` actions (the cut,
+          # reconcile, and escalate steps) resolve from the CURRENT ref — not the old baseline this
+          # step checked out. release-core-hotfix re-checks-out the ephemeral branch from the remote.
+          git checkout --force "$GITHUB_SHA" >/dev/null 2>&1
+
+          {
+            echo "baseline=$baseline"
+            echo "ephemeral=$ephemeral"
+            echo "fix_head=$fix_head"
+          } >> "$GITHUB_OUTPUT"
+
+      # Cut the hotfix release from the ephemeral branch (patch bump, tag-only, --latest=false). In
+      # dry-run it bumps + reports without tagging/pushing.
+      - name: Cut hotfix
+        id: cut
+        uses: a-novel-kit/workflows/publish-actions/release-core-hotfix@v1.17.1
+        with:
+          ref: ${{ steps.prepare.outputs.ephemeral }}
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.app_private_key }}
+          dry_run: ${{ inputs.dry_run }}
+
+      # The per-hotfix cleanup Task: a durable, escalatable marker that the fix MUST reach the default
+      # branch. The reconcile PR `Closes` it; if it lingers open the fix never reconciled and the
+      # watchdog escalates. Per-hotfix identity (the version in the title) so concurrent hotfixes don't
+      # collapse into one marker. Only opened once the cut succeeded (nothing to reconcile otherwise).
+      - name: Open cleanup Task
+        id: cleanup_task
+        if: ${{ success() && steps.cut.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          LINE: ${{ inputs.line }}
+          VERSION: ${{ steps.cut.outputs.version }}
+          BASELINE: ${{ steps.prepare.outputs.baseline }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[dry-run] would open a hotfix-reconcile cleanup Task for v${VERSION}." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "number=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh label create hotfix-reconcile --repo "$REPO" --force \
+            --color FBCA04 --description "Tracks a hotfix's forward-port to the default branch." >/dev/null 2>&1 || true
+          body=$(printf 'The **v%s** hotfix (patched from `%s`) must be forward-ported to the default branch, or a later minor cut from it would silently reintroduce the fixed bug.\n\nA `hotfix-reconcile/*` PR `Closes` this Task when the fix lands. While this Task stays open the hotfix has NOT reconciled — the watchdog escalates a rotting reconcile.' "$VERSION" "$BASELINE")
+          url=$(gh issue create --repo "$REPO" --label hotfix-reconcile \
+            --title "Reconcile hotfix v${VERSION} to the default branch" --body "$body")
+          num=$(printf '%s' "$url" | grep -oE '[0-9]+$')
+          echo "Opened cleanup Task #${num} (${url})." | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "number=$num" >> "$GITHUB_OUTPUT"
+
+      # Forward-port the fix diff (never the bump) to the default branch — a squash hotfix-reconcile/*
+      # PR that Closes the cleanup Task, degrading a conflict to a draft PR. Runs BEFORE the ephemeral
+      # branch is deleted (it fetches the fix commits from it).
+      - name: Reconcile fix to the default branch
+        id: reconcile
+        if: ${{ success() && steps.cut.outcome == 'success' }}
+        uses: a-novel-kit/workflows/generic-actions/hotfix-reconcile@v1.17.1
+        with:
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.app_private_key }}
+          source_ref: ${{ steps.prepare.outputs.ephemeral }}
+          baseline: ${{ steps.prepare.outputs.baseline }}
+          fix_head: ${{ steps.prepare.outputs.fix_head }}
+          line: ${{ inputs.line }}
+          cleanup_task: ${{ steps.cleanup_task.outputs.number }}
+          dry_run: ${{ inputs.dry_run }}
+
+      # If the reconcile short-circuited (the fix was ALREADY on the default branch, patch-id match),
+      # no PR closes the cleanup Task — so close it here, or the watchdog would later escalate a hotfix
+      # that did reach master. reconcile has no issues:write; the git token (this job) does.
+      - name: Close cleanup Task (already reconciled)
+        if: ${{ success() && steps.reconcile.outputs.already_on_master == 'true' && steps.cleanup_task.outputs.number != '' && steps.cleanup_task.outputs.number != '0' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.cleanup_task.outputs.number }}
+        run: |
+          gh issue close "$NUM" --repo "$REPO" --reason completed \
+            --comment "The fix was already on the default branch (patch-id match) — no reconcile PR was needed."
+          echo "Closed cleanup Task #${NUM} (fix already on the default branch)." | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Any failure in the hotfix path pulls a human in — the emergency path must be loud, never silent.
+      # Passes the dispatch severity; a wired ESCALATE_PUSH_WEBHOOK pages SEV1. dry-run just logs it.
+      - name: Escalate on failure
+        if: ${{ failure() }}
+        uses: a-novel-kit/workflows/generic-actions/escalate@v1.17.1
+        with:
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.app_private_key }}
+          project_id: ${{ inputs.project_id }}
+          severity: ${{ inputs.severity }}
+          summary: "hotfix v${{ inputs.line }}.x failed"
+          dedup_key: "hotfix-failed:${{ github.repository }}:${{ inputs.line }}"
+          repo: ${{ github.repository }}
+          mention: ${{ inputs.mention }}
+          push_webhook: ${{ secrets.push_webhook }}
+          dry_run: ${{ inputs.dry_run }}
+
+      # Clean up the ephemeral branch — AFTER the reconcile fetched its commits. The tag (if cut)
+      # preserves the fix commit. always() so an earlier failure still cleans up.
+      - name: Clean up ephemeral branch
+        if: ${{ always() && steps.prepare.outputs.ephemeral != '' }}
+        env:
+          EPHEMERAL: ${{ steps.prepare.outputs.ephemeral }}
+        run: |
+          git push origin --delete "$EPHEMERAL" 2>/dev/null \
+            && echo "Deleted ephemeral branch \`$EPHEMERAL\`." | tee -a "$GITHUB_STEP_SUMMARY" \
+            || echo "Ephemeral branch \`$EPHEMERAL\` already gone."

--- a/.github/workflows/merge-gate-run.yaml
+++ b/.github/workflows/merge-gate-run.yaml
@@ -1,0 +1,88 @@
+name: merge-gate (reusable)
+
+# The REUSABLE merge-gate engine (workflow_call): every governed repo's thin `merge-gate.yaml` caller
+# (repocfg-provisioned) calls this with its org creds. Runs in the CALLER's context — it gates the
+# caller repo's PRs. Nested actions are remote-pinned (`./` in a reusable resolves to the caller, not here).
+#
+# The required "may this PR merge?" gate, plus the landing coordinator for epic members. Two jobs:
+#
+#   evaluate   — posts the required `merge-gate` check on every PR and on the merge queue's group (the
+#                queue validates required checks on the group, so the gate must post there too or a
+#                queued PR waits out the timeout and drops). The check is posted by the [Agent] App via
+#                the Checks API (a stable integration id the ruleset requires), so the job is only the
+#                runner — its id is deliberately NOT `merge-gate`, to avoid a duplicate check name. A
+#                standalone PR passes; an epic member holds until every sibling is ready (epic-atomicity).
+#
+#   auto-merge — enables native auto-merge on an epic member so the whole set lands together once the
+#                gate + approval go green. Enabling is safe while the gate is still red — GitHub parks it
+#                and merges when green. Live at `dry_run: "false"` — auto-merge is enabled for epic members.
+on:
+  workflow_call:
+    inputs:
+      client_id:
+        description: The [Agent] bot App client id.
+        required: true
+        type: string
+      kill_switch:
+        description: >-
+          Org-level HALT token, threaded from the caller's `vars.AGENT_KILL_SWITCH` (a composite action
+          can't read `vars` itself). FAIL-SAFE — RUNNING only for an explicit off-token (empty/unset, 0,
+          off, false, no, disabled); ANYTHING ELSE engages the org-wide hold. The value need not exist —
+          an unset caller var reads as empty, which is a running state.
+        required: false
+        type: string
+        default: ""
+    secrets:
+      app_private_key:
+        description: The [Agent] bot App private key (PEM).
+        required: true
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    # The gate mints its own [Agent] token (checks:write) and never uses the
+    # default token, so it needs no repository permissions of its own.
+    permissions: {}
+    steps:
+      - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.17.0
+        with:
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.app_private_key }}
+          # Org-level HALT (FAIL-SAFE — RUNNING only for an explicit off-token: empty/unset, 0, off,
+          # false, no, disabled; ANYTHING ELSE, incl. a fat-fingered value, engages) → the gate posts
+          # a `failure` HOLD on every PR, BEFORE any success path, so nothing merges org-wide.
+          # Threaded from the org variable (a composite action can't read `vars` itself). The variable
+          # need not exist to run — an unset value reads as empty, which is a running state.
+          kill_switch: ${{ inputs.kill_switch }}
+
+  auto-merge:
+    # Only where there is a PR to enable (pull_request events), and never on a draft.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    # The member check reads the event payload (no API); enable-auto-merge mints its
+    # own [Agent] token — so no default-token permissions are needed.
+    permissions: {}
+    steps:
+      - name: Is this an epic member?
+        id: member
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if printf '%s' "$LABELS" | grep -qE '"epic:[0-9]+"'; then
+            echo "member=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "member=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: ${{ steps.member.outputs.member == 'true' }}
+        uses: a-novel-kit/workflows/generic-actions/enable-auto-merge@v1.17.0
+        with:
+          pull_request_number: ${{ github.event.pull_request.number }}
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.app_private_key }}
+          # Live: auto-merge is enabled for epic members.
+          dry_run: "false"
+          # Org-level HALT (FAIL-SAFE — RUNNING only for an explicit off-token; ANYTHING ELSE engages)
+          # → do not arm auto-merge (merge-gate HOLDs anyway). NOTE: this does NOT disarm auto-merge
+          # ALREADY armed on an idle ready PR before the halt — merge-gate's red check still blocks it,
+          # with a brief latency window until the next event / reconcile sweep re-posts the hold.
+          kill_switch: ${{ inputs.kill_switch }}

--- a/.github/workflows/release-train-run.yaml
+++ b/.github/workflows/release-train-run.yaml
@@ -1,0 +1,81 @@
+name: release-train (reusable)
+
+# The REUSABLE release-train engine (workflow_call): every governed repo's thin `release-train.yaml`
+# dispatch caller (repocfg-provisioned) calls this with its org creds + admin dispatch inputs. Runs in
+# the CALLER's context. Nested actions are remote-pinned (`./` in a reusable resolves to the caller, not here).
+on:
+  workflow_call:
+    inputs:
+      epic_number:
+        description: The Epic number N to release (numeric).
+        required: true
+        type: string
+      dry_run:
+        description: "true (default) = rehearse every repo, cut nothing; false = actually cut the releases."
+        required: false
+        default: "true"
+        # Former `choice` dispatch input. workflow_call has no choice type, so the thin caller keeps the
+        # choice-typed UI/API guard and passes a validated string through here.
+        type: string
+      client_id:
+        description: The [Agent] bot App client id.
+        required: true
+        type: string
+      kill_switch:
+        description: >-
+          Org-level HALT token (threaded from vars.AGENT_KILL_SWITCH). FAIL-SAFE: RUNNING only for an
+          explicit off-token (empty/unset, 0, off, false, no, disabled); ANYTHING else engages the halt.
+        required: false
+        type: string
+        default: ""
+    secrets:
+      app_private_key:
+        description: The [Agent] bot App private key (PEM).
+        required: true
+
+jobs:
+  release-train:
+    runs-on: ubuntu-latest
+    # The default token is used only for the admin check (Metadata:read, always present); the
+    # release-train action mints its own least-privilege [Agent] tokens (dispatch + reads).
+    permissions:
+      contents: read
+    steps:
+      # Fail closed unless the dispatcher is a repo admin, AND the epic number is numeric.
+      # workflow_dispatch is open to any write user, so this gate is what keeps the release train
+      # admin-only.
+      - name: Require admin + numeric epic
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          EPIC: ${{ inputs.epic_number }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          # Admin gate (copied from a-novel-kit/workflows' generic-actions/approve-pr/action.yaml):
+          # `|| echo ""` keeps a failed lookup from tripping `set -e` — an empty permission falls
+          # through and fails closed.
+          perm=$(gh api "repos/${REPO_FULL}/collaborators/${ACTOR}/permission" -q '.permission' 2>/dev/null || echo "")
+          if [ "$perm" != "admin" ]; then
+            echo "::error::release-train is admin-only; @${ACTOR} has permission '${perm:-none}'."
+            exit 1
+          fi
+          # Numeric validation before the number ever reaches the `label:"epic:<N>"` search grammar.
+          if ! [[ "${EPIC:-}" =~ ^[0-9]+$ ]]; then
+            echo "::error::epic_number must be an integer, got \"${EPIC:-}\"."
+            exit 1
+          fi
+          echo "@${ACTOR} is a repo admin — proceeding with the release train for epic:#${EPIC} (dry_run=${DRY_RUN:-true})." | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - uses: a-novel-kit/workflows/generic-actions/release-train@v1.17.0
+        with:
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.app_private_key }}
+          epic_number: ${{ inputs.epic_number }}
+          dry_run: ${{ inputs.dry_run }}
+          # Org-level HALT (FAIL-SAFE — RUNNING only for an explicit off-token: empty/unset, 0, off,
+          # false, no, disabled; ANYTHING else, incl. a fat-fingered value, engages) → the action
+          # aborts loud as its first step, before any mint. Threaded from the org variable (a composite
+          # action can't read `vars` itself).
+          kill_switch: ${{ inputs.kill_switch }}


### PR DESCRIPTION
Each governed repo currently carries the **full body** of these governance workflows — bash, token-mint, action calls — **79–285 lines duplicated fleet-wide**. This extracts the logic into reusable `workflow_call` engines (the `reconcile-board`/`watchdog` pattern) so each per-repo copy becomes a **thin caller**: triggers + one `uses:`, no bash.

## New reusables (all `on: workflow_call`, remote-self-pinned actions)
| Reusable | Jobs |
|---|---|
| `hotfix-run.yaml` | hotfix |
| `merge-gate-run.yaml` | evaluate + auto-merge |
| `epic-rollback-run.yaml` | rollback |
| `release-train-run.yaml` | release-train |
| `auto-approve-dependabot-run.yaml` | auto-approve |

This PR **only adds** the reusables. The repo's existing `hotfix.yaml`/`merge-gate.yaml`/etc. stay as-is (repocfg-managed); the companion stack PR turns those templates into thin callers, and the next `a-novel repo sync` thins the workflows repo's own copies too.

Creds are threaded as `workflow_call` **inputs** (`client_id`, `project_id`, `kill_switch`, `mention`) and **secrets** (`app_private_key`, `push_webhook`). The thin-caller templates pin these **`@v1.19.0`** (this ships in the next release; v1.18.0 predates the reusables).

## Why it's safe
- Reusable job bodies are **byte-identical** to the current templates except `${{ vars.X }} → ${{ inputs.X }}`.
- **Required checks unaffected**: the ruleset requires `merge-gate`/`epic-freeze`, which are **Checks-API runs posted by the actions**, not job contexts (the merge-gate job was already named `evaluate`).
- Interface-completeness verified per caller.

## Test plan
- [x] all 5 reusables valid YAML, prettier-clean, actionlint clean (bar the known `create-github-app-token` `client-id` stale-schema false positive)
- [x] caller↔reusable interface completeness checked mechanically
- [ ] review → release **v1.19.0** → the stack thin-caller PR pins `@v1.19.0`
- [ ] post-deploy smoke: merge-gate on a test PR + a dry-run dispatch of each

Part of Stage-5 governance-template factorization.