### PR TITLE
fix(release-core): grant workflows:write so the self-pin sync can push

### DIFF
--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -51,8 +51,10 @@ runs:
           exit 1
         fi
 
-    # Token that can push the bump commit + tag and create the release. Scoped
-    # to this repo and to contents only — the [Agent] App can do more.
+    # Token that can push the bump commit + tag and create the release, scoped to this repo.
+    # `workflows` is required alongside `contents`: the self-pin sync rewrites the version in
+    # `.github/workflows/*` self-refs, and GitHub refuses an App push that touches workflow files
+    # without it (contents alone → GH013 "without workflows permission"). The [Agent] App has it.
     - name: Mint push token
       id: token
       uses: actions/create-github-app-token@v3
@@ -62,6 +64,7 @@ runs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
         permission-contents: write
+        permission-workflows: write
 
     # Bot-authenticated checkout so the later push carries the bot's rights;
     # full history + tags so the tag and release notes resolve correctly.


### PR DESCRIPTION
**Fixes the failed v1.19.3 release.** #299's self-pin sync also rewrites version refs in `.github/workflows/*` (the reusable-workflow → action pins — the whole point), but release-core's token only requested `contents: write`. GitHub refuses an App push that touches workflow files without `workflows` permission:

```
GH013: refusing to allow a GitHub App to create or update workflow
`.github/workflows/approve-pr.yaml` without `workflows` permission
```

So the push was rejected **before any tag was cut** — master stayed clean, no `v1.19.3`.

**Fix:** add `permission-workflows: write` to the release token (the [Agent] App has it). No-op for repos without workflow self-refs. `release.yaml` runs `./publish-actions/release-core` locally, so this self-activates on the next release.

Merge → re-run the release and it goes green.