### PR TITLE
fix(release-core): sync internal self-pins to the released version on publish

### DIFF
--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -155,6 +155,21 @@ runs:
           printf '%s\n' "$tags" | sed 's/^/- `/; s/$/`/'
         } | tee -a "$GITHUB_STEP_SUMMARY"
 
+        # Internal-consistency: rewrite every self-reference to THIS repo's own actions/workflows
+        # (owner/repo/...@vX.Y.Z) to the version being cut, so the released tag runs its OWN siblings —
+        # not whatever older tag the pins lagged at. A reusable workflow can't use a relative ref, so its
+        # sibling pins would otherwise always trail a release (Renovate bumps them, but each bump needs
+        # its own release, so the tag is forever one behind). Only self-refs are rewritten; cross-repo pins
+        # stay Renovate-managed. A no-op in a repo that doesn't self-reference. Discarded under dry-run.
+        repo_esc=$(printf '%s' "$GITHUB_REPOSITORY" | sed 's/\./\\./g')
+        selfpin_files=$(git ls-files '*.yaml' '*.yml' | xargs -r grep -lE "${repo_esc}/[A-Za-z0-9._/-]+@v[0-9]+\.[0-9]+\.[0-9]+" 2>/dev/null || true)
+        if [ -n "$selfpin_files" ]; then
+          printf '%s\n' "$selfpin_files" | while IFS= read -r f; do
+            sed -i -E "s#(${repo_esc}/[A-Za-z0-9._/-]+)@v[0-9]+\.[0-9]+\.[0-9]+#\1@v${version}#g" "$f"
+          done
+          { echo "Self-pins synced → v${version}:"; printf '%s\n' "$selfpin_files" | sed 's/^/- /'; } | tee -a "$GITHUB_STEP_SUMMARY"
+        fi
+
         if [ "$DRY_RUN" = "true" ]; then
           echo "[dry-run] no commit, tag, push, or release." | tee -a "$GITHUB_STEP_SUMMARY"
           git checkout -- . 2>/dev/null || true


### PR DESCRIPTION
**The lagging-self-pin bug**, fixed at the source.

A reusable workflow can't reference a sibling action relatively (`./` resolves to the *caller*), so it pins it **by version** — and nothing rewrote those pins on release. So a reusable at `vN` ran its siblings at whatever older tag Renovate had reached; and since each Renovate bump needs its *own* release to ship, the tag is **forever one behind**. That silently shipped releases that ran stale internals — e.g. `reconcile-board.yaml@v1.19.1` still executed `rollup-board@v1.17.0`, which is exactly why the board fixes went inert and needed a follow-up bump.

**Fix:** in `release-core`, right before the commit+tag, rewrite every self-reference to **this repo's own** actions/workflows (`github.repository/…@vX.Y.Z`) to the version being cut. The released tag now runs its own siblings.

- Only **self-refs** are touched (`a-novel-kit/workflows/…`); cross-repo pins stay Renovate-managed.
- **No-op** in a repo that doesn't self-reference (services, libs).
- **Discarded under dry-run** (the working tree is reverted).
- Manifest-safe (0 `vars`/`secrets`), prettier clean.

**Verified:** the rewrite hits all **26** self-pinning files and leaves `actions/checkout@v7`, `actions/create-github-app-token@v3`, and cross-repo refs untouched.

Merge alongside **#298** — from then on, every publish is internally consistent and the whole class of "wiring/bump" follow-up PRs (#296-style) disappears: a fix in an action is live in its reusables the instant it releases.