### PR TITLE
feat(board): board-lifecycle consolidation — rules 3–6 (rollup, archive+close, sweep)

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -47,6 +47,14 @@ on:
           When "true" (default), the Epic status read-model only logs the table it would render; set
           "false" to rewrite it into each active Epic's issue body. Display-only (no board write, no
           check-run), so it flips live on its own schedule, independent of the other passes.
+      archive_dry_run:
+        required: false
+        type: string
+        default: "true"
+        description: >
+          When "true" (default), the Applied-archive pass only logs. Set "false" to archive + close
+          every org-wide "Applied" item (resolved escalation tickets, completed meta work that no
+          release ever ships). Independent of the other flags so it flips live on its own schedule.
     secrets:
       private_key:
         required: true
@@ -74,6 +82,24 @@ jobs:
           # and ENGAGES for anything else — so an unset variable runs, and a fat-fingered value halts.
           # Engaged → this writer no-ops.
           kill_switch: ${{ vars.AGENT_KILL_SWITCH }}
+
+  # Clear terminal META work off the board: archive + close every org-wide "Applied" item (a resolved
+  # escalation ticket, a completed meta task). Per-repo "Awaiting release" archival happens on each
+  # repo's publish (release.yaml → archive-board-items); this sweep handles the Applied items that no
+  # release ever ships. Independent of the rollup pass, so it flips live on its own schedule.
+  archive:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.17.0
+        with:
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.private_key }}
+          project_id: ${{ inputs.project_id }}
+          status: Applied
+          repo: "*"
+          close: "true"
+          dry_run: ${{ inputs.archive_dry_run }}
 
   # Enumerate ALL the org's open PRs (paginated) → matrices for the two per-PR passes.
   enumerate:

--- a/generic-actions/archive-board-items/action.yaml
+++ b/generic-actions/archive-board-items/action.yaml
@@ -1,10 +1,12 @@
 name: archive board items
 description: >
-  Archive a repository's "Awaiting release" items from the org "Tasks" project.
-  Run it from the release workflow when the repo publishes (everything on master
-  ships, so its awaiting-release work is now released), or — for repos that never
-  publish (e.g. .github) — on merge to the default branch, to clear shipped work
-  off the board automatically. Idempotent and safe to re-run.
+  Archive (and close) terminal items from the org "Tasks" project. Run it from the
+  release workflow when the repo publishes (everything on master ships, so its
+  awaiting-release work is now released), or — for repos that never publish (e.g.
+  .github) — on merge to the default branch. The reconcile sweep also runs it org-wide
+  (repo "*") over "Applied" items to clear resolved meta work. Archiving a Projects-v2
+  item does not close the issue, so it also CLOSES each one (archive = terminal signal).
+  Idempotent and safe to re-run.
 
 inputs:
   client_id:
@@ -18,7 +20,23 @@ inputs:
   status:
     required: false
     default: Awaiting release
