### PR TITLE
fix(renovate): hold pnpm 11.12.0 and typescript v7 fleet-wide

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -62,8 +62,8 @@ runs:
         RENOVATE_ASSIGN_AUTOMERGE: true
         RENOVATE_ASSIGNEES_FROM_CODE_OWNERS: true
         RENOVATE_LABELS: "['dependencies', 'renovate']"
-        # TODO: two temporary allowedVersions holds below — drop each once its condition
-        # clears (see the rule descriptions). Tracked in #308.
+        # TODO: two temporary allowedVersions holds below — drop each once its condition clears
+        # (see the rule descriptions). Tracked in https://github.com/a-novel-kit/workflows/issues/308
         RENOVATE_PACKAGE_RULES: |
           [
             {

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -62,10 +62,8 @@ runs:
         RENOVATE_ASSIGN_AUTOMERGE: true
         RENOVATE_ASSIGNEES_FROM_CODE_OWNERS: true
         RENOVATE_LABELS: "['dependencies', 'renovate']"
-        # TODO(deps): the two allowedVersions holds in the rules below are temporary. pnpm is
-        # held off 11.12.0 (its own self-installer is broken) and typescript off v7 (prettier's
-        # .ts-config loader and typescript-eslint don't support the native rewrite yet). Each
-        # rule's description carries its exact removal condition — delete the rule once it is met.
+        # TODO: two temporary allowedVersions holds below — drop each once its condition
+        # clears (see the rule descriptions). Tracked in #308.
         RENOVATE_PACKAGE_RULES: |
           [
             {

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -62,6 +62,10 @@ runs:
         RENOVATE_ASSIGN_AUTOMERGE: true
         RENOVATE_ASSIGNEES_FROM_CODE_OWNERS: true
         RENOVATE_LABELS: "['dependencies', 'renovate']"
+        # TODO(deps): the two allowedVersions holds in the rules below are temporary. pnpm is
+        # held off 11.12.0 (its own self-installer is broken) and typescript off v7 (prettier's
+        # .ts-config loader and typescript-eslint don't support the native rewrite yet). Each
+        # rule's description carries its exact removal condition — delete the rule once it is met.
         RENOVATE_PACKAGE_RULES: |
           [
             {

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -70,6 +70,16 @@ runs:
               "automerge": true
             },
             {
+              "description": "Hold pnpm off 11.12.0: that release regressed pnpm's own global self-installer (createFullPkgId throws 'Cannot use in operator to search for integrity in undefined'), so pnpm/action-setup crashes during CI setup the moment a repo bumps its packageManager field to it. The range allows every other version, so Renovate resumes bumping as soon as a fixed patch (11.12.1+) ships — drop this rule then.",
+              "matchPackageNames": ["pnpm"],
+              "allowedVersions": "<11.12.0 || >11.12.0"
+            },
+            {
+              "description": "Hold TypeScript on the v6 line until the toolchain supports the v7 native-compiler rewrite. TS7 removes JS-API surface prettier's .ts-config loader relies on (it reads an undefined ModuleKind member and throws), and typescript-eslint still caps its peer range at typescript <6.1.0, so a frozen-lockfile install fails on the unmet peer. Drop this rule once typescript-eslint's peer range admits v7.",
+              "matchPackageNames": ["typescript"],
+              "allowedVersions": "<7"
+            },
+            {
               "description": "Match pnpm's minimumReleaseAge supply-chain gate, scoped to the npm manager (which is what Renovate uses for pnpm: pnpm-lock.yaml, workspaces, catalogs) so it doesn't open/rebase PRs for packages too fresh to pass pnpm install. Other ecosystems (gomod, docker, github-actions) aren't gated by pnpm, so they keep landing security patches without delay. Keep >= pnpm's value (defined in nodelib-config).",
               "matchManagers": ["npm"],
               "minimumReleaseAge": "3 days"


### PR DESCRIPTION
## Why

Renovate is opening dependency PRs fleet-wide that cannot pass CI. Two updates fail identically across every repo in both orgs (the `eslint v10.7.0` bumps pass, so it is specific to these two):

- **`pnpm → 11.12.0`** — `pnpm/action-setup` crashes during CI setup (`Cannot use 'in' operator to search for 'integrity' in undefined`) the moment a repo bumps its `packageManager` field. This is a regression in pnpm 11.12.0's own global self-installer, not our config.
- **`typescript → v7`** — TS7 is the native-compiler rewrite. It removes JS-API surface prettier's `.ts`-config loader depends on (`lint-node` dies reading an undefined `ModuleKind` member), and `typescript-eslint` still caps its peer at `typescript <6.1.0`, so the `pnpm i --frozen-lockfile` artifact task fails on the unmet peer.

Both orgs' self-hosted runners call this action, so `RENOVATE_PACKAGE_RULES` here is the single place to express fleet-wide policy — the same block already carries the automerge, `minimumReleaseAge`, and override-ownership rules.

## What

Two `allowedVersions` holds added to `RENOVATE_PACKAGE_RULES`:

| Package | Hold | Auto-resumes when |
|---|---|---|
| `pnpm` | `<11.12.0 \|\| >11.12.0` (excludes only 11.12.0) | a fixed patch `11.12.1+` ships — no action needed |
| `typescript` | `<7` | **manual** — drop the rule once `typescript-eslint`'s peer range admits v7 |

Each rule documents its own removal condition in its `description`.

## Activation

This action is version-pinned (`@v1.19.3`) by both callers, so the pins go live only after **a `workflows` release** and the callers bump to it. Until then the stale bump PRs sit failing (harmless — not merged); once the pins are live, Renovate auto-closes the now-disallowed ones.

## Validation

- YAML parses; embedded `RENOVATE_PACKAGE_RULES` JSON parses (17 rules).
- `prettier --check` (repo config) clean.

> Note: the related `golang.org/x/crypto v0.54.0` failures on the two Go services were a separate, incomplete-`go.sum` issue — fixed directly on those Renovate branches with `go mod tidy`, not part of this PR.
