### PR TITLE
feat: activation-snapshot Epic membership (capture + read)

### DIFF
--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -15,10 +15,11 @@ description: >
 
   Membership freezes at activation. Before the Epic starts landing the set is the live
   `epic:<N>` label search below. Once merge-gate has captured the set into a snapshot marker
-  in the Epic body — the moment the whole set first goes merge-ready — that frozen set is
-  authoritative: a PR de-labeled, closed, or relabeled afterwards stays a member, so a member
-  abandoned mid-landing can no longer vanish, and a PR labeled after landing begins joins the
-  next wave rather than re-freezing an in-flight one. The frozen marker records only
+  in the Epic body — once the whole set has held merge-ready long enough for the eventually-consistent
+  label index to settle (a two-phase pending→frozen capture) — that frozen set is authoritative: a PR
+  de-labeled, closed, or relabeled afterwards stays a member, so a member abandoned mid-landing can no
+  longer vanish, and a PR labeled after landing begins joins the next wave rather than re-freezing an
+  in-flight one. The frozen marker records only
   `{repo, number}`; each member's live state (open/merged/closed, draft, review) is re-read on
   every resolve — the set is frozen, the state is not.
 
@@ -99,24 +100,50 @@ runs:
         fi
 
         # --- Activation snapshot -----------------------------------------------------------------