-    description: Archive this repo's items whose Status equals this value.
+    description: >
+      Comma-separated list of Status values to archive (e.g. "Awaiting release" on
+      publish, or "Applied" for the sweep's meta pass). An item matches if its Status
+      is any of them.
+  repo:
+    required: false
+    default: ""
+    description: >
+      Restrict to this repo's items (owner/name). Empty = the running repo
+      (github.repository). Pass "*" to sweep ALL repos — used by the reconcile sweep
+      to clear org-wide Applied items that aren't tied to a single repo's release.
+  close:
+    required: false
+    default: "true"
+    description: >
+      Also CLOSE each archived issue. Archiving a Projects-v2 item does not close the
+      tracker; terminal board work should leave its issue closed too (rule: archived → closed).
   project_id:
     required: true
     description: >
@@ -44,13 +62,15 @@ runs:
         private-key: ${{ inputs.app_private_key }}
         owner: ${{ github.repository_owner }}
         permission-organization-projects: write
+        permission-issues: write # close each archived issue (rule: archived → closed)
 
-    - name: Archive this repo's awaiting-release items
+    - name: Archive (and close) terminal board items
       shell: bash
       env:
         GH_TOKEN: ${{ steps.token.outputs.token }}
-        REPO_FULL: ${{ github.repository }}
+        REPO_IN: ${{ inputs.repo }}
         STATUS: ${{ inputs.status }}
+        CLOSE: ${{ inputs.close }}
         PROJECT_ID: ${{ inputs.project_id }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
@@ -62,6 +82,9 @@ runs:
           echo "::error::project_id is required (the org \"Tasks\" board node id)"
           exit 1
         fi
+
+        # Repo scope: empty → the running repo; "*" → every repo (the org-wide sweep).
+        REPO_FULL="${REPO_IN:-$GITHUB_REPOSITORY}"
 
         # Page the board, keeping this repo's still-on-board items in $STATUS.
         #    isArchived guards idempotency: an already-archived item is skipped,
@@ -84,12 +107,13 @@ runs:
           [ -n "$cursor" ] && args+=(-F cursor="$cursor")
           resp=$(gh api graphql -f query="$items_q" "${args[@]}")
           echo "$resp" | jq -c --arg repo "$REPO_FULL" --arg status "$STATUS" '
-            .data.node.items.nodes[]
+            ($status | split(",") | map(gsub("^\\s+|\\s+$";""))) as $statuses
+            | .data.node.items.nodes[]
             | select(
                 (.isArchived | not)
-                and .status.name == $status
-                and (.content.repository.nameWithOwner // "") == $repo)
-            | {id, number: .content.number, url: .content.url}' >> "$matches"
+                and ((.status.name // "") as $sn | ($statuses | any(. == $sn)))
+                and ($repo == "*" or (.content.repository.nameWithOwner // "") == $repo))
+            | {id, number: .content.number, url: .content.url, repo: (.content.repository.nameWithOwner // "")}' >> "$matches"
           [ "$(echo "$resp" | jq -r '.data.node.items.pageInfo.hasNextPage')" = "true" ] || break
           cursor=$(echo "$resp" | jq -r '.data.node.items.pageInfo.endCursor')
         done
@@ -105,10 +129,17 @@ runs:
           id=$(echo "$row" | jq -r '.id')
           num=$(echo "$row" | jq -r '.number')
           url=$(echo "$row" | jq -r '.url')
+          rp=$(echo "$row" | jq -r '.repo')
+          verb=$([ "$CLOSE" = "true" ] && echo "archive+close" || echo "archive")
           if [ "$DRY_RUN" = "true" ]; then
-            echo "- [dry-run] would archive #$num ($url)" | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "- [dry-run] would $verb #$num ($url)" | tee -a "$GITHUB_STEP_SUMMARY"
           else
             gh api graphql -f query="$archive_m" -F proj="$proj_id" -F item="$id" >/dev/null
-            echo "- archived #$num ($url)" | tee -a "$GITHUB_STEP_SUMMARY"
+            # Close the tracker too — archiving a board item does NOT close the issue. Best-effort:
+            # a board item that is a PR/draft has no closable issue, so tolerate a failure.
+            if [ "$CLOSE" = "true" ] && [ -n "$num" ] && [ "$num" != "null" ] && [ -n "$rp" ] && [ "$rp" != "null" ]; then
+              gh issue close "$num" --repo "$rp" --reason completed >/dev/null 2>&1 || true
+            fi
+            echo "- ${verb}d #$num ($url)" | tee -a "$GITHUB_STEP_SUMMARY"
           fi
         done < "$matches"

--- a/generic-actions/rollup-board/action.yaml
+++ b/generic-actions/rollup-board/action.yaml
@@ -52,6 +52,7 @@ runs:
         private-key: ${{ inputs.app_private_key }}
         owner: ${{ github.repository_owner }}
         permission-organization-projects: write
+        permission-issues: write # close a parent whose sub-issues are all closed (rule 5/6 archival)
 
     - name: Roll up epics
       shell: bash
@@ -127,8 +128,8 @@ runs:
               'items(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{id '
               'status:fieldValueByName(name:"Status"){... on ProjectV2ItemFieldSingleSelectValue{name}} '
               'start:fieldValueByName(name:"Start date"){... on ProjectV2ItemFieldDateValue{date}} '
-              'content{... on Issue{number repository{nameWithOwner} issueType{name} '
-              'parent{number repository{nameWithOwner}} subIssues(first:1){totalCount}}}}}}}}')
+              'content{... on Issue{number state repository{nameWithOwner} issueType{name} '
+              'parent{number repository{nameWithOwner}} subIssues(first:50){totalCount nodes{state}}}}}}}}}')
         items, cursor = [], ""
         while True:
             d = gh(iq, proj=PROJECT, **({"cursor": cursor} if cursor else {}))
@@ -169,9 +170,31 @@ runs:
             return ORDER[mx]                # all pre-work → most-ready
 
         changes = 0
+        archived = 0
+        arch_m = 'mutation($p:ID!,$i:ID!){archiveProjectV2Item(input:{projectId:$p,itemId:$i}){item{id}}}'
         for e in epics:
             c = e["content"]
             ek = "%s#%s" % (c["repository"]["nameWithOwner"], c["number"])
+
+            # Parent-archival (rules 5/6): once EVERY sub-issue is closed (children get archived+closed
+            # on publish), the parent is terminal — archive it off the board and close its tracker. It
+            # propagates up over successive passes (Task -> Feature -> Epic -> Initiative). Guard on the
+            # full node set: an epic with >50 sub-issues isn't fully seen here, so fall through to status.
+            sub = c.get("subIssues") or {}
+            tc = sub.get("totalCount", 0)
+            nodes = sub.get("nodes") or []
+            if tc > 0 and tc <= len(nodes) and all(n.get("state") == "CLOSED" for n in nodes):
+                archived += 1
+                emit("- %s %s: all %d sub-issue(s) closed -> archive + close"
+                     % ("would archive" if DRY else "archived", ek, tc))
+                if not DRY:
+                    gh(arch_m, p=PROJECT, i=e["id"])
+                    if c.get("state") == "OPEN":
+                        subprocess.run(["gh", "issue", "close", str(c["number"]),
+                                        "--repo", c["repository"]["nameWithOwner"], "--reason", "completed"],
+                                       check=False, capture_output=True)
+                continue
+
             kids = children.get(ek, [])
             if not kids:
                 continue
@@ -195,7 +218,7 @@ runs:
                     gh('mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}',
                        p=PROJECT, i=e["id"], f=sfield["id"], o=opt[new])
 
-        emit("\nrollup-board: %d epic(s) scanned, %d change(s) (%s)." % (len(epics), changes, "DRY RUN — no writes" if DRY else "written"))
+        emit("\nrollup-board: %d parent(s) scanned, %d status change(s), %d archived (%s)." % (len(epics), changes, archived, "DRY RUN — no writes" if DRY else "written"))
         if summary:
             summary.close()
         PY

--- a/generic-actions/rollup-board/action.yaml
+++ b/generic-actions/rollup-board/action.yaml
@@ -1,17 +1,18 @@
 name: rollup-board
 description: >
-  Roll each epic's board Status + Start date up from its direct children, as the
-  [Agent] App. For every epic on the board it aggregates its children's statuses into
-  one epic status — all-terminal → the least-advanced terminal (an epic isn't released
-  until every child is); any child active, or a mix of done and not-done → In progress;
-  all pre-work → the most-ready — and sets the epic's Start date to the earliest child's.
-  Deep trees converge over successive runs (it rolls up direct children each pass), so
-  it is eventually consistent under the periodic reconcile sweep that invokes it.
+  Roll each parent's board Status + Start date up from its direct children, as the
+  [Agent] App. For every Epic / Feature / Initiative on the board it aggregates its
+  children's statuses into one parent status — the FLOOR (least-advanced child) once all
+  children are In review or above (so all-In-review → In review, all-Awaiting-release →
+  Awaiting release, an Applied meta child counting as ≥ Awaiting release); any child still
+  below In review → In progress; all pre-work → the most-ready — and sets the parent's
+  Start date to the earliest child's. Deep trees (Initiative → Epic → Feature → Task)
+  converge over successive runs (it rolls up direct children each pass), so it is
+  eventually consistent under the periodic reconcile sweep that invokes it.
 
   Ships read-only: with dry_run "true" (the default) it only logs what it would change,
   so the aggregation can be validated against the live board before it starts moving
-  statuses. Initiatives (lifecycle Tracking/Applied) are left alone — only Epics/Features
-  roll up.
+  statuses.
 
 inputs:
   client_id:
@@ -117,7 +118,7 @@ runs:
         # the rollup never drifts from what the board actually defines.
         ORDER = [o["name"] for o in sfield.get("options", [])]
         RANK = {s: i for i, s in enumerate(ORDER)}
-        for needed in ("Done", "In progress"):
+        for needed in ("In review", "Done", "In progress"):
             if needed not in RANK:
                 raise SystemExit("::error::rollup-board: board Status is missing the %r option" % needed)
 
@@ -151,7 +152,9 @@ runs:
                 pk = "%s#%s" % (p["repository"]["nameWithOwner"], p["number"])
                 children.setdefault(pk, []).append(it)
             typ = (c.get("issueType") or {}).get("name")
-            if (c.get("subIssues") or {}).get("totalCount", 0) > 0 and typ in ("Epic", "Feature"):
+            # Any parent with children rolls up — Initiatives included (rule 6), so an
+            # Initiative reaches Awaiting release once all its Epics do, over successive passes.
+            if (c.get("subIssues") or {}).get("totalCount", 0) > 0 and typ in ("Epic", "Feature", "Initiative"):
                 epics.append(it)
 
         def rollup_status(kids):
@@ -159,9 +162,9 @@ runs:
             if not rs:
                 return None
             mn, mx = min(rs), max(rs)
-            if mn >= RANK["Done"]:          # all terminal → least-advanced terminal
-                return ORDER[mn]
-            if mx >= RANK["In progress"]:   # any active, or a mix of done + not-done
+            if mn >= RANK["In review"]:     # ALL children In review or above → the floor
+                return ORDER[mn]            # (In review / Done / Awaiting release / Applied)
+            if mx >= RANK["In progress"]:   # some child still below In review → In progress
                 return "In progress"
             return ORDER[mx]                # all pre-work → most-ready
 


### PR DESCRIPTION
Makes the board-lifecycle rules "strictly apply" (companion to a stack docs PR for the cross-ref linkage discipline). Rules 1–2 already held for the linked issue via `derive-status`; this closes rules 3–6.

## Changes
- **`rollup-board`** — (rule 5) emit **In review** (the floor triggers at In review, not Done, so all-children-In-review rolls the parent to In review); (rule 6) roll up **Initiatives**, not just Epics/Features; (rules 5/6 archival) **archive + close a parent once every sub-issue is closed**, propagating up over sweep passes. Token gains `issues:write`. Halt- and dry-run-guarded.
- **`archive-board-items`** — (rule 4) **close** each archived issue (archiving a board item never closed the tracker — this was fully missing); (rule 3) accept a comma-separated status list + a `repo="*"` all-repos scope so the sweep can clear org-wide **`Applied`** meta work (fixes the `escalate` latent bug — resolved tickets sat `Applied` forever).
- **`reconcile-board`** — new **`archive`** job runs the Applied archive+close pass org-wide, with an independent `archive_dry_run` flag.

## Verification
- `rollup-board`: unit-tested across the status ladder (all-In-review→In review, Applied counts as ≥ Awaiting release, etc.); python compiles; **dry-run on the live board** — the 3 real parents (all with open sub-issues) correctly do NOT archive and status rollup is right.
- `archive-board-items`: **end-to-end on the spike repo** — an "Awaiting release" item → archived off the board + issue **CLOSED**; then cleaned up.
- Both composites stay manifest-safe (0 `vars`/`secrets`); prettier clean.

## Deploy notes (⚠ ordering)
- The `reconcile-board` action pins (`rollup-board`, `archive-board-items`) stay `@v1.17.0`; they must **bump to the release carrying these fixes** (Renovate, post-release) for the new sweep behavior to take effect.
- Then the operator flips the reconcile-board caller's `rollup_dry_run` / `archive_dry_run` → `false` (staged, like the detector), after a dry-run cycle validates.
- Per-repo publish archival (`release.yaml → archive-board-items`) now also closes — no caller change needed there.

Part of Stage-5.5 board consolidation.