### PR TITLE
chore(reconcile-board): point the sweep at v1.19.1 (activate the board consolidation)

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/rollup-board@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/rollup-board@v1.19.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.19.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -176,7 +176,7 @@ jobs:
           permission-contents: read
           permission-issues: read
           permission-pull-requests: read
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.19.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -200,7 +200,7 @@ jobs:
       matrix:
         pr: ${{ fromJSON(needs.enumerate.outputs.epic_prs) }}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.19.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.19.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
@@ -239,7 +239,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/render-epic-status@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/render-epic-status@v1.19.1
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}


### PR DESCRIPTION
The board-consolidation fixes shipped in **v1.19.1** (#295), but the reconcile sweep still pinned every action `@v1.17.0` — so it kept running the **old** code and nothing changed. This bumps all six sweep action pins to `v1.19.1`.

Still **dry by default** — this only makes the sweep *run the fixed logic*; it writes nothing until the caller flips `rollup_dry_run` / `archive_dry_run`.

**Deploy chain after this merges:** release workflows → the per-org reconcile-board callers bump to the new tag (Renovate; they're currently drifted at `v1.17.1` / `v1.19.0`) → watch one dry sweep cycle's logs → flip the two dry_run flags to `false`.