-        # Once landing is under way the member set is frozen: merge-gate captures it into a marker in
-        # the Epic body at activation. When that marker is present it IS the set — a later de-label,
-        # close, or relabel never changes it. The per-member STATE is still read live below (the set
-        # is frozen, the state is not). No marker → the live label search further down.
-        snap=""
-        if body=$(gh api "repos/${OWNER}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null); then
-          snap=$(printf '%s\n' "$body" \
-            | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
-            | grep -m1 '^\[' || true)
+        # Once landing has stabilized, merge-gate freezes the member set into a marker in the Epic body
+        # (a two-phase pending→frozen capture, so an index-lagging member is never frozen out). A
+        # FROZEN marker IS the set — a later de-label, close, or relabel never changes it; per-member
+        # STATE is still read live below. A `pending` marker, a malformed one, or none → the live label
+        # search further down (the safe, self-healing default).
+        #
+        # Guard planning_repo before it becomes an API path component (as the sibling actions do).
+        if ! [[ "${PLANNING_REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+          echo "::error::planning_repo must be a bare repository name (no owner/slash), got \"${PLANNING_REPO:-}\""
+          exit 1
         fi
-        if [ -n "$snap" ] && printf '%s' "$snap" | jq -e 'type == "array"' >/dev/null 2>&1; then
-          # One GraphQL call, one alias per frozen member, to re-read current state (OPEN / MERGED /
-          # CLOSED-unmerged). A member whose PR 404s (deleted) simply drops from the re-hydrated set.
-          alias_q=$(printf '%s' "$snap" | jq -r 'to_entries | map(
+        frozen=""
+        # GitHub stores bodies with CRLF; strip \r so the marker lines match.
+        if body=$(gh api "repos/${OWNER}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
+          marker=$(printf '%s\n' "$body" \
+            | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
+            | grep -m1 '^{' || true)
+          # Only a well-formed FROZEN marker with a valid member list counts; anything else (pending,
+          # hand-edited garbage, wrong shape) yields an empty `frozen` and falls through to the live
+          # search — never a crash or a permanent HOLD.
+          [ -n "$marker" ] && frozen=$(printf '%s' "$marker" | jq -c '
+            select(type == "object" and .status == "frozen" and (.members | type == "array")
+              and (.members | all(type == "object"
+                and (.repo | type == "string") and (.repo | test("^[^/]+/[^/]+$"))
+                and (.number | type == "number")))) | .members' 2>/dev/null || true)
+        fi
+        if [ -n "$frozen" ] && [ "$frozen" != "null" ]; then
+          # Re-read each frozen member's current state (OPEN / MERGED / CLOSED), one GraphQL alias per
+          # member in a single call. Aliases that error (a member repo deleted or renamed) are skipped
+          # and the survivors kept — one bad repo never collapses the set to [] (which would HOLD the
+          # Epic). Only a transport failure (no `data` at all, after retries) falls through to [], the
+          # correct fail-closed.
+          alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
               + "{pullRequest(number:\(.value.number)){number isDraft reviewDecision headRefOid state repository{nameWithOwner}}}"
             ) | join("\n")')
-          rh=$(gh api graphql -f query="{ ${alias_q} }" 2>/dev/null || printf '{}')
+          rh='{}'
+          for attempt in 1 2 3; do
+            out=$(gh api graphql -f query="{ ${alias_q} }" 2>&1 || true)
+            if printf '%s' "$out" | jq -e 'has("data") and (.data | length > 0)' >/dev/null 2>&1; then
+              rh="$out"; break
+            fi
+            [ "$attempt" -lt 3 ] && sleep 2
+          done
           members=$(printf '%s' "$rh" | jq -c '[(.data // {}) | to_entries[] | .value.pullRequest
             | select(. != null)
             | {repo: .repository.nameWithOwner, number, headRefOid, isDraft, reviewDecision, state}]
@@ -126,7 +153,7 @@ runs:
             echo "members=$members"
             echo "count=$count"
           } >> "$GITHUB_OUTPUT"
-          echo "Epic #${EPIC}: ${count} member(s) from the activation snapshot (frozen set, live state)." \
+          echo "Epic #${EPIC}: ${count} member(s) from the frozen activation snapshot (live state)." \
             | tee -a "$GITHUB_STEP_SUMMARY"
           exit 0
         fi

--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -9,25 +9,33 @@ description: >
   subIssues` walk serves only as a discovery hint (a way to suggest the label), never as
   the definition of the set here.
 
-  Read-only: it queries the label set and emits it. It mutates nothing — no check post,
-  no board write — so it takes no dry_run. The caller decides what to do with the set
-  (and, on error, whether to hold or fail-open); this action just reports.
+  Read-only: it reads the snapshot marker or the live label set and emits it. It mutates
+  nothing — no check post, no board write — so it takes no dry_run. The caller decides what
+  to do with the set (and, on error, whether to hold or fail-open); this action just reports.
 
-  TODO (follow-up, intentionally not built here to keep the MVP small): membership
-  should be the activation snapshot, not the live label set — a timeline-fold where a PR
-  is a member iff its last `epic:<N>` label event at time <= the Epic's activation
-  timestamp is `labeled` (a pure fold over GET issues/{n}/timeline). That freezes the
-  set so a PR labeled after the Epic starts landing joins the next wave instead of
-  re-freezing an in-flight one, and a reopened/relabeled sibling can't resurrect a
-  finished Epic. The MVP below uses the current open-PR label set, which is correct for
-  a single steady wave and is the input the snapshot fold will later consume.
+  Membership freezes at activation. Before the Epic starts landing the set is the live
+  `epic:<N>` label search below. Once merge-gate has captured the set into a snapshot marker
+  in the Epic body — the moment the whole set first goes merge-ready — that frozen set is
+  authoritative: a PR de-labeled, closed, or relabeled afterwards stays a member, so a member
+  abandoned mid-landing can no longer vanish, and a PR labeled after landing begins joins the
+  next wave rather than re-freezing an in-flight one. The frozen marker records only
+  `{repo, number}`; each member's live state (open/merged/closed, draft, review) is re-read on
+  every resolve — the set is frozen, the state is not.
 
 inputs:
   epic_number:
     required: true
     description: >
       The Epic issue number N. Used to build the authoritative label name `epic:<N>` to
-      search for; informational otherwise (this action does not read the Epic issue).
+      search for, and to locate the Epic issue whose activation snapshot (if present) freezes
+      the member set.
+  planning_repo:
+    required: false
+    default: .github
+    description: >
+      Repository (name only; owner is the workflow's org) where the Epic issue lives — the
+      activation snapshot is read from `<org>/<planning_repo>#<epic_number>`. Defaults to the
+      org `.github` repo, where planning Epics are tracked.
   client_id:
     required: true
     description: Client id of the [Agent] App (issues + pull-requests read for the org-wide label search).
@@ -38,9 +46,11 @@ inputs:
 outputs:
   members:
     description: >
-      Compact JSON array of the authorized members, one object per open `epic:<N>` PR:
-      {repo (nameWithOwner), number, headRefOid, isDraft, reviewDecision}. `[]` when the
-      Epic has no open labeled PRs.
+      Compact JSON array of the authorized members, one object per member:
+      {repo (nameWithOwner), number, headRefOid, isDraft, reviewDecision, state}. Before activation
+      the set is the live open `epic:<N>` PRs (state always `OPEN`); once the Epic carries an
+      activation snapshot it is the frozen set, each member's `state` re-read live
+      (`OPEN` / `MERGED` / `CLOSED`). `[]` when the Epic has no members.
     value: ${{ steps.resolve.outputs.members }}
   count:
     description: Integer count of members (length of the array).
@@ -71,6 +81,7 @@ runs:
         GH_TOKEN: ${{ steps.token.outputs.token }}
         OWNER: ${{ github.repository_owner }}
         EPIC: ${{ inputs.epic_number }}
+        PLANNING_REPO: ${{ inputs.planning_repo }}
       run: |
         set -euo pipefail
 
@@ -85,6 +96,39 @@ runs:
         if ! [[ "$EPIC" =~ ^[0-9]+$ ]]; then
           echo "::error::epic_number must be an integer, got \"$EPIC\""
           exit 1
+        fi
+
+        # --- Activation snapshot -----------------------------------------------------------------
+        # Once landing is under way the member set is frozen: merge-gate captures it into a marker in
+        # the Epic body at activation. When that marker is present it IS the set — a later de-label,
+        # close, or relabel never changes it. The per-member STATE is still read live below (the set
+        # is frozen, the state is not). No marker → the live label search further down.
+        snap=""
+        if body=$(gh api "repos/${OWNER}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null); then
+          snap=$(printf '%s\n' "$body" \
+            | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
+            | grep -m1 '^\[' || true)
+        fi
+        if [ -n "$snap" ] && printf '%s' "$snap" | jq -e 'type == "array"' >/dev/null 2>&1; then
+          # One GraphQL call, one alias per frozen member, to re-read current state (OPEN / MERGED /
+          # CLOSED-unmerged). A member whose PR 404s (deleted) simply drops from the re-hydrated set.
+          alias_q=$(printf '%s' "$snap" | jq -r 'to_entries | map(
+              "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
+              + "{pullRequest(number:\(.value.number)){number isDraft reviewDecision headRefOid state repository{nameWithOwner}}}"
+            ) | join("\n")')
+          rh=$(gh api graphql -f query="{ ${alias_q} }" 2>/dev/null || printf '{}')
+          members=$(printf '%s' "$rh" | jq -c '[(.data // {}) | to_entries[] | .value.pullRequest
+            | select(. != null)
+            | {repo: .repository.nameWithOwner, number, headRefOid, isDraft, reviewDecision, state}]
+            | sort_by(.repo, .number)')
+          count=$(printf '%s' "$members" | jq 'length')
+          {
+            echo "members=$members"
+            echo "count=$count"
+          } >> "$GITHUB_OUTPUT"
+          echo "Epic #${EPIC}: ${count} member(s) from the activation snapshot (frozen set, live state)." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 0
         fi
 
         # The authority: open PRs carrying the permission-gated `epic:<N>` label,
@@ -164,7 +208,8 @@ runs:
           number,
           headRefOid,
           isDraft,
-          reviewDecision
+          reviewDecision,
+          state: "OPEN"
         }] | sort_by(.repo, .number)')
         count=$(printf '%s' "$members" | jq 'length')
 

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -329,6 +329,7 @@ runs:
     # Recompute readiness over the member set and post the gate. Runs for the labeled-Epic
     # path only; standalone / misconfig / hold cases were already posted by the classify step.
     - name: Evaluate readiness + post merge-gate
+      id: evaluate
       if: ${{ steps.discover.outputs.epic_number != '' }}
       shell: bash
       env:
@@ -370,15 +371,112 @@ runs:
         # to draft, or approval dismissed) the set is no longer all-ready and the `failure`
         # below dequeues the group. (Set-shrink — a member closed unmerged — is the
         # partial-landing detector's job, not this gate's.)
+        # Readiness is about the still-OPEN members: with a snapshot the set is frozen and can carry
+        # merged / closed members, which have already left (or abandoned) the landing and are the
+        # partial-landing detector's concern, not the gate's.
         unready=$(printf '%s' "$MEMBERS" | jq -r '.[]
+          | select(.state == "OPEN")
           | select(.isDraft or (.reviewDecision != "APPROVED"))
           | "  - \(.repo)#\(.number) (draft=\(.isDraft), review=\(.reviewDecision // "none"))"')
 
-        total=$(printf '%s' "$MEMBERS" | jq 'length')
+        total=$(printf '%s' "$MEMBERS" | jq '[.[] | select(.state == "OPEN")] | length')
         if [ -z "$unready" ]; then
           post_check success "Epic #${EPIC} — all ${total} open member(s) merge-ready ${where}. Atomic landing OK."
+          # Activation: the whole set is approved and merge-ready, before any merge or de-label. Freeze
+          # it (write-once) so an abandoned member can't later vanish. Done by the capture step below.
+          echo "capture=true" >> "$GITHUB_OUTPUT"
         else
           count=$(printf '%s\n' "$unready" | grep -c '')
           post_check failure "$(printf 'Epic #%s — holding for atomic landing %s: %s of %s member(s) not ready:\n%s' \
             "$EPIC" "$where" "$count" "$total" "$unready")"
+        fi
+
+    # Activation snapshot: freeze the member set the first time the whole Epic is merge-ready — before
+    # any member merges or is de-labelled. A separate, minimal issues:write token: the gate's own token
+    # stays read-only on issues, so the write capability lives only in this step.
+    - name: Mint snapshot-write token
+      id: snap_token
+      if: ${{ steps.evaluate.outputs.capture == 'true' }}
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.client_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: ${{ github.repository_owner }}
+        permission-issues: write
+
+    - name: Capture activation snapshot
+      if: ${{ steps.evaluate.outputs.capture == 'true' }}
+      # Best-effort: a failed capture must NEVER fail the gate — the merge-gate check is already posted
+      # success. Membership just stays live-derived until the next ready-pass writes the marker.
+      continue-on-error: true
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.snap_token.outputs.token }}
+        ORG: ${{ github.repository_owner }}
+        PLANNING_REPO: .github
+        EPIC: ${{ steps.discover.outputs.epic_number }}
+        MEMBERS: ${{ steps.membership.outputs.members }}
+      run: |
+        set -euo pipefail
+        START='<!-- epic-membership:snapshot:start -->'
+        END='<!-- epic-membership:snapshot:end -->'
+
+        # Write-once. This step runs per member PR, so several ready-passes reach it; the FIRST writes
+        # the marker and the rest see it and stop. A late-labelled PR therefore never re-freezes an
+        # in-flight Epic — it joins the next wave. (Concurrent first-passes can race; both write the
+        # SAME {repo,number} set, and epic-membership's reader takes the first marker, so a transient
+        # double-write is idempotent.)
+        body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""')
+        if printf '%s\n' "$body" | grep -qxF -- "$START"; then
+          echo "Epic #${EPIC}: activation snapshot already frozen — leaving it." | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        # The frozen marker records only {repo, number}; epic-membership re-reads each member's live
+        # state on every resolve.
+        set_json=$(printf '%s' "$MEMBERS" | jq -c '[.[] | {repo, number}] | sort_by(.repo, .number)')
+
+        # splice(): hand-edit-safe marker writer, lifted verbatim from render-epic-status. A well-formed
+        # existing region is replaced in place; otherwise stray marker lines are stripped and one fresh
+        # region is appended — human prose is never dropped. Here there is no marker (checked above), so
+        # it appends.
+        splice() { # $1 = body file, $2 = region file (already wrapped in the markers)
+          local bodyf="$1" regionf="$2" ns ne sl el wellformed=false
+          ns=$(grep -cxF -- "$START" "$bodyf" || true)
+          ne=$(grep -cxF -- "$END" "$bodyf" || true)
+          if [ "$ns" = "1" ] && [ "$ne" = "1" ]; then
+            sl=$(grep -nxF -- "$START" "$bodyf" | cut -d: -f1)
+            el=$(grep -nxF -- "$END" "$bodyf" | cut -d: -f1)
+            if [ "$sl" -lt "$el" ]; then wellformed=true; fi
+          fi
+          if [ "$wellformed" = true ]; then
+            awk -v startm="$START" -v endm="$END" -v regionfile="$regionf" '
+              BEGIN { region=""; while ((getline line < regionfile) > 0) region = region line "\n" }
+              $0 == startm { if (!done) { printf "%s", region; done=1 } inside=1; next }
+              $0 == endm { inside=0; next }
+              inside { next }
+              { print }
+            ' "$bodyf"
+          else
+            grep -vxF -e "$START" -e "$END" -- "$bodyf" || true
+            printf '\n'
+            cat "$regionf"
+          fi
+        }
+
+        bodyf=$(mktemp); regionf=$(mktemp); outf=$(mktemp)
+        printf '%s' "$body" > "$bodyf"
+        {
+          echo "$START"
+          echo "_Epic membership, frozen at activation by the merge-gate. The authoritative set for this landing — a later de-label, close, or relabel does not change it. Do not edit._"
+          printf '%s\n' "$set_json"
+          echo "$END"
+        } > "$regionf"
+        splice "$bodyf" "$regionf" > "$outf"
+
+        if gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" >/dev/null; then
+          n=$(printf '%s' "$set_json" | jq 'length')
+          echo "Epic #${EPIC}: froze the activation snapshot — ${n} member(s)." | tee -a "$GITHUB_STEP_SUMMARY"
+        else
+          echo "::warning::Epic #${EPIC}: could not write the activation snapshot; membership stays live-derived until the next ready-pass."
         fi

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -339,6 +339,7 @@ runs:
         EPIC: ${{ steps.discover.outputs.epic_number }}
         MEMBERS: ${{ steps.membership.outputs.members }}
         IN_QUEUE: ${{ github.event.merge_group.head_sha }}
+        PR_NUMBER: ${{ inputs.pull_request_number }}
       run: |
         set -euo pipefail
 
@@ -371,19 +372,32 @@ runs:
         # to draft, or approval dismissed) the set is no longer all-ready and the `failure`
         # below dequeues the group. (Set-shrink — a member closed unmerged — is the
         # partial-landing detector's job, not this gate's.)
+        # A PR carrying epic:<N> that is NOT in the resolved set — labelled after the snapshot froze, or
+        # missed at capture — must not inherit the wave's verdict (it would merge un-gated for its own
+        # readiness). Hold it: it belongs to a later wave, not this landing. Pre-snapshot the live set
+        # is the PR's own set, so this is a no-op; a merge_group event gates the whole group, not one PR.
+        if [ -z "${IN_QUEUE:-}" ] && [ -n "${PR_NUMBER:-}" ]; then
+          if [ "$(printf '%s' "$MEMBERS" | jq --arg r "$REPO_FULL" --argjson n "${PR_NUMBER}" \
+                'any(.[]; .repo == $r and .number == $n)')" != "true" ]; then
+            post_check failure "Epic #${EPIC} — this PR carries the label but is not in the member set ${where}; holding (it belongs to a later wave, not this landing)."
+            exit 0
+          fi
+        fi
+
         # Readiness is about the still-OPEN members: with a snapshot the set is frozen and can carry
         # merged / closed members, which have already left (or abandoned) the landing and are the
-        # partial-landing detector's concern, not the gate's.
+        # partial-landing detector's concern, not the gate's. `state == null` tolerates an older
+        # epic-membership (pre-`state`) so a version skew degrades to the all-open live behavior rather
+        # than passing every set.
         unready=$(printf '%s' "$MEMBERS" | jq -r '.[]
-          | select(.state == "OPEN")
+          | select(.state == "OPEN" or .state == null)
           | select(.isDraft or (.reviewDecision != "APPROVED"))
           | "  - \(.repo)#\(.number) (draft=\(.isDraft), review=\(.reviewDecision // "none"))"')
 
-        total=$(printf '%s' "$MEMBERS" | jq '[.[] | select(.state == "OPEN")] | length')
+        total=$(printf '%s' "$MEMBERS" | jq '[.[] | select(.state == "OPEN" or .state == null)] | length')
         if [ -z "$unready" ]; then
           post_check success "Epic #${EPIC} — all ${total} open member(s) merge-ready ${where}. Atomic landing OK."
-          # Activation: the whole set is approved and merge-ready, before any merge or de-label. Freeze
-          # it (write-once) so an abandoned member can't later vanish. Done by the capture step below.
+          # The set is approved and merge-ready. Trigger the two-phase capture (pending→frozen) below.
           echo "capture=true" >> "$GITHUB_OUTPUT"
         else
           count=$(printf '%s\n' "$unready" | grep -c '')
@@ -397,6 +411,8 @@ runs:
     - name: Mint snapshot-write token
       id: snap_token
       if: ${{ steps.evaluate.outputs.capture == 'true' }}
+      # Best-effort with its capture step: a token-mint hiccup must not fail the gate.
+      continue-on-error: true
       uses: actions/create-github-app-token@v3
       with:
         client-id: ${{ inputs.client_id }}
@@ -413,33 +429,63 @@ runs:
       env:
         GH_TOKEN: ${{ steps.snap_token.outputs.token }}
         ORG: ${{ github.repository_owner }}
-        PLANNING_REPO: .github
+        PLANNING_REPO: ${{ inputs.planning_repo }}
         EPIC: ${{ steps.discover.outputs.epic_number }}
         MEMBERS: ${{ steps.membership.outputs.members }}
+        STABILIZE_SECONDS: "120"
       run: |
         set -euo pipefail
         START='<!-- epic-membership:snapshot:start -->'
         END='<!-- epic-membership:snapshot:end -->'
 
-        # Write-once. This step runs per member PR, so several ready-passes reach it; the FIRST writes
-        # the marker and the rest see it and stop. A late-labelled PR therefore never re-freezes an
-        # in-flight Epic — it joins the next wave. (Concurrent first-passes can race; both write the
-        # SAME {repo,number} set, and epic-membership's reader takes the first marker, so a transient
-        # double-write is idempotent.)
-        body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""')
-        if printf '%s\n' "$body" | grep -qxF -- "$START"; then
-          echo "Epic #${EPIC}: activation snapshot already frozen — leaving it." | tee -a "$GITHUB_STEP_SUMMARY"
+        # Two-phase capture, so the eventually-consistent label search never freezes an INCOMPLETE set
+        # (an index-lagging member is exactly why "all ready" can trip early on a short set). The first
+        # all-ready pass writes a `pending` marker with a timestamp; a later pass promotes it to `frozen`
+        # only once the set is UNCHANGED and has aged past STABILIZE_SECONDS — giving the index time to
+        # surface any missing member. A changed set resets the clock. epic-membership treats only
+        # `frozen` as the set; `pending` reads as no-snapshot. Runs per member PR (several passes reach
+        # here). GitHub stores bodies with CRLF; strip \r so the exact marker matches (grep + splice).
+        body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' | tr -d '\r')
+
+        cur=$(printf '%s' "$MEMBERS" | jq -c '[.[] | {repo, number}] | sort_by(.repo, .number)')
+        marker=$(printf '%s\n' "$body" \
+          | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
+          | grep -m1 '^{' || true)
+        # An unparseable marker (hand-edited garbage) is treated as absent → a fresh pending, which
+        # self-heals it rather than crashing or freezing corruption.
+        if [ -z "$marker" ] || ! printf '%s' "$marker" | jq empty 2>/dev/null; then marker=null; fi
+        now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+        # frozen → skip; a valid pending → reset (members changed) / promote (unchanged + aged) / wait;
+        # anything else (missing, malformed, other status) → write a fresh pending.
+        do=$(jq -rn --argjson cur "$cur" --argjson mk "$marker" --arg now "$now" \
+          --argjson thr "${STABILIZE_SECONDS}" '
+          if ($mk | type) != "object" then "pending"
+          elif $mk.status == "frozen" then "skip"
+          elif ($mk.status == "pending" and ($mk.members | type == "array") and ($mk.at | type == "string"))
+            then (
+              if (($mk.members | sort_by(.repo, .number)) != $cur) then "pending"
+              elif (($now | fromdateiso8601) - ($mk.at | try fromdateiso8601 catch 0)) >= $thr then "frozen"
+              else "skip" end)
+          else "pending" end' 2>/dev/null || echo skip)
+
+        if [ "$do" = "skip" ]; then
+          echo "Epic #${EPIC}: snapshot already frozen, or stable but not yet aged — leaving it." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
 
-        # The frozen marker records only {repo, number}; epic-membership re-reads each member's live
-        # state on every resolve.
-        set_json=$(printf '%s' "$MEMBERS" | jq -c '[.[] | {repo, number}] | sort_by(.repo, .number)')
+        if [ "$do" = "frozen" ]; then
+          payload=$(printf '%s' "$cur" | jq -c '{status: "frozen", members: .}')
+          note="_Epic membership, FROZEN at activation by the merge-gate. The authoritative set for this landing — a later de-label, close, or relabel does not change it. Do not edit._"
+        else
+          payload=$(printf '%s' "$cur" | jq -c --arg at "$now" '{status: "pending", at: $at, members: .}')
+          note="_Epic membership, PENDING — stabilizing before it freezes (the label index is eventually consistent). Do not edit._"
+        fi
 
-        # splice(): hand-edit-safe marker writer, lifted verbatim from render-epic-status. A well-formed
-        # existing region is replaced in place; otherwise stray marker lines are stripped and one fresh
-        # region is appended — human prose is never dropped. Here there is no marker (checked above), so
-        # it appends.
+        # splice(): hand-edit-safe marker writer, lifted verbatim from render-epic-status. Replaces a
+        # well-formed region in place (pending→pending reset, pending→frozen promote); otherwise strips
+        # any stray marker lines and appends one fresh region — human prose is never dropped.
         splice() { # $1 = body file, $2 = region file (already wrapped in the markers)
           local bodyf="$1" regionf="$2" ns ne sl el wellformed=false
           ns=$(grep -cxF -- "$START" "$bodyf" || true)
@@ -468,15 +514,15 @@ runs:
         printf '%s' "$body" > "$bodyf"
         {
           echo "$START"
-          echo "_Epic membership, frozen at activation by the merge-gate. The authoritative set for this landing — a later de-label, close, or relabel does not change it. Do not edit._"
-          printf '%s\n' "$set_json"
+          echo "$note"
+          printf '%s\n' "$payload"
           echo "$END"
         } > "$regionf"
         splice "$bodyf" "$regionf" > "$outf"
 
         if gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" >/dev/null; then
-          n=$(printf '%s' "$set_json" | jq 'length')
-          echo "Epic #${EPIC}: froze the activation snapshot — ${n} member(s)." | tee -a "$GITHUB_STEP_SUMMARY"
+          n=$(printf '%s' "$cur" | jq 'length')
+          echo "Epic #${EPIC}: wrote ${do} activation snapshot — ${n} member(s)." | tee -a "$GITHUB_STEP_SUMMARY"
         else
-          echo "::warning::Epic #${EPIC}: could not write the activation snapshot; membership stays live-derived until the next ready-pass."
+          echo "::warning::Epic #${EPIC}: could not write the ${do} activation snapshot; membership stays live-derived."
         fi


### PR DESCRIPTION
Closes #312. Part of the activation-snapshot Epic (#253).

Once an Epic starts landing, its member set must stop changing — today it's the live `epic:<N>` label set, so a de-labelled sibling vanishes and the partial-landing detector can miss it (INV-1). This freezes the set at activation.

## Design (post self-review)

**Two-phase capture** (`merge-gate`), so an eventually-consistent label search never freezes an *incomplete* set:
- First all-ready pass writes a **`pending`** marker (timestamped) into the Epic body.
- A later pass promotes it to **`frozen`** only when the set is **unchanged AND aged past 120s** — giving the label index time to surface a lagging member. A changed set resets the clock.
- Separate step-scoped `issues:write` token (gate token stays read-only); fail-soft.

**Read** (`epic-membership`): a `frozen` marker → that set, each member re-read live for `state` via one aliased GraphQL call (retried, partial-data-tolerant); `pending` / malformed / absent → the live search. New `planning_repo` input.

**Gate**: a PR carrying the label but **not in the resolved set is HELD** (it can't inherit the wave's verdict); readiness filters to open members (`state==null` tolerated for version skew).

## Self-review outcome

A fresh adversarial reviewer found **2 design-level INV-1 gaps + 6 code issues** — all fixed:

| # | Was | Now |
|---|---|---|
| 1 | first-pass freeze could capture an index-lagging incomplete set | two-phase stability guard |
| 2 | a non-member PR inherited the wave's verdict (un-gated merge) | hold non-members |
| 3 | a state-less response passed **every** set (version skew) | `state==null` tolerated |
| 4 | one bad member repo collapsed the set → HOLD | retry + partial-data survival |
| 5 | a malformed marker could crash / HOLD forever | degrade to live (read) / pending (write) |
| 6 | mint step could fail the gate | `continue-on-error` |
| 7/8 | `planning_repo` hardcoded / unguarded | threaded + guarded |

(One I flagged and retracted: CRLF — `grep -xF` tolerates `\r`; the `tr -d '\r'` stays as it's now load-bearing for the in-place promote.) Verified standalone: the state machine (reset/promote/self-heal), read validation, #2/#3, splice round-trip.

## Then #313

Wires `detect-partial-landing` to read through `epic-membership`. Separate PR, blocked by this.
