### PR TITLE
feat(board): closed → archive pass (feature + sweep wiring)

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -100,6 +100,17 @@ jobs:
           repo: "*"
           close: "true"
           dry_run: ${{ inputs.archive_dry_run }}
+      # Rule-4 complement: archive every board item whose ISSUE is CLOSED (org-wide) — done leaf
+      # planning issues in non-publishing .github never get archived by a publish otherwise, so this
+      # keeps closed ⟺ archived true on the board. Idempotent with the Applied pass above.
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.19.2
+        with:
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.private_key }}
+          project_id: ${{ inputs.project_id }}
+          archive_closed: "true"
+          repo: "*"
+          dry_run: ${{ inputs.archive_dry_run }}
 
   # Enumerate ALL the org's open PRs (paginated) → matrices for the two per-PR passes.
   enumerate:

--- a/generic-actions/archive-board-items/action.yaml
+++ b/generic-actions/archive-board-items/action.yaml
@@ -37,6 +37,13 @@ inputs:
     description: >
       Also CLOSE each archived issue. Archiving a Projects-v2 item does not close the
       tracker; terminal board work should leave its issue closed too (rule: archived → closed).
+  archive_closed:
+    required: false
+    default: "false"
+    description: >
+      When "true", IGNORE `status` and archive every board item whose linked ISSUE is CLOSED
+      (the rule-4 complement: closed → archived). The sweep runs this org-wide (repo="*") to
+      clear done leaf planning issues that never publish, so closed ⟺ archived on the board.
   project_id:
     required: true
     description: >
@@ -71,6 +78,7 @@ runs:
         REPO_IN: ${{ inputs.repo }}
         STATUS: ${{ inputs.status }}
         CLOSE: ${{ inputs.close }}
+        ARCHIVE_CLOSED: ${{ inputs.archive_closed }}
         PROJECT_ID: ${{ inputs.project_id }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
@@ -97,7 +105,7 @@ runs:
                 status: fieldValueByName(name:"Status"){
                   ... on ProjectV2ItemFieldSingleSelectValue{ name } }
                 content{
-                  ... on Issue{ repository{ nameWithOwner } number url }
+                  ... on Issue{ repository{ nameWithOwner } number url state }
                   ... on PullRequest{ repository{ nameWithOwner } number url } } } } } } }'
 
         matches=$(mktemp)
@@ -106,12 +114,14 @@ runs:
           args=(-F proj="$proj_id")
           [ -n "$cursor" ] && args+=(-F cursor="$cursor")
           resp=$(gh api graphql -f query="$items_q" "${args[@]}")
-          echo "$resp" | jq -c --arg repo "$REPO_FULL" --arg status "$STATUS" '
+          echo "$resp" | jq -c --arg repo "$REPO_FULL" --arg status "$STATUS" --arg closed "$ARCHIVE_CLOSED" '
             ($status | split(",") | map(gsub("^\\s+|\\s+$";""))) as $statuses
             | .data.node.items.nodes[]
             | select(
                 (.isArchived | not)
-                and ((.status.name // "") as $sn | ($statuses | any(. == $sn)))
+                and (if $closed == "true"
+                     then (.content.state == "CLOSED")
+                     else ((.status.name // "") as $sn | ($statuses | any(. == $sn))) end)
                 and ($repo == "*" or (.content.repository.nameWithOwner // "") == $repo))
             | {id, number: .content.number, url: .content.url, repo: (.content.repository.nameWithOwner // "")}' >> "$matches"
           [ "$(echo "$resp" | jq -r '.data.node.items.pageInfo.hasNextPage')" = "true" ] || break
@@ -119,7 +129,8 @@ runs:
         done
 
         count=$(grep -c '' "$matches" || true)
-        echo "Found ${count:-0} '$STATUS' item(s) for $REPO_FULL." | tee -a "$GITHUB_STEP_SUMMARY"
+        kind=$([ "$ARCHIVE_CLOSED" = "true" ] && echo "closed" || echo "'$STATUS'")
+        echo "Found ${count:-0} ${kind} item(s) for $REPO_FULL." | tee -a "$GITHUB_STEP_SUMMARY"
         [ "${count:-0}" -eq 0 ] && exit 0
 
         # Archive each match (or just report, under dry-run).


### PR DESCRIPTION
The rule-4 complement the **ultimate test** surfaced: closed **leaf** planning issues never auto-archive — archival is publish-triggered + repo-scoped, but planning issues live in non-publishing `.github`, and the Applied pass only catches `Applied`. So done Features sat *closed but on the board*. This closes that (`closed ⟺ archived`) and wires it into the sweep.

## Changes
- **`archive-board-items`**: new **`archive_closed`** input — when `"true"`, ignore `status` and archive every board item whose linked **issue is CLOSED**. Query selects `Issue.state`; match branches on it. (`archive_closed=true` → CLOSED only; `false` → the `status` list, unchanged — both verified.)
- **`reconcile-board`**: a second `archive` step runs the closed pass org-wide (`repo:"*"`, gated by `archive_dry_run`), next to the Applied pass.

## Depends on #299 (merge together)
The new sweep step pins `archive-board-items@v1.19.2` (which predates `archive_closed`) — that's fine **because of #299**: the release-core self-pin sync rewrites it to the release carrying `archive_closed` on publish. No circular pin, no follow-up bump. Before that release the callers still run the old sweep, so there's no dangerous interim.

## Deploy
Merge **#298 + #299** → one release → callers bump `reconcile-board@…` (Renovate) → the closed pass runs live. The board then fully self-cleans; the manual archive step from the ultimate test is never needed again.

Manifest-safe, prettier clean. Finishes the Stage-5.5 board consolidation.