### PR TITLE
feat: consume the activation snapshot in detect-partial-landing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,3 +59,35 @@ jobs:
           done < <(find . -type f -name action.yaml -not -path './node_modules/*')
           if [ "$fail" -ne 0 ]; then exit 1; fi
           echo "✓ no composite-illegal expression contexts in any action manifest."
+
+  # The landing-saga actions are bash, and their decisions (freeze / clear / hold) are too costly to
+  # get wrong to leave unexercised. Each test in tests/ extracts the functions it covers straight out
+  # of its action manifest and runs them against stubbed network leaves — offline, deterministic, and
+  # no fixture drift, since the shipped code is what executes.
+  test-actions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run the action test suites
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          suites=(tests/*.sh)
+          if [ ${#suites[@]} -eq 0 ]; then
+            echo "::error::no test suites found under tests/ — the job would pass vacuously"
+            exit 1
+          fi
+          fail=0
+          for suite in "${suites[@]}"; do
+            echo "::group::$suite"
+            bash "$suite" || fail=1
+            echo "::endgroup::"
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::at least one action test suite failed"
+            exit 1
+          fi
+          echo "✓ ${#suites[@]} action test suite(s) passed."

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -13,7 +13,14 @@ description: >
   uncertainty) so a fresh head is never stranded on "Expected". The sweep (a level-triggered floor,
   roughly every 15 minutes) enumerates active Epics org-wide, rolls strays forward within grace,
   freezes REST-confirmed partials, and backstops every open non-member head; it fails closed. Both
-  re-derive ground truth each pass, so there is no stored state to drift.
+  re-derive every member's state each pass, so no judgment rests on stored state.
+
+  One thing is read from storage: WHICH pull requests are members. Until merge-gate freezes the set,
+  that is the live `epic:<N>` label search; after, it is the activation snapshot merge-gate captured
+  into the Epic body. The snapshot is what makes an abandoned member visible — a PR de-labeled and
+  closed mid-landing leaves no trace the live search can find, because GitHub indexes no "ever
+  carried label X", so without the frozen set the detector would read the remaining siblings as a
+  clean landing.
 
   The freeze is a check-run, not a status: an `epic-freeze` check-run (checks:write) posted with
   `conclusion: failure` — never `neutral`, which GitHub counts as a passing required check — on a
@@ -433,6 +440,90 @@ runs:
           printf '%s\n' "$out" | grep -qx 'automation:paused'
         }
 
+        # Bucket an Epic's FROZEN activation-snapshot members by their live state. Once landing
+        # stabilizes, merge-gate captures the member set into a marker in the Epic body; from then on
+        # membership IS that set, so a member de-labeled mid-landing stays a member and its
+        # abandonment is still seen here. The live label search cannot cover that: GitHub indexes no
+        # "ever carried label X", so a de-labeled PR is unrecoverable from live truth — which is the
+        # whole reason the set is persisted. Only the SET is frozen; every member's STATE is re-read
+        # live on each pass.
+        # Prints nothing; fills SNAP_MERGED / SNAP_CLOSED / SNAP_OPEN with the same node shape
+        # search_prs returns (repository.nameWithOwner, number, headRefOid, mergedAt, baseRefName,
+        # isDraft), so the bucketing downstream is identical whichever source fed it.
+        # Returns 0 = frozen set resolved, 2 = no usable snapshot (caller uses the live searches),
+        # 1 = a frozen set exists but could not be re-read (caller fails closed for this Epic).
+        # The marker contract (fence names, `status`, `members`) is shared with epic-membership and
+        # merge-gate — a change to its shape has to land in all three.
+        snapshot_buckets() { # $1 = epic number
+          SNAP_MERGED='[]'; SNAP_CLOSED='[]'; SNAP_OPEN='[]'
+          local body="" ok=false marker frozen alias_q rh out nodes
+          for attempt in 1 2 3; do
+            # GitHub stores bodies with CRLF; strip \r so the marker fences match. stderr is folded in
+            # so a 404 — the Epic issue simply is not in the planning repo — is recognizable and not retried.
+            if body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" --jq '.body // ""' 2>&1 | tr -d '\r'); then
+              ok=true
+              break
+            fi
+            case "$body" in *"HTTP 404"*) break ;; esac
+            [ "$attempt" -lt 3 ] && sleep 2
+          done
+          if [ "$ok" != true ]; then
+            # Downgrading to the live set is the recoverable failure (a missed freeze is re-derived by
+            # the next sweep); holding every Epic on a body-read hiccup is not. Warn so it stays visible.
+            echo "::warning::epic #$1: could not read ${ORG}/${PLANNING_REPO}#$1 — no snapshot applied this pass, using the live label set."
+            return 2
+          fi
+
+          marker=$(printf '%s\n' "$body" \
+            | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
+            | grep -m1 '^{' || true)
+          [ -n "$marker" ] || return 2
+          # Only a well-formed FROZEN marker counts, validated exactly as epic-membership validates it.
+          # A pending marker (the set has not settled yet), a hand-edited one, or the wrong shape falls
+          # back to the live set rather than crashing or freezing the Epic on garbage.
+          frozen=$(printf '%s' "$marker" | jq -c '
+            select(type == "object" and .status == "frozen" and (.members | type == "array")
+              and (.members | all(type == "object"
+                and (.repo | type == "string") and (.repo | test("^[^/]+/[^/]+$"))
+                and (.number | type == "number")))) | .members' 2>/dev/null || true)
+          { [ -n "$frozen" ] && [ "$frozen" != "null" ]; } || return 2
+          # An empty frozen set has nothing to re-read (and would build an empty GraphQL query): leave
+          # the buckets empty, which reads downstream as "nothing has landed" → clear.
+          [ "$(printf '%s' "$frozen" | jq 'length')" -gt 0 ] || return 0
+
+          # One aliased GraphQL call re-reads every member's live state. Aliases that error (a member
+          # repo deleted or renamed) are skipped and the survivors kept, so one bad repo cannot quietly
+          # empty the set. A total failure is an error rather than a fallback: we KNOW a frozen set
+          # exists, and the live set is precisely the weaker answer the snapshot exists to replace.
+          alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
+              "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
+              + "{pullRequest(number:\(.value.number)){number headRefOid mergedAt baseRefName isDraft state repository{nameWithOwner}}}"
+            ) | join("\n")')
+          rh=""
+          for attempt in 1 2 3; do
+            out=$(gh api graphql -f query="{ ${alias_q} }" 2>&1 || true)
+            if printf '%s' "$out" | jq -e 'has("data") and (.data | length > 0)' >/dev/null 2>&1; then
+              rh="$out"
+              break
+            fi
+            [ "$attempt" -lt 3 ] && sleep 2
+          done
+          if [ -z "$rh" ]; then
+            # Runs in the caller's shell but the decision is silent (EV_DECISION stays error), so echo
+            # the underlying failure here or the fail-closed pass is undiagnosable.
+            printf 'snapshot_buckets: could not re-read frozen member state for epic #%s after 3 attempts: %s\n' "$1" "$out" >&2
+            return 1
+          fi
+
+          # MERGED / CLOSED / OPEN are exclusive on a PullRequest — a merged PR reports MERGED, never
+          # CLOSED — so CLOSED is exactly the closed-without-merge bucket the live search widens for.
+          nodes=$(printf '%s' "$rh" | jq -c '[(.data // {}) | to_entries[] | .value.pullRequest | select(. != null)]')
+          SNAP_MERGED=$(printf '%s' "$nodes" | jq -c '[.[] | select(.state == "MERGED")]')
+          SNAP_CLOSED=$(printf '%s' "$nodes" | jq -c '[.[] | select(.state == "CLOSED")]')
+          SNAP_OPEN=$(printf '%s' "$nodes" | jq -c '[.[] | select(.state == "OPEN")]')
+          return 0
+        }
+
         # ---- Post helpers (dry-run aware; the checks token posts) -------------------------
 
         # Post an epic-freeze check-run (jq builds the payload so quotes / newlines can't break the JSON).
@@ -501,12 +592,33 @@ runs:
           local EPIC="$1"
           local base_q="label:\"epic:${EPIC}\" org:${ORG}"
 
-          # Widened resolve, three passes: is:closed is:unmerged catches the closed-without-merge blind
-          # spot; is:merged and is:open complete the picture. Any failure → EV_DECISION stays error.
-          local merged closed_unmerged open
-          if ! merged=$(search_prs "is:pr is:merged $base_q"); then return 0; fi
-          if ! closed_unmerged=$(search_prs "is:pr is:closed is:unmerged $base_q"); then return 0; fi
-          if ! open=$(search_prs "is:pr is:open $base_q"); then return 0; fi
+          # The member set comes from the Epic's frozen activation snapshot once it has one, and from
+          # the live `epic:<N>` label search until then. Both hand back the same three buckets in the
+          # same shape, so everything below is source-agnostic: the snapshot changes only WHICH pull
+          # requests are members — a de-labeled one stays — never how a member is judged.
+          local merged closed_unmerged open membership=snapshot snap_rc=0
+          snapshot_buckets "$EPIC" || snap_rc=$?
+          case "$snap_rc" in
+            0)
+              merged="$SNAP_MERGED"
+              closed_unmerged="$SNAP_CLOSED"
+              open="$SNAP_OPEN"
+              ;;
+            2)
+              # Pre-activation, or a marker that is pending / unreadable. Widened resolve, three passes:
+              # is:closed is:unmerged catches the closed-without-merge blind spot; is:merged and is:open
+              # complete the picture. Any failure → EV_DECISION stays error.
+              membership=live
+              if ! merged=$(search_prs "is:pr is:merged $base_q"); then return 0; fi
+              if ! closed_unmerged=$(search_prs "is:pr is:closed is:unmerged $base_q"); then return 0; fi
+              if ! open=$(search_prs "is:pr is:open $base_q"); then return 0; fi
+              ;;
+            *)
+              # A frozen set exists but its state could not be re-read → EV_DECISION stays error, which
+              # fails open here and is re-derived by merge-gate and the next sweep.
+              return 0
+              ;;
+          esac
 
           EV_OPEN="$open"
           EV_MERGED_COUNT=$(printf '%s' "$merged" | jq 'length')
@@ -573,7 +685,7 @@ runs:
             fi
           fi
 
-          echo "epic #$EPIC: merged=$EV_MERGED_COUNT closed_unmerged=$EV_CLOSED_COUNT open=$EV_OPEN_COUNT stray=$EV_STRAY_COUNT grace_elapsed=$grace_elapsed" \
+          echo "epic #$EPIC: membership=$membership merged=$EV_MERGED_COUNT closed_unmerged=$EV_CLOSED_COUNT open=$EV_OPEN_COUNT stray=$EV_STRAY_COUNT grace_elapsed=$grace_elapsed" \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
           # Predicate: needs >=1 merged sibling (nothing has landed otherwise); then a closed-unmerged
@@ -750,8 +862,10 @@ runs:
             | unique | .[]')
 
           # Backstop first: running it before the epic loop means any epic-pass success/failure posts last
-          # and wins on a head both could touch (a lagging label index) — flipping a contested head to
-          # fail-closed. Always runs, even with no active Epics.
+          # and wins on a head both could touch — flipping a contested head to fail-closed. Two things
+          # contest a head: a lagging label index, and a snapshot member whose label was removed while it
+          # stayed open (the backstop reads labels, so it sees a non-member; the epic pass reads the frozen
+          # set, so it sees a member — and the member view has to win). Always runs, even with no active Epics.
           standalone_sweep
 
           if [ -n "$epics" ]; then

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -172,9 +172,13 @@ runs:
     # targets (a reenqueue target is a landable stray, i.e. an open Epic member). The enqueue token
     # below is scoped to exactly these, not org-wide, so a leak can't reach a repo that isn't mid-landing.
     # Reads the same open-PR + label view the run step's enumeration does (labels first:100), so it is a
-    # superset of the reenqueue targets (a stray is an open Epic member). Residual divergence is only a PR
-    # opening in the seconds between (self-heals — the reenqueue logs "next sweep retries") or an org with
-    # >1000 open PRs (not realistic here). A partial page failure abandons the token, never a partial scope.
+    # superset of the reenqueue targets (a stray is an open Epic member). It stays a superset only because
+    # the roll-forward skips strays the label search no longer returns — the frozen activation snapshot
+    # widens MEMBERSHIP past this query, so a snapshot-only member's repo can be absent here; see
+    # sweep_post_clear, which is what keeps that member out of reenqueue's reach. Residual divergence is
+    # only a PR opening in the seconds between (self-heals — the reenqueue logs "next sweep retries") or an
+    # org with >1000 open PRs (not realistic here). A partial page failure abandons the token, never a
+    # partial scope.
     - name: Discover active-Epic repos (scope for the enqueue token)
       id: scope
       if: ${{ steps.mode.outputs.mode == 'sweep' }}
@@ -466,27 +470,41 @@ runs:
           SNAP_MERGED='[]'
           SNAP_CLOSED='[]'
           SNAP_OPEN='[]'
-          local resp="" body="" ok=false marker frozen want alias_q rh out nodes
+          local resp="" err="" errf body="" ok=false marker frozen want alias_q rh out nodes
+          errf=$(mktemp)
           for attempt in 1 2 3; do
-            # Read the whole issue and take `.body` through jq rather than `--jq`: validating that the
-            # response parses as an issue object is what keeps a gh notice on stderr (folded in here so
-            # the 404 case is recognizable) from being parsed as body text.
-            if resp=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" 2>&1) \
+            # Keep the streams apart: stdout is the payload, stderr is diagnosis. Folding them together
+            # would let a benign `gh` notice land inside the JSON and turn a healthy read into a parse
+            # failure — which now costs a whole pass, since an unreadable body no longer falls back.
+            # `.body` goes through jq rather than `--jq` so a non-issue response is rejected as a whole
+            # rather than silently yielding an empty body (which reads as "no snapshot").
+            if resp=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" 2>"$errf") \
               && printf '%s' "$resp" | jq -e 'type == "object" and has("body")' >/dev/null 2>&1; then
               # GitHub stores bodies with CRLF; strip \r so the marker fences match.
               body=$(printf '%s' "$resp" | jq -r '.body // ""' | tr -d '\r')
               ok=true
               break
             fi
+            err=$(cat "$errf" 2>/dev/null || true)
             # The Epic issue simply is not in the planning repo — nothing to retry.
-            case "$resp" in *"HTTP 404"*) break ;; esac
+            case "$err" in *"HTTP 404"*) break ;; esac
             [ "$attempt" -lt 3 ] && sleep 2
           done
+          rm -f "$errf"
           if [ "$ok" != true ]; then
-            # No snapshot applied, so this pass sees exactly what it saw before the snapshot existed —
-            # bounded by the live floor, and re-derived by the next sweep. Warn so it stays visible.
-            echo "::warning::epic #$1: could not read ${ORG}/${PLANNING_REPO}#$1 — no snapshot applied this pass, live label set only."
-            return 2
+            # A 404 is an ANSWER: the Epic issue is not there, so no snapshot can exist and the live
+            # floor is the whole truth. Any other failure leaves us not knowing whether a frozen set
+            # exists — and deciding on the live floor while ignorant is not neutral, because a `clear`
+            # POSTS success and would lift a freeze an earlier pass had correctly set. Treat ignorance
+            # the same way the re-read failure below does: decide nothing, re-derive next pass.
+            case "$err" in
+              *"HTTP 404"*)
+                echo "::warning::epic #$1: ${ORG}/${PLANNING_REPO}#$1 not found — no snapshot possible, live label set only."
+                return 2
+                ;;
+            esac
+            echo "::error::epic #$1: could not read ${ORG}/${PLANNING_REPO}#$1 after 3 attempts, so it is unknown whether a snapshot exists — deciding nothing this pass: ${err}"
+            return 1
           fi
 
           # Take the whole fenced region and let jq parse it, so the marker is not silently required to
@@ -502,15 +520,16 @@ runs:
           # below and the Epic body is writable by anyone with write access to the planning repo:
           # `[^/]` would admit quotes and newlines (enough to inject fields), and `type == "number"`
           # alone would admit 1.5, which is a document-level validation error rather than a skippable
-          # one. `unique` keeps a repeated member from double-posting downstream; the cap bounds the
-          # single aliased query below.
+          # one. The dedup key is case-folded because GitHub resolves repository names case-insensitively,
+          # so `org/Repo` and `org/repo` are one member and would otherwise both be queried and both be
+          # counted. The cap bounds the single aliased query below.
           frozen=$(printf '%s' "$marker" | jq -c '
             select(type == "object" and .status == "frozen" and (.members | type == "array"))
             | .members
             | select(all(.[]; type == "object"
                 and (.repo | type == "string") and (.repo | test("^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+$"))
                 and (.number | type == "number" and . == floor and . > 0 and . < 2147483648)))
-            | unique_by(.repo, .number)
+            | unique_by((.repo | ascii_downcase), .number)
             | select(length > 0 and length <= 200)' 2>/dev/null || true)
           { [ -n "$frozen" ] && [ "$frozen" != "null" ]; } || return 2
           want=$(printf '%s' "$frozen" | jq 'length')
@@ -521,9 +540,13 @@ runs:
           # would in epic-membership, where the consumer then HOLDs), it erases the evidence of
           # abandonment and reads as "nothing wrong". Accepting a short answer here would silently
           # decide `clear` and post success on the very case this exists to catch.
+          # `|floor` renders the number as a canonical integer literal. The guard above already rejects
+          # a fractional value, but jq preserves the literal a body was written with, so 1.0 and 1e2
+          # would reach the query verbatim — and a non-Int literal is a document-level validation error
+          # that rejects the whole query rather than one alias, wedging the Epic on every retry.
           alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
-              + "{pullRequest(number:\(.value.number)){number headRefOid mergedAt baseRefName isDraft state repository{nameWithOwner}}}"
+              + "{pullRequest(number:\(.value.number|floor)){number headRefOid mergedAt baseRefName isDraft state repository{nameWithOwner}}}"
             ) | join("\n")')
           rh=""
           for attempt in 1 2 3; do
@@ -545,16 +568,21 @@ runs:
             return 1
           fi
 
-          # Keep only nodes that answer a member actually asked for, then require the count to still
-          # match: a response is trusted to describe the frozen set, and a node for some other pull
-          # request would otherwise flow into EV_OPEN and become a freeze target under an org-wide
-          # checks:write token.
+          # Reconcile each node against the member it was asked for, so a response cannot smuggle in a
+          # pull request nobody asked about — such a node would flow into EV_OPEN and become a freeze
+          # target under an org-wide checks:write token. Identity is the ALIAS INDEX plus the pull
+          # request number, deliberately not the repository name: GraphQL follows a rename silently and
+          # answers with the NEW nameWithOwner, and since a frozen marker is never rewritten, matching
+          # on the name would wedge a renamed member's Epic at `error` forever. The number is stable
+          # under a rename, and the alias index is ours, so together they still pin identity.
           nodes=$(printf '%s' "$rh" | jq -c --argjson want "$frozen" '
-            [ (.data // {}) | to_entries[] | .value.pullRequest | select(. != null)
-              | . as $n | select($want | any(.repo == $n.repository.nameWithOwner and .number == $n.number)) ]')
-          if [ "$(printf '%s' "$nodes" | jq 'length')" -ne "$want" ] \
+            [ (.data // {}) | to_entries[]
+              | (.key | ltrimstr("m") | tonumber) as $i
+              | .value.pullRequest | select(. != null)
+              | select($want[$i] != null and .number == ($want[$i].number | floor)) ]' 2>/dev/null || true)
+          if [ -z "$nodes" ] || [ "$(printf '%s' "$nodes" | jq 'length')" -ne "$want" ] \
             || ! printf '%s' "$nodes" | jq -e 'all(.[]; .state == "MERGED" or .state == "CLOSED" or .state == "OPEN")' >/dev/null 2>&1; then
-            printf 'snapshot_buckets: re-read of epic #%s did not answer its own member set (unknown or unmatched nodes)\n' "$1" >&2
+            printf 'snapshot_buckets: re-read of epic #%s did not answer its own member set (unmatched, duplicated, or unknown-state nodes)\n' "$1" >&2
             return 1
           fi
 
@@ -566,14 +594,33 @@ runs:
           return 0
         }
 
-        # Merge snapshot members into a live bucket, one entry per (repo, number). The live node wins a
-        # collision: both describe the same pull request, and the live one came from the search shape
-        # the rest of evaluate_epic was written against.
-        union_nodes() { # $1 = live array, $2 = snapshot array
-          jq -cn --argjson live "$1" --argjson snap "$2" '
-            $live + [ $snap[] | . as $n
-              | select($live | any(.repository.nameWithOwner == $n.repository.nameWithOwner
-                  and .number == $n.number) | not) ]'
+        # Combine the live label buckets with the frozen snapshot's into one membership view, printed as
+        # {merged, closed, open}. Prints nothing and returns non-zero if the merge fails.
+        #
+        # A pull request present in the snapshot is taken FROM the snapshot, bucket and all. Both
+        # sources describe the same pull request, but the snapshot node is a direct read issued this
+        # pass while the live node comes from GitHub's eventually-consistent search index, so the
+        # snapshot carries the fresher state and head SHA — and posting a check on a stale head is the
+        # "stranded on Expected" failure this action exists to avoid. It also keeps each pull request in
+        # exactly ONE bucket: two sources disagreeing about a member (the index still calling a merged
+        # pull request open) would otherwise count it twice and post success on a merged head.
+        # This cannot weaken detection: MERGED is terminal, so a fresher read never demotes a member the
+        # index already reports as merged, and `merged >= 1` is the precondition every decision needs.
+        #
+        # Every node is tagged `liveMember`, recording whether the live `epic:<N>` label search still
+        # returns it. Detection ignores the tag — a de-labeled member is a member. Mutations must not:
+        # see the roll-forward in sweep_post_clear.
+        union_buckets() { # $1..$3 = live merged/closed/open, $4..$6 = snapshot merged/closed/open
+          jq -cn --argjson lm "$1" --argjson lc "$2" --argjson lo "$3" \
+            --argjson sm "$4" --argjson sc "$5" --argjson so "$6" '
+            def key: "\(.repository.nameWithOwner | ascii_downcase)#\(.number)";
+            ([$lm[], $lc[], $lo[]] | map(key)) as $livekeys
+            | ([$sm[], $sc[], $so[]] | map(key)) as $snapkeys
+            | def live($b): [ $b[] | select((key | IN($snapkeys[])) | not) | . + {liveMember: true} ];
+              def snap($b): [ $b[] | . + {liveMember: (key | IN($livekeys[]))} ];
+            { merged: (snap($sm) + live($lm)),
+              closed: (snap($sc) + live($lc)),
+              open:   (snap($so) + live($lo)) }'
         }
 
         # ---- Post helpers (dry-run aware; the checks token posts) -------------------------
@@ -664,16 +711,23 @@ runs:
           case "$snap_rc" in
             0)
               membership=live+snapshot
-              merged=$(union_nodes "$merged" "$SNAP_MERGED")
-              closed_unmerged=$(union_nodes "$closed_unmerged" "$SNAP_CLOSED")
-              open=$(union_nodes "$open" "$SNAP_OPEN")
+              local buckets
+              if ! buckets=$(union_buckets "$merged" "$closed_unmerged" "$open" \
+                "$SNAP_MERGED" "$SNAP_CLOSED" "$SNAP_OPEN"); then
+                printf 'evaluate_epic: could not merge the live and snapshot member sets for epic #%s\n' "$EPIC" >&2
+                return 0
+              fi
+              merged=$(printf '%s' "$buckets" | jq -c '.merged')
+              closed_unmerged=$(printf '%s' "$buckets" | jq -c '.closed')
+              open=$(printf '%s' "$buckets" | jq -c '.open')
               ;;
             2) : ;; # pre-activation, or no usable marker — the live floor stands alone
             *)
-              # A frozen set exists but could not be resolved. Deciding on the live floor alone would
-              # mean answering "is a member missing?" with the one source that cannot see a missing
-              # member — and a `clear` is not passive here, it POSTS success. Leave EV_DECISION=error:
-              # the sweep posts nothing (any standing freeze survives) and re-derives next pass.
+              # A frozen set exists (or might) and could not be resolved. Deciding on the live floor
+              # alone would mean answering "is a member missing?" with the one source that cannot see a
+              # missing member — and a `clear` is not passive here, it POSTS success and would lift a
+              # freeze an earlier pass set. Leave EV_DECISION=error: the sweep posts nothing (a standing
+              # freeze survives) and re-derives next pass.
               return 0
               ;;
           esac
@@ -811,11 +865,23 @@ runs:
           local epic="$1"
           if [ "$EV_MERGED_COUNT" -ge 1 ] && [ "$EV_STRAY_COUNT" -ge 1 ]; then
             echo "epic #$epic: $EV_STRAY_COUNT stray sibling(s) within grace — rolling forward." | tee -a "$GITHUB_STEP_SUMMARY"
-            local s_repo s_num
+            # Roll forward only strays the live `epic:<N>` label search still returns. A snapshot-only
+            # member is one a human de-labeled, and re-arming auto-merge on it would do three wrong
+            # things at once: resume a landing a human stepped out of (the one thing epic-freeze must
+            # never do), arm a pull request that merge-gate and per-PR both now classify as standalone
+            # and therefore no longer gate, and reach for a repository outside the enqueue token's
+            # scope, which is derived from that same label search and would 403 on every sweep forever.
+            # Detection still counts it: it stays in EV_STRAYS and can still trip the freeze at grace.
+            local s_repo s_num skipped
             while read -r s_repo s_num <&5; do
               [ -n "$s_repo" ] || continue
               reenqueue "$s_repo" "$s_num"
-            done 5< <(printf '%s' "$EV_STRAYS" | jq -r '.[] | select(.isDraft | not) | "\(.repository.nameWithOwner) \(.number)"')
+            done 5< <(printf '%s' "$EV_STRAYS" | jq -r '.[] | select((.isDraft | not) and .liveMember) | "\(.repository.nameWithOwner) \(.number)"')
+            skipped=$(printf '%s' "$EV_STRAYS" | jq -r '[.[] | select((.isDraft | not) and (.liveMember | not))] | length')
+            if [ "$skipped" -gt 0 ]; then
+              echo "::warning::epic #$epic: $skipped stray sibling(s) are frozen-set members the \`epic:$epic\` label no longer returns — NOT rolled forward (a de-labeled member is not auto-merged back into a landing). They still count toward the freeze." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
           fi
           if [ "$EV_OPEN_COUNT" -eq 0 ]; then
             echo "epic #$epic: no open siblings — nothing to post." | tee -a "$GITHUB_STEP_SUMMARY"
@@ -923,9 +989,12 @@ runs:
           # and wins on a head both could touch — flipping a contested head to fail-closed. Two things
           # contest a head: a lagging label index, and a snapshot member whose label was removed while it
           # stayed open (the backstop reads labels, so it sees a non-member; the epic pass reads the frozen
-          # set, so it sees a member). The epic pass wins wherever it runs — but note it does not always
-          # run: a paused Epic returns before evaluate_epic, and an error decision posts nothing, so on
-          # those two branches the backstop's success stands as the last word on such a head.
+          # set, so it sees a member).
+          # This ordering only settles the contest WITHIN one sweep, and only on the branches that post: a
+          # paused Epic returns before evaluate_epic, and an error decision posts nothing, so on those the
+          # backstop's success stands. It settles nothing against per-PR mode, which classifies by label
+          # alone and will green a de-labeled member's head on its next event —
+          # https://github.com/a-novel-kit/workflows/issues/325. Treat the sweep as a floor, not a gate.
           # Always runs, even with no active Epics.
           standalone_sweep
 

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -521,7 +521,7 @@ runs:
           # that opens a value before parsing. Requiring the JSON to be one compact line at column 0
           # (what a `grep '^{'` does) silently kills a pretty-printed marker; parsing the note as JSON
           # kills every marker the writer actually emits. `-s .[0]` takes the first value if a hand-edit
-          # left several. All three participants extract identically — see the contract note above.
+          # left several — though trailing prose inside the region still voids the whole marker, which fails safe. All three participants extract identically — see the contract note above.
           marker=$(printf '%s\n' "$body" \
             | awk -v s="$START_M" -v e="$END_M" '$0 == s {f=1;next} $0 == e {f=0} f' \
             | sed -n '/^[[:space:]]*[{[]/,$p' \
@@ -536,11 +536,12 @@ runs:
           # one. The dedup key is case-folded because GitHub resolves repository names case-insensitively,
           # so `org/Repo` and `org/repo` are one member and would otherwise both be queried and both be
           # counted. The cap bounds the single aliased query below.
-          frozen=$(printf '%s' "$marker" | jq -c '
+          frozen=$(printf '%s' "$marker" | jq -c --arg org "$ORG" '
             select(type == "object" and .status == "frozen" and (.members | type == "array"))
             | .members
             | select(all(.[]; type == "object"
                 and (.repo | type == "string") and (.repo | test("\\A[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+\\z"))
+                and (.repo | ascii_downcase | startswith(($org | ascii_downcase) + "/"))
                 and (.number | type == "number" and . == floor and . > 0 and . < 2147483648)))
             | unique_by((.repo | ascii_downcase), .number)
             | select(length > 0 and length <= 50)' 2>/dev/null || true)
@@ -591,8 +592,13 @@ runs:
           # member must show it: either it still carries `epic:<N>`, or its timeline records having been
           # labeled with it. That is exactly the "was a member" claim the snapshot exists to remember —
           # unavailable by SEARCH, which is why the set is persisted, but verifiable per pull request.
-          # Any member that cannot show it means the marker is not trustworthy, so the whole snapshot is
-          # dropped and the pass falls back to the live floor rather than acting on part of it.
+          # A member that cannot show it means the marker is not trustworthy. Dropping just that member
+          # would be worse than useless — the marker is attacker-controlled, so the surviving subset is
+          # attacker-chosen — and falling back to the live floor is worse still: the floor is the blind
+          # spot the snapshot exists to cover, and a `clear` POSTS success, so a single appended object
+          # would LIFT a standing freeze and let the partial landing finish. The only honest answer to
+          # "the authoritative record is untrustworthy" is to decide nothing (rc 1), which leaves any
+          # prior freeze in place and re-derives next pass.
           local unverified
           unverified=$(printf '%s' "$rh" | jq -r --arg lbl "epic:$1" '
             [ (.data // {}) | to_entries[] | .value.pullRequest | select(. != null)
@@ -600,8 +606,8 @@ runs:
                   + [(.timelineItems.nodes // [])[] | .label.name // empty]) | index($lbl)) | not)
               | "\(.repository.nameWithOwner)#\(.number)" ] | join(", ")' 2>/dev/null || printf 'PARSE_FAILURE')
           if [ -n "$unverified" ]; then
-            echo "::error::epic #$1: the activation snapshot names pull request(s) that never carried the \`epic:$1\` label (${unverified}) — ignoring the whole snapshot and using the live label set. Check who edited ${ORG}/${PLANNING_REPO}#$1."
-            return 2
+            echo "::error::epic #$1: the activation snapshot names pull request(s) that never carried the \`epic:$1\` label (${unverified}) — refusing to decide anything for this Epic until it is corrected. Check who edited ${ORG}/${PLANNING_REPO}#$1."
+            return 1
           fi
 
           # Reconcile each node against the member it was asked for, so a response cannot smuggle in a
@@ -700,16 +706,17 @@ runs:
         # to follow that method.
         reenqueue() { # $1=owner/repo $2=number
           local target="$1#$2" already
-          if [ "$dry" != "false" ]; then
-            echo "would re-enqueue (enable auto-merge) on $target (DRY RUN)" | tee -a "$GITHUB_STEP_SUMMARY"
-            return 0
-          fi
-          # The enqueue token is deliberately absent when repo discovery failed (the scope step warns
-          # and mints nothing). Say that plainly here, or every stray reports as a GitHub failure and
-          # the log reads like an outage instead of the deliberate skip it is.
+          # Checked before the dry-run return, so a rehearsal reports what would REALLY happen: the
+          # enqueue token is deliberately absent when repo discovery failed (the scope step warns and
+          # mints nothing), and claiming "would re-enqueue" there is a rehearsal that lies. It also
+          # keeps a live sweep from reporting the deliberate skip as a GitHub outage.
           if [ -z "${WRITE_TOKEN:-}" ]; then
             echo "::warning::no enqueue token this sweep (repo discovery failed) — not rolling $target forward; the next sweep retries." \
               | tee -a "$GITHUB_STEP_SUMMARY"
+            return 0
+          fi
+          if [ "$dry" != "false" ]; then
+            echo "would re-enqueue (enable auto-merge) on $target (DRY RUN)" | tee -a "$GITHUB_STEP_SUMMARY"
             return 0
           fi
           already=$(GH_TOKEN="$WRITE_TOKEN" gh pr view "$2" --repo "$1" --json autoMergeRequest \

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -9,8 +9,10 @@ description: >
 
   It runs in two modes over one shared, pure predicate (evaluate_epic — no posting or mutation) so
   the two writers structurally cannot disagree. Per-PR is the event-driven fast path: it classifies
-  the triggering PR and posts epic-freeze on its head only, and fails open (success on any
-  uncertainty) so a fresh head is never stranded on "Expected". The sweep (a level-triggered floor,
+  the triggering PR and posts epic-freeze on its head only, and fails open (success) on uncertainty it
+  can attribute — a resolve, queue, or REST error against a known head — so a fresh head is never
+  stranded on "Expected". It fails CLOSED where it cannot even identify what it is judging: an
+  unparseable merge-group ref, or a head with no pull request, dequeue rather than pass blind. The sweep (a level-triggered floor,
   roughly every 15 minutes) enumerates active Epics org-wide, rolls strays forward within grace,
   freezes REST-confirmed partials, and backstops every open non-member head; it fails closed. Both
   re-derive every member's state each pass, so no judgment rests on stored state.
@@ -31,18 +33,20 @@ description: >
 
   It recovers rather than rolls back: the sweep re-enqueues a landable stray within grace
   (self-heals, no freeze), freezes after grace, and unfreezes (re-posts `success`) once the Epic is
-  whole. Unfreeze never re-enables auto-merge — dequeue disabled it on purpose so a frozen sibling
-  can't thrash; resuming a frozen landing is a human's call. It never reverts a merged PR. `dry_run`
+  whole. The unfreeze POST itself never arms auto-merge, but the same pass rolls landable strays
+  forward, so an Epic that returns to landable inside the grace window does get its siblings re-armed
+  — a freeze is not a latch a human must clear. It never reverts a merged PR. `dry_run`
   defaults on: it logs every intended freeze, unfreeze, and re-enqueue without calling GitHub.
 
 inputs:
   client_id:
     required: true
     description: >
-      Client ID of the [Agent] App. The sweep mints three least-privilege org-wide tokens: issues +
-      PR read, checks:write, and PR + contents write (to roll a stray forward). Per-PR mints only the
-      first two — the write token is gated to the sweep. The App identity fixes the check's
-      integration ID so a ruleset can require it.
+      Client ID of the [Agent] App. The sweep mints up to three least-privilege tokens: issues + PR
+      read and checks:write, both org-wide, plus PR + contents write to roll a stray forward — that
+      third one SCOPED to the repositories with an active Epic (see the discovery step), not org-wide,
+      and skipped entirely when that set is empty. Per-PR mints only the first two; the write token is
+      gated to the sweep. The App identity fixes the check's integration ID so a ruleset can require it.
   app_private_key:
     required: true
     description: Private key (PEM) of that App.
@@ -411,13 +415,13 @@ runs:
         rest_pr_state() { # $1=owner/repo $2=number
           local data
           for attempt in 1 2 3; do
-            if data=$(gh api "repos/$1/pulls/$2" 2>/dev/null); then
+            if data=$(gh api "repos/$1/pulls/$2" 2>&1); then
               printf '%s' "$data" | jq -r '"\(.state) \(.merged)"'
               return 0
             fi
             [ "$attempt" -lt 3 ] && sleep 2
           done
-          printf 'rest_pr_state failed for %s#%s\n' "$1" "$2" >&2
+          printf 'rest_pr_state failed for %s#%s after 3 attempts: %s\n' "$1" "$2" "${data:-<no response>}" >&2
           return 1
         }
 
@@ -426,13 +430,14 @@ runs:
         fetch_pr_labels() { # $1 = pr number
           local data
           for attempt in 1 2 3; do
-            if data=$(gh api graphql -f query="$PR_LABELS_Q" -F owner="$OWNER" -F repo="$REPO" -F num="$1" 2>/dev/null) \
+            if data=$(gh api graphql -f query="$PR_LABELS_Q" -F owner="$OWNER" -F repo="$REPO" -F num="$1" 2>&1) \
               && printf '%s' "$data" | jq -e 'has("data") and (has("errors") | not) and (.data.repository.pullRequest != null)' >/dev/null 2>&1; then
               printf '%s' "$data" | jq -c '[(.data.repository.pullRequest.labels.nodes // [])[].name]'
               return 0
             fi
             [ "$attempt" -lt 3 ] && sleep 2
           done
+          printf 'fetch_pr_labels failed for PR #%s after 3 attempts: %s\n' "$1" "${data:-<no response>}" >&2
           return 1
         }
 
@@ -467,6 +472,11 @@ runs:
         # The marker contract (fence names, `status`, `members`) is shared with epic-membership and
         # merge-gate — a change to its shape has to land in all three.
         snapshot_buckets() { # $1 = epic number
+          # The fence strings, matched as WHOLE LINES. An unanchored match would let a pseudo-fence
+          # planted inside an HTML comment shadow the real region on every read while staying
+          # invisible to merge-gate's splice (which matches exact lines), so a tamper would survive
+          # every capture pass instead of self-healing.
+          local START_M='<!-- epic-membership:snapshot:start -->' END_M='<!-- epic-membership:snapshot:end -->'
           SNAP_MERGED='[]'
           SNAP_CLOSED='[]'
           SNAP_OPEN='[]'
@@ -507,11 +517,14 @@ runs:
             return 1
           fi
 
-          # Take the whole fenced region and let jq parse it, so the marker is not silently required to
-          # be single-line compact JSON — a pretty-printed one would otherwise kill the feature with no
-          # warning. `-s .[0]` takes the first value if a hand-edit left several.
+          # The fenced region holds a human-readable note and then the JSON, so skip to the first line
+          # that opens a value before parsing. Requiring the JSON to be one compact line at column 0
+          # (what a `grep '^{'` does) silently kills a pretty-printed marker; parsing the note as JSON
+          # kills every marker the writer actually emits. `-s .[0]` takes the first value if a hand-edit
+          # left several. All three participants extract identically — see the contract note above.
           marker=$(printf '%s\n' "$body" \
-            | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
+            | awk -v s="$START_M" -v e="$END_M" '$0 == s {f=1;next} $0 == e {f=0} f' \
+            | sed -n '/^[[:space:]]*[{[]/,$p' \
             | jq -s -c '.[0] // empty' 2>/dev/null || true)
           [ -n "$marker" ] || return 2
           # Only a well-formed FROZEN marker counts. A pending marker (the set has not settled yet), a
@@ -527,10 +540,10 @@ runs:
             select(type == "object" and .status == "frozen" and (.members | type == "array"))
             | .members
             | select(all(.[]; type == "object"
-                and (.repo | type == "string") and (.repo | test("^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+$"))
+                and (.repo | type == "string") and (.repo | test("\\A[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+\\z"))
                 and (.number | type == "number" and . == floor and . > 0 and . < 2147483648)))
             | unique_by((.repo | ascii_downcase), .number)
-            | select(length > 0 and length <= 200)' 2>/dev/null || true)
+            | select(length > 0 and length <= 50)' 2>/dev/null || true)
           { [ -n "$frozen" ] && [ "$frozen" != "null" ]; } || return 2
           want=$(printf '%s' "$frozen" | jq 'length')
 
@@ -546,7 +559,9 @@ runs:
           # that rejects the whole query rather than one alias, wedging the Epic on every retry.
           alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
-              + "{pullRequest(number:\(.value.number|floor)){number headRefOid mergedAt baseRefName isDraft state repository{nameWithOwner}}}"
+              + "{pullRequest(number:\(.value.number|floor)){number headRefOid mergedAt baseRefName isDraft state repository{nameWithOwner}"
+              + " labels(first:100){nodes{name}}"
+              + " timelineItems(last:250, itemTypes:[LABELED_EVENT]){nodes{... on LabeledEvent{label{name}}}}}}"
             ) | join("\n")')
           rh=""
           for attempt in 1 2 3; do
@@ -568,6 +583,27 @@ runs:
             return 1
           fi
 
+          # CORROBORATE membership before trusting the marker. The marker lives in an issue body, so its
+          # author is whoever can edit that issue — and every member it names becomes a freeze target
+          # posted with an org-wide checks:write token. Without this, naming arbitrary pull requests
+          # would let one issue edit block merges across the whole org.
+          # The label is the permission-gated assertion (applying it needs >= triage on that repo), so a
+          # member must show it: either it still carries `epic:<N>`, or its timeline records having been
+          # labeled with it. That is exactly the "was a member" claim the snapshot exists to remember —
+          # unavailable by SEARCH, which is why the set is persisted, but verifiable per pull request.
+          # Any member that cannot show it means the marker is not trustworthy, so the whole snapshot is
+          # dropped and the pass falls back to the live floor rather than acting on part of it.
+          local unverified
+          unverified=$(printf '%s' "$rh" | jq -r --arg lbl "epic:$1" '
+            [ (.data // {}) | to_entries[] | .value.pullRequest | select(. != null)
+              | select((([(.labels.nodes // [])[].name]
+                  + [(.timelineItems.nodes // [])[] | .label.name // empty]) | index($lbl)) | not)
+              | "\(.repository.nameWithOwner)#\(.number)" ] | join(", ")' 2>/dev/null || printf 'PARSE_FAILURE')
+          if [ -n "$unverified" ]; then
+            echo "::error::epic #$1: the activation snapshot names pull request(s) that never carried the \`epic:$1\` label (${unverified}) — ignoring the whole snapshot and using the live label set. Check who edited ${ORG}/${PLANNING_REPO}#$1."
+            return 2
+          fi
+
           # Reconcile each node against the member it was asked for, so a response cannot smuggle in a
           # pull request nobody asked about — such a node would flow into EV_OPEN and become a freeze
           # target under an org-wide checks:write token. Identity is the ALIAS INDEX plus the pull
@@ -575,11 +611,11 @@ runs:
           # answers with the NEW nameWithOwner, and since a frozen marker is never rewritten, matching
           # on the name would wedge a renamed member's Epic at `error` forever. The number is stable
           # under a rename, and the alias index is ours, so together they still pin identity.
-          nodes=$(printf '%s' "$rh" | jq -c --argjson want "$frozen" '
+          nodes=$(printf '%s' "$rh" | jq -c --argjson members "$frozen" '
             [ (.data // {}) | to_entries[]
               | (.key | ltrimstr("m") | tonumber) as $i
               | .value.pullRequest | select(. != null)
-              | select($want[$i] != null and .number == ($want[$i].number | floor)) ]' 2>/dev/null || true)
+              | select($members[$i] != null and .number == ($members[$i].number | floor)) ]' 2>/dev/null || true)
           if [ -z "$nodes" ] || [ "$(printf '%s' "$nodes" | jq 'length')" -ne "$want" ] \
             || ! printf '%s' "$nodes" | jq -e 'all(.[]; .state == "MERGED" or .state == "CLOSED" or .state == "OPEN")' >/dev/null 2>&1; then
             printf 'snapshot_buckets: re-read of epic #%s did not answer its own member set (unmatched, duplicated, or unknown-state nodes)\n' "$1" >&2
@@ -617,7 +653,9 @@ runs:
             ([$lm[], $lc[], $lo[]] | map(key)) as $livekeys
             | ([$sm[], $sc[], $so[]] | map(key)) as $snapkeys
             | def live($b): [ $b[] | select((key | IN($snapkeys[])) | not) | . + {liveMember: true} ];
-              def snap($b): [ $b[] | . + {liveMember: (key | IN($livekeys[]))} ];
+              # unique_by here as well as on the marker: two entries naming one repository under an old
+              # and a new name are distinct strings, but GraphQL resolves both to the same pull request.
+              def snap($b): [ $b[] | . + {liveMember: (key | IN($livekeys[]))} ] | unique_by(key);
             { merged: (snap($sm) + live($lm)),
               closed: (snap($sc) + live($lc)),
               open:   (snap($so) + live($lo)) }'
@@ -666,6 +704,14 @@ runs:
             echo "would re-enqueue (enable auto-merge) on $target (DRY RUN)" | tee -a "$GITHUB_STEP_SUMMARY"
             return 0
           fi
+          # The enqueue token is deliberately absent when repo discovery failed (the scope step warns
+          # and mints nothing). Say that plainly here, or every stray reports as a GitHub failure and
+          # the log reads like an outage instead of the deliberate skip it is.
+          if [ -z "${WRITE_TOKEN:-}" ]; then
+            echo "::warning::no enqueue token this sweep (repo discovery failed) — not rolling $target forward; the next sweep retries." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            return 0
+          fi
           already=$(GH_TOKEN="$WRITE_TOKEN" gh pr view "$2" --repo "$1" --json autoMergeRequest \
             -q '.autoMergeRequest != null' 2>/dev/null || echo "unknown")
           if [ "$already" = "true" ]; then
@@ -709,19 +755,13 @@ runs:
           # `merged >= 1` is the precondition every decision below hangs on.
           snapshot_buckets "$EPIC" || snap_rc=$?
           case "$snap_rc" in
-            0)
-              membership=live+snapshot
-              local buckets
-              if ! buckets=$(union_buckets "$merged" "$closed_unmerged" "$open" \
-                "$SNAP_MERGED" "$SNAP_CLOSED" "$SNAP_OPEN"); then
-                printf 'evaluate_epic: could not merge the live and snapshot member sets for epic #%s\n' "$EPIC" >&2
-                return 0
-              fi
-              merged=$(printf '%s' "$buckets" | jq -c '.merged')
-              closed_unmerged=$(printf '%s' "$buckets" | jq -c '.closed')
-              open=$(printf '%s' "$buckets" | jq -c '.open')
-              ;;
-            2) : ;; # pre-activation, or no usable marker — the live floor stands alone
+            0) membership=live+snapshot ;;
+            # Pre-activation, or no usable marker: the live floor stands alone. It still goes through
+            # union_buckets, against an empty snapshot — every membership view is built the same way, so
+            # `liveMember` is present on every node no matter which path produced it. Tagging only on the
+            # snapshot path once left these nodes untagged, and since jq reads a missing key as null, the
+            # roll-forward silently selected nothing while its skip-warning selected everything.
+            2) SNAP_MERGED='[]'; SNAP_CLOSED='[]'; SNAP_OPEN='[]' ;;
             *)
               # A frozen set exists (or might) and could not be resolved. Deciding on the live floor
               # alone would mean answering "is a member missing?" with the one source that cannot see a
@@ -731,6 +771,15 @@ runs:
               return 0
               ;;
           esac
+          local buckets
+          if ! buckets=$(union_buckets "$merged" "$closed_unmerged" "$open" \
+            "$SNAP_MERGED" "$SNAP_CLOSED" "$SNAP_OPEN"); then
+            printf 'evaluate_epic: could not build the member set for epic #%s\n' "$EPIC" >&2
+            return 0
+          fi
+          merged=$(printf '%s' "$buckets" | jq -c '.merged')
+          closed_unmerged=$(printf '%s' "$buckets" | jq -c '.closed')
+          open=$(printf '%s' "$buckets" | jq -c '.open')
 
           EV_OPEN="$open"
           EV_MERGED_COUNT=$(printf '%s' "$merged" | jq 'length')
@@ -872,7 +921,7 @@ runs:
             # and therefore no longer gate, and reach for a repository outside the enqueue token's
             # scope, which is derived from that same label search and would 403 on every sweep forever.
             # Detection still counts it: it stays in EV_STRAYS and can still trip the freeze at grace.
-            local s_repo s_num skipped
+            local s_repo s_num skipped drafts
             while read -r s_repo s_num <&5; do
               [ -n "$s_repo" ] || continue
               reenqueue "$s_repo" "$s_num"
@@ -880,6 +929,14 @@ runs:
             skipped=$(printf '%s' "$EV_STRAYS" | jq -r '[.[] | select((.isDraft | not) and (.liveMember | not))] | length')
             if [ "$skipped" -gt 0 ]; then
               echo "::warning::epic #$epic: $skipped stray sibling(s) are frozen-set members the \`epic:$epic\` label no longer returns — NOT rolled forward (a de-labeled member is not auto-merged back into a landing). They still count toward the freeze." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
+            # Drafts are skipped too, and silently until now: a draft stray cannot be auto-merged, so it
+            # sits out every roll-forward and is guaranteed to reach the freeze at grace. Say so while
+            # there is still time to mark it ready.
+            drafts=$(printf '%s' "$EV_STRAYS" | jq -r '[.[] | select(.isDraft)] | length')
+            if [ "$drafts" -gt 0 ]; then
+              echo "::warning::epic #$epic: $drafts stray sibling(s) are DRAFTS — not rolled forward (a draft cannot auto-merge). Mark them ready before the ${GRACE_MINUTES}-minute grace elapses or they trip the freeze." \
                 | tee -a "$GITHUB_STEP_SUMMARY"
             fi
           fi

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -15,12 +15,14 @@ description: >
   freezes REST-confirmed partials, and backstops every open non-member head; it fails closed. Both
   re-derive every member's state each pass, so no judgment rests on stored state.
 
-  One thing is read from storage: WHICH pull requests are members. Until merge-gate freezes the set,
-  that is the live `epic:<N>` label search; after, it is the activation snapshot merge-gate captured
-  into the Epic body. The snapshot is what makes an abandoned member visible — a PR de-labeled and
-  closed mid-landing leaves no trace the live search can find, because GitHub indexes no "ever
-  carried label X", so without the frozen set the detector would read the remaining siblings as a
-  clean landing.
+  One thing is read from storage: WHICH pull requests are members. The live `epic:<N>` label search is
+  the floor, and once merge-gate has frozen an activation snapshot into the Epic body its members are
+  added on top — added, never substituted, so a snapshot can only widen what the detector sees and
+  never narrow it. That addition is what makes an abandoned member visible: a pull request de-labeled
+  and closed mid-landing leaves no trace the live search can find, because GitHub indexes no "ever
+  carried label X", so on the live set alone the survivors read as a clean landing. The sweep still
+  REACHES an Epic through live labels, so an Epic whose last labeled open pull request is de-labeled
+  drops out of enumeration altogether — the snapshot rescues a forgotten member, not a forgotten Epic.
 
   The freeze is a check-run, not a status: an `epic-freeze` check-run (checks:write) posted with
   `conclusion: failure` — never `neutral`, which GitHub counts as a passing required check — on a
@@ -440,61 +442,85 @@ runs:
           printf '%s\n' "$out" | grep -qx 'automation:paused'
         }
 
-        # Bucket an Epic's FROZEN activation-snapshot members by their live state. Once landing
-        # stabilizes, merge-gate captures the member set into a marker in the Epic body; from then on
-        # membership IS that set, so a member de-labeled mid-landing stays a member and its
-        # abandonment is still seen here. The live label search cannot cover that: GitHub indexes no
-        # "ever carried label X", so a de-labeled PR is unrecoverable from live truth — which is the
-        # whole reason the set is persisted. Only the SET is frozen; every member's STATE is re-read
-        # live on each pass.
-        # Prints nothing; fills SNAP_MERGED / SNAP_CLOSED / SNAP_OPEN with the same node shape
-        # search_prs returns (repository.nameWithOwner, number, headRefOid, mergedAt, baseRefName,
-        # isDraft), so the bucketing downstream is identical whichever source fed it.
-        # Returns 0 = frozen set resolved, 2 = no usable snapshot (caller uses the live searches),
-        # 1 = a frozen set exists but could not be re-read (caller fails closed for this Epic).
+        # Read an Epic's FROZEN activation-snapshot members and bucket them by their live state. Once
+        # landing stabilizes, merge-gate captures the member set into a marker in the Epic body. That
+        # set is what the live label search cannot reconstruct: GitHub indexes no "ever carried label
+        # X", so a member de-labeled mid-landing is gone from live truth for good. Only the SET is
+        # persisted; every member's STATE is re-read here on each pass.
+        #
+        # These buckets are ADDED to the live ones by the caller, never substituted for them (see
+        # evaluate_epic). That is deliberate: the frozen set is NOT a superset of the live one. merge-gate
+        # builds it from OPEN pull requests and promotes it only after the set holds still, while
+        # auto-merge is armed earlier — so members routinely merge before the freeze and a frozen set
+        # commonly omits them. Substituting it would empty the `merged` bucket that gates all detection.
+        #
+        # Prints nothing; fills SNAP_MERGED / SNAP_CLOSED / SNAP_OPEN with the node shape search_prs
+        # returns (repository.nameWithOwner, number, headRefOid, mergedAt, baseRefName, isDraft).
+        # Returns 0 = frozen set resolved, 2 = no usable snapshot (the live floor stands on its own),
+        # 1 = a frozen set exists but could NOT be resolved. On 1 the caller leaves EV_DECISION=error,
+        # which the sweep treats as "post nothing this pass" (a standing freeze survives) and per-PR as
+        # fail-open on the head — so 1 costs a pass, never a false clear in the sweep.
         # The marker contract (fence names, `status`, `members`) is shared with epic-membership and
         # merge-gate — a change to its shape has to land in all three.
         snapshot_buckets() { # $1 = epic number
-          SNAP_MERGED='[]'; SNAP_CLOSED='[]'; SNAP_OPEN='[]'
-          local body="" ok=false marker frozen alias_q rh out nodes
+          SNAP_MERGED='[]'
+          SNAP_CLOSED='[]'
+          SNAP_OPEN='[]'
+          local resp="" body="" ok=false marker frozen want alias_q rh out nodes
           for attempt in 1 2 3; do
-            # GitHub stores bodies with CRLF; strip \r so the marker fences match. stderr is folded in
-            # so a 404 — the Epic issue simply is not in the planning repo — is recognizable and not retried.
-            if body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" --jq '.body // ""' 2>&1 | tr -d '\r'); then
+            # Read the whole issue and take `.body` through jq rather than `--jq`: validating that the
+            # response parses as an issue object is what keeps a gh notice on stderr (folded in here so
+            # the 404 case is recognizable) from being parsed as body text.
+            if resp=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" 2>&1) \
+              && printf '%s' "$resp" | jq -e 'type == "object" and has("body")' >/dev/null 2>&1; then
+              # GitHub stores bodies with CRLF; strip \r so the marker fences match.
+              body=$(printf '%s' "$resp" | jq -r '.body // ""' | tr -d '\r')
               ok=true
               break
             fi
-            case "$body" in *"HTTP 404"*) break ;; esac
+            # The Epic issue simply is not in the planning repo — nothing to retry.
+            case "$resp" in *"HTTP 404"*) break ;; esac
             [ "$attempt" -lt 3 ] && sleep 2
           done
           if [ "$ok" != true ]; then
-            # Downgrading to the live set is the recoverable failure (a missed freeze is re-derived by
-            # the next sweep); holding every Epic on a body-read hiccup is not. Warn so it stays visible.
-            echo "::warning::epic #$1: could not read ${ORG}/${PLANNING_REPO}#$1 — no snapshot applied this pass, using the live label set."
+            # No snapshot applied, so this pass sees exactly what it saw before the snapshot existed —
+            # bounded by the live floor, and re-derived by the next sweep. Warn so it stays visible.
+            echo "::warning::epic #$1: could not read ${ORG}/${PLANNING_REPO}#$1 — no snapshot applied this pass, live label set only."
             return 2
           fi
 
+          # Take the whole fenced region and let jq parse it, so the marker is not silently required to
+          # be single-line compact JSON — a pretty-printed one would otherwise kill the feature with no
+          # warning. `-s .[0]` takes the first value if a hand-edit left several.
           marker=$(printf '%s\n' "$body" \
             | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
-            | grep -m1 '^{' || true)
+            | jq -s -c '.[0] // empty' 2>/dev/null || true)
           [ -n "$marker" ] || return 2
-          # Only a well-formed FROZEN marker counts, validated exactly as epic-membership validates it.
-          # A pending marker (the set has not settled yet), a hand-edited one, or the wrong shape falls
-          # back to the live set rather than crashing or freezing the Epic on garbage.
+          # Only a well-formed FROZEN marker counts. A pending marker (the set has not settled yet), a
+          # hand-edited one, or the wrong shape falls back to the live floor rather than crashing.
+          # The guards are strict because `.repo` and `.number` are interpolated into a GraphQL document
+          # below and the Epic body is writable by anyone with write access to the planning repo:
+          # `[^/]` would admit quotes and newlines (enough to inject fields), and `type == "number"`
+          # alone would admit 1.5, which is a document-level validation error rather than a skippable
+          # one. `unique` keeps a repeated member from double-posting downstream; the cap bounds the
+          # single aliased query below.
           frozen=$(printf '%s' "$marker" | jq -c '
-            select(type == "object" and .status == "frozen" and (.members | type == "array")
-              and (.members | all(type == "object"
-                and (.repo | type == "string") and (.repo | test("^[^/]+/[^/]+$"))
-                and (.number | type == "number")))) | .members' 2>/dev/null || true)
+            select(type == "object" and .status == "frozen" and (.members | type == "array"))
+            | .members
+            | select(all(.[]; type == "object"
+                and (.repo | type == "string") and (.repo | test("^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+$"))
+                and (.number | type == "number" and . == floor and . > 0 and . < 2147483648)))
+            | unique_by(.repo, .number)
+            | select(length > 0 and length <= 200)' 2>/dev/null || true)
           { [ -n "$frozen" ] && [ "$frozen" != "null" ]; } || return 2
-          # An empty frozen set has nothing to re-read (and would build an empty GraphQL query): leave
-          # the buckets empty, which reads downstream as "nothing has landed" → clear.
-          [ "$(printf '%s' "$frozen" | jq 'length')" -gt 0 ] || return 0
+          want=$(printf '%s' "$frozen" | jq 'length')
 
-          # One aliased GraphQL call re-reads every member's live state. Aliases that error (a member
-          # repo deleted or renamed) are skipped and the survivors kept, so one bad repo cannot quietly
-          # empty the set. A total failure is an error rather than a fallback: we KNOW a frozen set
-          # exists, and the live set is precisely the weaker answer the snapshot exists to replace.
+          # One aliased GraphQL call re-reads every member's live state. It is all-or-nothing on
+          # purpose. GitHub answers a multi-alias query with partial data plus an `errors` array,
+          # nulling what failed — and in a DETECTOR a dropped member does not shrink a ready set (as it
+          # would in epic-membership, where the consumer then HOLDs), it erases the evidence of
+          # abandonment and reads as "nothing wrong". Accepting a short answer here would silently
+          # decide `clear` and post success on the very case this exists to catch.
           alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
               + "{pullRequest(number:\(.value.number)){number headRefOid mergedAt baseRefName isDraft state repository{nameWithOwner}}}"
@@ -502,7 +528,10 @@ runs:
           rh=""
           for attempt in 1 2 3; do
             out=$(gh api graphql -f query="{ ${alias_q} }" 2>&1 || true)
-            if printf '%s' "$out" | jq -e 'has("data") and (.data | length > 0)' >/dev/null 2>&1; then
+            if printf '%s' "$out" | jq -e --argjson want "$want" '
+                 (has("errors") | not)
+                 and (((.data // {}) | to_entries | map(.value.pullRequest | select(. != null)) | length) == $want)
+               ' >/dev/null 2>&1; then
               rh="$out"
               break
             fi
@@ -511,17 +540,40 @@ runs:
           if [ -z "$rh" ]; then
             # Runs in the caller's shell but the decision is silent (EV_DECISION stays error), so echo
             # the underlying failure here or the fail-closed pass is undiagnosable.
-            printf 'snapshot_buckets: could not re-read frozen member state for epic #%s after 3 attempts: %s\n' "$1" "$out" >&2
+            printf 'snapshot_buckets: could not re-read all %s frozen member(s) of epic #%s after 3 attempts: %s\n' \
+              "$want" "$1" "$out" >&2
+            return 1
+          fi
+
+          # Keep only nodes that answer a member actually asked for, then require the count to still
+          # match: a response is trusted to describe the frozen set, and a node for some other pull
+          # request would otherwise flow into EV_OPEN and become a freeze target under an org-wide
+          # checks:write token.
+          nodes=$(printf '%s' "$rh" | jq -c --argjson want "$frozen" '
+            [ (.data // {}) | to_entries[] | .value.pullRequest | select(. != null)
+              | . as $n | select($want | any(.repo == $n.repository.nameWithOwner and .number == $n.number)) ]')
+          if [ "$(printf '%s' "$nodes" | jq 'length')" -ne "$want" ] \
+            || ! printf '%s' "$nodes" | jq -e 'all(.[]; .state == "MERGED" or .state == "CLOSED" or .state == "OPEN")' >/dev/null 2>&1; then
+            printf 'snapshot_buckets: re-read of epic #%s did not answer its own member set (unknown or unmatched nodes)\n' "$1" >&2
             return 1
           fi
 
           # MERGED / CLOSED / OPEN are exclusive on a PullRequest — a merged PR reports MERGED, never
           # CLOSED — so CLOSED is exactly the closed-without-merge bucket the live search widens for.
-          nodes=$(printf '%s' "$rh" | jq -c '[(.data // {}) | to_entries[] | .value.pullRequest | select(. != null)]')
           SNAP_MERGED=$(printf '%s' "$nodes" | jq -c '[.[] | select(.state == "MERGED")]')
           SNAP_CLOSED=$(printf '%s' "$nodes" | jq -c '[.[] | select(.state == "CLOSED")]')
           SNAP_OPEN=$(printf '%s' "$nodes" | jq -c '[.[] | select(.state == "OPEN")]')
           return 0
+        }
+
+        # Merge snapshot members into a live bucket, one entry per (repo, number). The live node wins a
+        # collision: both describe the same pull request, and the live one came from the search shape
+        # the rest of evaluate_epic was written against.
+        union_nodes() { # $1 = live array, $2 = snapshot array
+          jq -cn --argjson live "$1" --argjson snap "$2" '
+            $live + [ $snap[] | . as $n
+              | select($live | any(.repository.nameWithOwner == $n.repository.nameWithOwner
+                  and .number == $n.number) | not) ]'
         }
 
         # ---- Post helpers (dry-run aware; the checks token posts) -------------------------
@@ -592,30 +644,36 @@ runs:
           local EPIC="$1"
           local base_q="label:\"epic:${EPIC}\" org:${ORG}"
 
-          # The member set comes from the Epic's frozen activation snapshot once it has one, and from
-          # the live `epic:<N>` label search until then. Both hand back the same three buckets in the
-          # same shape, so everything below is source-agnostic: the snapshot changes only WHICH pull
-          # requests are members — a de-labeled one stays — never how a member is judged.
-          local merged closed_unmerged open membership=snapshot snap_rc=0
+          # The live label set is the FLOOR. Widened resolve, three passes: is:closed is:unmerged
+          # catches the closed-without-merge blind spot; is:merged and is:open complete the picture.
+          # Any failure → EV_DECISION stays error.
+          local merged closed_unmerged open membership=live snap_rc=0
+          if ! merged=$(search_prs "is:pr is:merged $base_q"); then return 0; fi
+          if ! closed_unmerged=$(search_prs "is:pr is:closed is:unmerged $base_q"); then return 0; fi
+          if ! open=$(search_prs "is:pr is:open $base_q"); then return 0; fi
+
+          # The frozen snapshot is added ON TOP of that floor, never swapped for it. It contributes the
+          # members live truth has forgotten — a de-labeled one stays a member — and nothing else. The
+          # union is what makes this monotone: no snapshot, however degraded or incomplete, can shrink
+          # what the detector already saw, so the worst case is the behaviour that predates it. A
+          # straight substitution would not be safe, because a frozen set is not a superset of the live
+          # one: merge-gate captures it from OPEN pull requests after the set holds still, while
+          # auto-merge is armed earlier, so already-merged members are commonly absent from it — and
+          # `merged >= 1` is the precondition every decision below hangs on.
           snapshot_buckets "$EPIC" || snap_rc=$?
           case "$snap_rc" in
             0)
-              merged="$SNAP_MERGED"
-              closed_unmerged="$SNAP_CLOSED"
-              open="$SNAP_OPEN"
+              membership=live+snapshot
+              merged=$(union_nodes "$merged" "$SNAP_MERGED")
+              closed_unmerged=$(union_nodes "$closed_unmerged" "$SNAP_CLOSED")
+              open=$(union_nodes "$open" "$SNAP_OPEN")
               ;;
-            2)
-              # Pre-activation, or a marker that is pending / unreadable. Widened resolve, three passes:
-              # is:closed is:unmerged catches the closed-without-merge blind spot; is:merged and is:open
-              # complete the picture. Any failure → EV_DECISION stays error.
-              membership=live
-              if ! merged=$(search_prs "is:pr is:merged $base_q"); then return 0; fi
-              if ! closed_unmerged=$(search_prs "is:pr is:closed is:unmerged $base_q"); then return 0; fi
-              if ! open=$(search_prs "is:pr is:open $base_q"); then return 0; fi
-              ;;
+            2) : ;; # pre-activation, or no usable marker — the live floor stands alone
             *)
-              # A frozen set exists but its state could not be re-read → EV_DECISION stays error, which
-              # fails open here and is re-derived by merge-gate and the next sweep.
+              # A frozen set exists but could not be resolved. Deciding on the live floor alone would
+              # mean answering "is a member missing?" with the one source that cannot see a missing
+              # member — and a `clear` is not passive here, it POSTS success. Leave EV_DECISION=error:
+              # the sweep posts nothing (any standing freeze survives) and re-derives next pass.
               return 0
               ;;
           esac
@@ -865,7 +923,10 @@ runs:
           # and wins on a head both could touch — flipping a contested head to fail-closed. Two things
           # contest a head: a lagging label index, and a snapshot member whose label was removed while it
           # stayed open (the backstop reads labels, so it sees a non-member; the epic pass reads the frozen
-          # set, so it sees a member — and the member view has to win). Always runs, even with no active Epics.
+          # set, so it sees a member). The epic pass wins wherever it runs — but note it does not always
+          # run: a paused Epic returns before evaluate_epic, and an error decision posts nothing, so on
+          # those two branches the backstop's success stands as the last word on such a head.
+          # Always runs, even with no active Epics.
           standalone_sweep
 
           if [ -n "$epics" ]; then

--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -133,7 +133,7 @@ runs:
             | select(all(.[]; type == "object"
                 and (.repo | type == "string") and (.repo | test("^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+$"))
                 and (.number | type == "number" and . == floor and . > 0 and . < 2147483648)))
-            | unique_by(.repo, .number)
+            | unique_by((.repo | ascii_downcase), .number)
             | select(length > 0 and length <= 200)' 2>/dev/null || true)
         fi
         if [ -n "$frozen" ] && [ "$frozen" != "null" ]; then
@@ -144,7 +144,7 @@ runs:
           # correct fail-closed.
           alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
-              + "{pullRequest(number:\(.value.number)){number isDraft reviewDecision headRefOid state repository{nameWithOwner}}}"
+              + "{pullRequest(number:\(.value.number|floor)){number isDraft reviewDecision headRefOid state repository{nameWithOwner}}}"
             ) | join("\n")')
           rh='{}'
           for attempt in 1 2 3; do

--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -122,7 +122,7 @@ runs:
           # that opens a value before parsing. Requiring the JSON to be one compact line at column 0
           # (what a `grep '^{'` does) silently kills a pretty-printed marker; parsing the note as JSON
           # kills every marker merge-gate actually emits. `-s .[0]` takes the first value if a hand-edit
-          # left several. All three participants extract identically.
+          # left several — though trailing prose inside the region still voids the whole marker, which fails safe. All three participants extract identically.
           marker=$(printf '%s\n' "$body" \
             | awk -v s="$START_M" -v e="$END_M" '$0 == s {f=1;next} $0 == e {f=0} f' \
             | sed -n '/^[[:space:]]*[{[]/,$p' \

--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -114,17 +114,27 @@ runs:
         frozen=""
         # GitHub stores bodies with CRLF; strip \r so the marker lines match.
         if body=$(gh api "repos/${OWNER}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
+          # Take the whole fenced region and let jq parse it, so the marker is not silently required to
+          # be single-line compact JSON — a pretty-printed one would otherwise fall through to the live
+          # search with no warning. `-s .[0]` takes the first value if a hand-edit left several.
           marker=$(printf '%s\n' "$body" \
             | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
-            | grep -m1 '^{' || true)
+            | jq -s -c '.[0] // empty' 2>/dev/null || true)
           # Only a well-formed FROZEN marker with a valid member list counts; anything else (pending,
           # hand-edited garbage, wrong shape) yields an empty `frozen` and falls through to the live
           # search — never a crash or a permanent HOLD.
+          # The guards are strict because `.repo` and `.number` are interpolated into the GraphQL
+          # document below, and the Epic body is writable by anyone with write access to this repo:
+          # `[^/]` would admit quotes and newlines (enough to inject fields), and `type == "number"`
+          # alone would admit 1.5, a document-level validation error rather than a skippable one.
           [ -n "$marker" ] && frozen=$(printf '%s' "$marker" | jq -c '
-            select(type == "object" and .status == "frozen" and (.members | type == "array")
-              and (.members | all(type == "object"
-                and (.repo | type == "string") and (.repo | test("^[^/]+/[^/]+$"))
-                and (.number | type == "number")))) | .members' 2>/dev/null || true)
+            select(type == "object" and .status == "frozen" and (.members | type == "array"))
+            | .members
+            | select(all(.[]; type == "object"
+                and (.repo | type == "string") and (.repo | test("^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+$"))
+                and (.number | type == "number" and . == floor and . > 0 and . < 2147483648)))
+            | unique_by(.repo, .number)
+            | select(length > 0 and length <= 200)' 2>/dev/null || true)
         fi
         if [ -n "$frozen" ] && [ "$frozen" != "null" ]; then
           # Re-read each frozen member's current state (OPEN / MERGED / CLOSED), one GraphQL alias per

--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -112,13 +112,20 @@ runs:
           exit 1
         fi
         frozen=""
+        # The fence strings, matched as WHOLE LINES — see the note in detect-partial-landing: an
+        # unanchored match lets a pseudo-fence planted in an HTML comment shadow the real region.
+        START_M='<!-- epic-membership:snapshot:start -->'
+        END_M='<!-- epic-membership:snapshot:end -->'
         # GitHub stores bodies with CRLF; strip \r so the marker lines match.
         if body=$(gh api "repos/${OWNER}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
-          # Take the whole fenced region and let jq parse it, so the marker is not silently required to
-          # be single-line compact JSON — a pretty-printed one would otherwise fall through to the live
-          # search with no warning. `-s .[0]` takes the first value if a hand-edit left several.
+          # The fenced region holds a human-readable note and then the JSON, so skip to the first line
+          # that opens a value before parsing. Requiring the JSON to be one compact line at column 0
+          # (what a `grep '^{'` does) silently kills a pretty-printed marker; parsing the note as JSON
+          # kills every marker merge-gate actually emits. `-s .[0]` takes the first value if a hand-edit
+          # left several. All three participants extract identically.
           marker=$(printf '%s\n' "$body" \
-            | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
+            | awk -v s="$START_M" -v e="$END_M" '$0 == s {f=1;next} $0 == e {f=0} f' \
+            | sed -n '/^[[:space:]]*[{[]/,$p' \
             | jq -s -c '.[0] // empty' 2>/dev/null || true)
           # Only a well-formed FROZEN marker with a valid member list counts; anything else (pending,
           # hand-edited garbage, wrong shape) yields an empty `frozen` and falls through to the live
@@ -131,33 +138,50 @@ runs:
             select(type == "object" and .status == "frozen" and (.members | type == "array"))
             | .members
             | select(all(.[]; type == "object"
-                and (.repo | type == "string") and (.repo | test("^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+$"))
+                and (.repo | type == "string") and (.repo | test("\\A[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+\\z"))
                 and (.number | type == "number" and . == floor and . > 0 and . < 2147483648)))
             | unique_by((.repo | ascii_downcase), .number)
-            | select(length > 0 and length <= 200)' 2>/dev/null || true)
+            | select(length > 0 and length <= 50)' 2>/dev/null || true)
         fi
         if [ -n "$frozen" ] && [ "$frozen" != "null" ]; then
           # Re-read each frozen member's current state (OPEN / MERGED / CLOSED), one GraphQL alias per
-          # member in a single call. Aliases that error (a member repo deleted or renamed) are skipped
-          # and the survivors kept — one bad repo never collapses the set to [] (which would HOLD the
-          # Epic). Only a transport failure (no `data` at all, after retries) falls through to [], the
-          # correct fail-closed.
+          # member in a single call. The response must account for EVERY member: GitHub answers a
+          # multi-alias query with partial data plus an `errors` array, nulling what failed, and a
+          # dropped member here does not merely shrink a report — this set is what merge-gate gates on,
+          # so a member that silently vanishes is a member never evaluated, and the gate posts success
+          # on a wave that was never whole. That is the premature partial landing the gate exists to
+          # prevent. An incomplete answer therefore yields [], which merge-gate reads as a HOLD: a held
+          # pull request only waits, while a wrongly-passed set has already merged.
+          # Identity is the alias index plus the number, not the repository name: GraphQL follows a
+          # rename silently and answers with the new nameWithOwner, and a frozen marker is never
+          # rewritten, so name-matching would strand a renamed member's Epic permanently.
           alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
               + "{pullRequest(number:\(.value.number|floor)){number isDraft reviewDecision headRefOid state repository{nameWithOwner}}}"
             ) | join("\n")')
+          want=$(printf '%s' "$frozen" | jq 'length')
           rh='{}'
           for attempt in 1 2 3; do
             out=$(gh api graphql -f query="{ ${alias_q} }" 2>&1 || true)
-            if printf '%s' "$out" | jq -e 'has("data") and (.data | length > 0)' >/dev/null 2>&1; then
+            if printf '%s' "$out" | jq -e --argjson want "$want" '
+                 (has("errors") | not)
+                 and (((.data // {}) | to_entries | map(.value.pullRequest | select(. != null)) | length) == $want)
+               ' >/dev/null 2>&1; then
               rh="$out"; break
             fi
             [ "$attempt" -lt 3 ] && sleep 2
           done
-          members=$(printf '%s' "$rh" | jq -c '[(.data // {}) | to_entries[] | .value.pullRequest
-            | select(. != null)
-            | {repo: .repository.nameWithOwner, number, headRefOid, isDraft, reviewDecision, state}]
-            | sort_by(.repo, .number)')
+          members=$(printf '%s' "$rh" | jq -c --argjson members "$frozen" '
+            [ (.data // {}) | to_entries[]
+              | (.key | ltrimstr("m") | tonumber) as $i
+              | .value.pullRequest | select(. != null)
+              | select($members[$i] != null and .number == ($members[$i].number | floor))
+              | {repo: .repository.nameWithOwner, number, headRefOid, isDraft, reviewDecision, state} ]
+            | sort_by(.repo, .number)' 2>/dev/null || printf '[]')
+          if [ "$(printf '%s' "$members" | jq 'length')" -ne "$want" ]; then
+            echo "::warning::Epic #${EPIC}: could not re-read all ${want} frozen member(s) — reporting an empty set, which holds the Epic rather than gating on a partial one."
+            members='[]'
+          fi
           count=$(printf '%s' "$members" | jq 'length')
           {
             echo "members=$members"

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -452,9 +452,14 @@ runs:
         body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' | tr -d '\r')
 
         cur=$(printf '%s' "$MEMBERS" | jq -c '[.[] | {repo, number}] | sort_by(.repo, .number)')
+        # Parse the whole fenced region as JSON rather than grepping one compact line. Grepping made the
+        # marker silently require single-line JSON at column 0, and here that is destructive rather than
+        # merely blind: an unreadable FROZEN marker falls to the `pending` branch below, which OVERWRITES
+        # it with the current live set — permanently erasing exactly the de-labeled member the snapshot
+        # was frozen to remember. The readers parse it the same way.
         marker=$(printf '%s\n' "$body" \
           | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
-          | grep -m1 '^{' || true)
+          | jq -s -c '.[0] // empty' 2>/dev/null || true)
         # An unparseable marker (hand-edited garbage) is treated as absent → a fresh pending, which
         # self-heals it rather than crashing or freezing corruption.
         if [ -z "$marker" ] || ! printf '%s' "$marker" | jq empty 2>/dev/null; then marker=null; fi

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -323,6 +323,10 @@ runs:
       uses: a-novel-kit/workflows/generic-actions/epic-membership@v1.19.5
       with:
         epic_number: ${{ steps.discover.outputs.epic_number }}
+        # Thread it through: this gate WRITES the snapshot to planning_repo below, and this step READS
+        # it back. Left to its own default the two would target different repos the moment a caller
+        # overrides planning_repo, and the gate would gate on a set it never froze.
+        planning_repo: ${{ inputs.planning_repo }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
 

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -422,6 +422,10 @@ runs:
         client-id: ${{ inputs.client_id }}
         private-key: ${{ inputs.app_private_key }}
         owner: ${{ github.repository_owner }}
+        # Scoped to the planning repo. This token exists to edit ONE issue, and that issue is the
+        # trust boundary the readers act on, so org-wide issues:write would let a bug here reach
+        # every issue in the org.
+        repositories: ${{ inputs.planning_repo }}
         permission-issues: write
 
     - name: Capture activation snapshot
@@ -451,14 +455,28 @@ runs:
         # here). GitHub stores bodies with CRLF; strip \r so the exact marker matches (grep + splice).
         body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' | tr -d '\r')
 
-        cur=$(printf '%s' "$MEMBERS" | jq -c '[.[] | {repo, number}] | sort_by(.repo, .number)')
-        # Parse the whole fenced region as JSON rather than grepping one compact line. Grepping made the
-        # marker silently require single-line JSON at column 0, and here that is destructive rather than
-        # merely blind: an unreadable FROZEN marker falls to the `pending` branch below, which OVERWRITES
-        # it with the current live set — permanently erasing exactly the de-labeled member the snapshot
-        # was frozen to remember. The readers parse it the same way.
+        # Normalize exactly as the readers validate, so the writer cannot emit a marker they reject —
+        # a frozen marker is never rewritten, so one they refuse is a permanently dead snapshot that
+        # silently degrades every Epic to live membership. Dedup is case-folded (GitHub resolves repo
+        # names case-insensitively) and the 200 cap matches theirs.
+        cur=$(printf '%s' "$MEMBERS" | jq -c '
+          [.[] | {repo, number}] | unique_by((.repo | ascii_downcase), .number) | sort_by(.repo, .number)')
+        if ! printf '%s' "$cur" | jq -e '
+              length > 0 and length <= 50
+              and all(.[]; (.repo | test("\\A[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+\\z"))
+                and (.number | type == "number" and . == floor and . > 0 and . < 2147483648))' >/dev/null 2>&1; then
+          echo "::warning::Epic #${EPIC}: resolved member set is not snapshot-writable (empty, over 200, or malformed) — not capturing an activation snapshot this pass." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+        # The fenced region holds a human-readable note and then the JSON, so skip to the first line that
+        # opens a value before parsing. Both failure modes here are silent and this one is destructive:
+        # an unreadable FROZEN marker falls to the `pending` branch below, which OVERWRITES it with the
+        # current live set — erasing exactly the de-labeled member the snapshot was frozen to remember.
+        # All three participants extract identically.
         marker=$(printf '%s\n' "$body" \
-          | awk '/<!-- epic-membership:snapshot:start -->/{f=1;next} /<!-- epic-membership:snapshot:end -->/{f=0} f' \
+          | awk -v s="$START" -v e="$END" '$0 == s {f=1;next} $0 == e {f=0} f' \
+          | sed -n '/^[[:space:]]*[{[]/,$p' \
           | jq -s -c '.[0] // empty' 2>/dev/null || true)
         # An unparseable marker (hand-edited garbage) is treated as absent → a fresh pending, which
         # self-heals it rather than crashing or freezing corruption.
@@ -474,7 +492,10 @@ runs:
           elif ($mk.status == "pending" and ($mk.members | type == "array") and ($mk.at | type == "string"))
             then (
               if (($mk.members | sort_by(.repo, .number)) != $cur) then "pending"
-              elif (($now | fromdateiso8601) - ($mk.at | try fromdateiso8601 catch 0)) >= $thr then "frozen"
+              # An unparseable `at` must read as NOT aged. Defaulting it to epoch 0 made any corrupt or
+              # hand-edited timestamp infinitely old, promoting on the very next pass and skipping the
+              # stabilization window the two-phase capture exists to enforce.
+              elif (($now | fromdateiso8601) - ($mk.at | try fromdateiso8601 catch ($now | fromdateiso8601))) >= $thr then "frozen"
               else "skip" end)
           else "pending" end' 2>/dev/null || echo skip)
 

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -458,14 +458,14 @@ runs:
         # Normalize exactly as the readers validate, so the writer cannot emit a marker they reject —
         # a frozen marker is never rewritten, so one they refuse is a permanently dead snapshot that
         # silently degrades every Epic to live membership. Dedup is case-folded (GitHub resolves repo
-        # names case-insensitively) and the 200 cap matches theirs.
+        # names case-insensitively) and the 50-member cap matches theirs.
         cur=$(printf '%s' "$MEMBERS" | jq -c '
           [.[] | {repo, number}] | unique_by((.repo | ascii_downcase), .number) | sort_by(.repo, .number)')
         if ! printf '%s' "$cur" | jq -e '
               length > 0 and length <= 50
               and all(.[]; (.repo | test("\\A[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+\\z"))
                 and (.number | type == "number" and . == floor and . > 0 and . < 2147483648))' >/dev/null 2>&1; then
-          echo "::warning::Epic #${EPIC}: resolved member set is not snapshot-writable (empty, over 200, or malformed) — not capturing an activation snapshot this pass." \
+          echo "::warning::Epic #${EPIC}: resolved member set is not snapshot-writable (empty, over 50 members, or malformed) — not capturing an activation snapshot this pass." \
             | tee -a "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
@@ -492,10 +492,14 @@ runs:
           elif ($mk.status == "pending" and ($mk.members | type == "array") and ($mk.at | type == "string"))
             then (
               if (($mk.members | sort_by(.repo, .number)) != $cur) then "pending"
-              # An unparseable `at` must read as NOT aged. Defaulting it to epoch 0 made any corrupt or
-              # hand-edited timestamp infinitely old, promoting on the very next pass and skipping the
-              # stabilization window the two-phase capture exists to enforce.
-              elif (($now | fromdateiso8601) - ($mk.at | try fromdateiso8601 catch ($now | fromdateiso8601))) >= $thr then "frozen"
+              # An unparseable `at` rewrites a fresh pending rather than promoting or waiting. Reading it
+              # as epoch 0 made a corrupt timestamp infinitely old and promoted on the next pass, skipping
+              # the stabilization window; reading it as "now" never ages, and since the member set is
+              # unchanged the reset branch above never fires either, so the marker stalls forever and the
+              # Epic silently keeps live membership. Rewriting is the only answer that both refuses the
+              # premature freeze and repairs the marker.
+              elif (($mk.at | try (fromdateiso8601 | true) catch false) | not) then "pending"
+              elif (($now | fromdateiso8601) - ($mk.at | fromdateiso8601)) >= $thr then "frozen"
               else "skip" end)
           else "pending" end' 2>/dev/null || echo skip)
 

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Regression tests for detect-partial-landing's membership sourcing.
+#
+# These actions are bash inside a composite manifest, so there is nothing to import: the harness
+# EXTRACTS the functions under test verbatim from the manifest and sources them, which keeps the
+# shipped code the code that runs here — a paraphrase would drift the moment the action changed.
+# Only the network leaves are stubbed (gh, and the three read helpers evaluate_epic calls), so every
+# decision below is the real predicate running on fixture truth. Offline and deterministic.
+#
+# The case that matters: a member de-labeled and closed mid-landing. Live label truth has forgotten
+# it — GitHub indexes no "ever carried label X" — so the detector reads the survivors as a clean
+# landing and clears. The frozen activation snapshot is what keeps it a member, and the first two
+# assertions are that exact counterfactual on identical fixtures.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION="${1:-$ROOT/generic-actions/detect-partial-landing/action.yaml}"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+extract() { # $1 = function name — lift it out of the run: block and de-indent
+  awk -v n="$1" '
+    $0 ~ "^        "n"\\(\\) \\{" {f=1}
+    f {print}
+    f && /^        \}$/ {exit}
+  ' "$ACTION" | sed 's/^        //'
+}
+
+for fn in snapshot_buckets evaluate_epic; do
+  out=$(extract "$fn")
+  if [ -z "$out" ]; then
+    echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
+    exit 1
+  fi
+  printf '%s\n' "$out" >> "$WORK/lib.sh"
+done
+
+export ORG=a-novel-kit PLANNING_REPO=.github GRACE_MINUTES=30
+export GITHUB_STEP_SUMMARY="$WORK/summary.md"
+now_epoch=$(date -u +%s)
+grace_seconds=1800
+
+# ---- stubbed leaves ---------------------------------------------------------------------
+# gh serves only the two calls snapshot_buckets makes; everything else is a harness bug.
+gh() {
+  case "$*" in
+    *graphql*)
+      [ "$FX_REHYDRATE" = "FAIL" ] && { echo "gh: Bad credentials" >&2; return 1; }
+      printf '%s' "$FX_REHYDRATE" ;;
+    *issues*)
+      case "$FX_BODY" in
+        FAIL404) echo "gh: Not Found (HTTP 404)" >&2; return 1 ;;
+        FAIL500) echo "gh: HTTP 502" >&2; return 1 ;;
+      esac
+      printf '%s' "$FX_BODY" ;;
+    *) echo "unexpected gh call: $*" >&2; return 1 ;;
+  esac
+}
+search_prs() {
+  case "$1" in
+    *is:merged*) printf '%s' "$FX_LIVE_MERGED" ;;
+    *is:unmerged*) printf '%s' "$FX_LIVE_CLOSED" ;;
+    *is:open*) printf '%s' "$FX_LIVE_OPEN" ;;
+  esac
+}
+merge_queue_entries() { printf '%s' "$FX_QUEUE"; }
+rest_pr_state() { printf '%s' "$FX_REST" | jq -r --arg k "$1#$2" '.[$k] // "open false"'; }
+
+# shellcheck disable=SC1091
+. "$WORK/lib.sh"
+
+# ---- fixtures ---------------------------------------------------------------------------
+node() { # repo number state [mergedAt]
+  jq -cn --arg r "$1" --argjson n "$2" --arg s "$3" --arg m "${4:-}" \
+    '{number:$n, headRefOid:("sha"+($n|tostring)), mergedAt:(if $m=="" then null else $m end),
+      baseRefName:"master", isDraft:false, state:$s, repository:{nameWithOwner:$r}}'
+}
+rehydrate() { # the aliased re-read response, one alias per member
+  jq -s -c '{data: ([.[] | {pullRequest: .}] | to_entries
+    | map({key:("m"+(.key|tostring)), value:.value}) | from_entries)}' <<<"$*"
+}
+marker() { # status members-json
+  printf '<!-- epic-membership:snapshot:start -->\n%s\n<!-- epic-membership:snapshot:end -->\n' \
+    "$(jq -cn --arg s "$1" --argjson m "$2" '{status:$s, at:"2026-07-20T10:00:00Z", members:$m}')"
+}
+
+A=$(node a-novel-kit/repo-a 1 MERGED "$(date -u -d '-40 minutes' +%Y-%m-%dT%H:%M:%SZ)")
+B=$(node a-novel-kit/repo-b 2 CLOSED)   # the abandoned member: closed unmerged, label removed
+C=$(node a-novel-kit/repo-c 3 OPEN)
+ABC='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-c","number":3}]'
+AC='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-c","number":3}]'
+FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
+FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"}]'  # repo-c sits in its queue → not a stray
+
+# ---- assertions -------------------------------------------------------------------------
+pass=0
+fail=0
+check() { # name expected-decision [expected-membership-source]
+  local name="$1" want="$2" wantsrc="${3:-}" src
+  evaluate_epic 900 >/dev/null 2>&1
+  src=$(grep -o 'membership=[a-z]*' "$GITHUB_STEP_SUMMARY" | tail -1 | cut -d= -f2)
+  : > "$GITHUB_STEP_SUMMARY"
+  if [ "$EV_DECISION" = "$want" ] && { [ -z "$wantsrc" ] || [ "$src" = "$wantsrc" ]; }; then
+    printf '  ✓ %-56s decision=%-7s membership=%s\n' "$name" "$EV_DECISION" "${src:-n/a}"
+    pass=$((pass + 1))
+  else
+    printf '  ✗ %-56s decision=%-7s (want %s) membership=%s (want %s)\n' \
+      "$name" "$EV_DECISION" "$want" "${src:-n/a}" "${wantsrc:-any}"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "the regression: a member de-labeled and closed mid-landing"
+FX_LIVE_MERGED="[$A]"; FX_LIVE_CLOSED='[]'; FX_LIVE_OPEN="[$C]"   # live truth has forgotten B
+FX_BODY=""; FX_REHYDRATE=""
+check "without a snapshot, the abandonment is invisible" clear live
+FX_BODY=$(marker frozen "$ABC"); FX_REHYDRATE=$(rehydrate "$A" "$B" "$C")
+check "the frozen set catches it" frozen snapshot
+
+echo
+echo "unchanged behaviour"
+FX_BODY=$(marker frozen "$AC"); FX_REHYDRATE=$(rehydrate "$A" "$C")
+check "a healthy set under a snapshot still clears" clear snapshot
+FX_BODY=""; FX_LIVE_CLOSED="[$B]"
+check "the live path still trips on a closed member" frozen live
+FX_LIVE_CLOSED='[]'
+check "the live path still clears a healthy set" clear live
+
+echo
+echo "a degraded marker falls back to live — never a crash, never a freeze on garbage"
+FX_BODY=$(marker pending "$ABC")
+check "a pending marker (the set has not settled)" clear live
+FX_BODY='<!-- epic-membership:snapshot:start -->
+{"status":"frozen","members":"nope"}
+<!-- epic-membership:snapshot:end -->'
+check "members of the wrong type" clear live
+FX_BODY='<!-- epic-membership:snapshot:start -->
+{{{ not json
+<!-- epic-membership:snapshot:end -->'
+check "hand-edited garbage" clear live
+FX_BODY=FAIL404
+check "the Epic issue is absent" clear live
+FX_BODY=FAIL500
+check "the body read fails outright" clear live
+FX_BODY=$(marker frozen '[]')
+check "an empty frozen set" clear snapshot
+
+echo
+echo "a frozen set that cannot be re-read fails closed, rather than downgrading to live"
+FX_BODY=$(marker frozen "$ABC"); FX_REHYDRATE=FAIL
+check "re-hydration fails outright" error
+# evaluate_epic returns before it logs anything on this path, so stderr is the only diagnosis.
+if evaluate_epic 900 2>&1 >/dev/null | grep -q 'could not re-read frozen member state'; then
+  printf '  ✓ %s\n' "the reason reaches the run log"
+  pass=$((pass + 1))
+else
+  printf '  ✗ %s\n' "the fail-closed pass is silent"
+  fail=$((fail + 1))
+fi
+: > "$GITHUB_STEP_SUMMARY"
+
+echo
+echo "one unreadable member repo must not empty the set"
+FX_REHYDRATE=$(jq -cn --argjson a "$A" --argjson b "$B" \
+  '{data:{m0:{pullRequest:$a}, m1:{pullRequest:$b}, m2:{pullRequest:null}}, errors:[{message:"repo gone"}]}')
+check "the survivors still trip the freeze" frozen snapshot
+
+echo
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -9,8 +9,13 @@
 #
 # The case that matters: a member de-labeled and closed mid-landing. Live label truth has forgotten
 # it — GitHub indexes no "ever carried label X" — so the detector reads the survivors as a clean
-# landing and clears. The frozen activation snapshot is what keeps it a member, and the first two
-# assertions are that exact counterfactual on identical fixtures.
+# landing and clears. The frozen activation snapshot is what keeps it a member.
+#
+# Note the shape of the fixtures for that case. merge-gate captures the set from OPEN pull requests
+# and freezes it only after the set holds still, while auto-merge is armed earlier — so a real frozen
+# set routinely does NOT contain the members that already merged. The snapshot is therefore added to
+# the live set rather than replacing it, and the fixtures model exactly that: `A` merged is visible
+# only live, `B` abandoned only in the snapshot, and the freeze depends on both.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -26,7 +31,7 @@ extract() { # $1 = function name — lift it out of the run: block and de-indent
   ' "$ACTION" | sed 's/^        //'
 }
 
-for fn in snapshot_buckets evaluate_epic; do
+for fn in snapshot_buckets union_nodes evaluate_epic; do
   out=$(extract "$fn")
   if [ -z "$out" ]; then
     echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
@@ -34,37 +39,66 @@ for fn in snapshot_buckets evaluate_epic; do
   fi
   printf '%s\n' "$out" >> "$WORK/lib.sh"
 done
+# Extraction stops at the first 8-space `}`. If that ever lands mid-function the result is invalid
+# bash, and without this check the suite fails later with a confusing unbound-variable abort.
+if ! bash -n "$WORK/lib.sh"; then
+  echo "::error::extracted functions do not parse — extraction truncated a definition"
+  exit 1
+fi
 
 export ORG=a-novel-kit PLANNING_REPO=.github GRACE_MINUTES=30
 export GITHUB_STEP_SUMMARY="$WORK/summary.md"
 now_epoch=$(date -u +%s)
-grace_seconds=1800
+grace_seconds=$((GRACE_MINUTES * 60)) # derived, so it cannot drift from the action's own arithmetic
+sleep() { :; }                        # retries are asserted by call count below, not by wall clock
 
 # ---- stubbed leaves ---------------------------------------------------------------------
-# gh serves only the two calls snapshot_buckets makes; everything else is a harness bug.
+# Every stub can fail on demand: the action's central promise is that it fails CLOSED, and stubs
+# that cannot fail leave that promise untested.
+GH_CALLS=0
 gh() {
+  GH_CALLS=$((GH_CALLS + 1))
   case "$*" in
     *graphql*)
+      # The stub runs inside $( ), i.e. a subshell, so a shell-variable countdown would never reach
+      # the parent. Keep it in a file to make "fail twice, then succeed" actually observable.
+      if [ "$(< "$WORK/rehydrate_fails")" -gt 0 ]; then
+        printf '%s' "$(($(< "$WORK/rehydrate_fails") - 1))" > "$WORK/rehydrate_fails"
+        echo "gh: API rate limit exceeded" >&2
+        return 1
+      fi
       [ "$FX_REHYDRATE" = "FAIL" ] && { echo "gh: Bad credentials" >&2; return 1; }
       printf '%s' "$FX_REHYDRATE" ;;
     *issues*)
       case "$FX_BODY" in
         FAIL404) echo "gh: Not Found (HTTP 404)" >&2; return 1 ;;
         FAIL500) echo "gh: HTTP 502" >&2; return 1 ;;
-      esac
-      printf '%s' "$FX_BODY" ;;
+        NOISE) printf 'gh: a deprecation notice\n%s' "$(jq -cn '{body:"irrelevant"}')" ;;
+        *) jq -cn --arg b "$FX_BODY" '{body: $b}' ;;
+      esac ;;
     *) echo "unexpected gh call: $*" >&2; return 1 ;;
   esac
 }
 search_prs() {
+  [ "$FX_SEARCH_FAIL" = true ] && return 1
   case "$1" in
     *is:merged*) printf '%s' "$FX_LIVE_MERGED" ;;
     *is:unmerged*) printf '%s' "$FX_LIVE_CLOSED" ;;
     *is:open*) printf '%s' "$FX_LIVE_OPEN" ;;
+    *) echo "unexpected search: $1" >&2; return 1 ;;
   esac
 }
-merge_queue_entries() { printf '%s' "$FX_QUEUE"; }
-rest_pr_state() { printf '%s' "$FX_REST" | jq -r --arg k "$1#$2" '.[$k] // "open false"'; }
+merge_queue_entries() {
+  [ "$FX_QUEUE_FAIL" = true ] && return 1
+  printf '%s' "$FX_QUEUE" | jq -c --arg repo "$1/$2" '[.[] | select(.repo == null or .repo == $repo)]'
+}
+rest_pr_state() {
+  [ "$FX_REST_FAIL" = true ] && return 1
+  printf '%s' "$FX_REST" | jq -er --arg k "$1#$2" '.[$k]' 2>/dev/null || {
+    echo "harness gap: no REST fixture for $1#$2" >&2
+    return 1
+  }
+}
 
 # shellcheck disable=SC1091
 . "$WORK/lib.sh"
@@ -79,91 +113,193 @@ rehydrate() { # the aliased re-read response, one alias per member
   jq -s -c '{data: ([.[] | {pullRequest: .}] | to_entries
     | map({key:("m"+(.key|tostring)), value:.value}) | from_entries)}' <<<"$*"
 }
-marker() { # status members-json
-  printf '<!-- epic-membership:snapshot:start -->\n%s\n<!-- epic-membership:snapshot:end -->\n' \
-    "$(jq -cn --arg s "$1" --argjson m "$2" '{status:$s, at:"2026-07-20T10:00:00Z", members:$m}')"
+marker() { # status members-json — mirrors merge-gate's payload (frozen carries no `at`)
+  local payload
+  if [ "$1" = frozen ]; then
+    payload=$(jq -cn --argjson m "$2" '{status:"frozen", members:$m}')
+  else
+    payload=$(jq -cn --arg s "$1" --argjson m "$2" '{status:$s, at:"2026-07-20T10:00:00Z", members:$m}')
+  fi
+  printf '<!-- epic-membership:snapshot:start -->\n%s\n<!-- epic-membership:snapshot:end -->\n' "$payload"
 }
 
-A=$(node a-novel-kit/repo-a 1 MERGED "$(date -u -d '-40 minutes' +%Y-%m-%dT%H:%M:%SZ)")
-B=$(node a-novel-kit/repo-b 2 CLOSED)   # the abandoned member: closed unmerged, label removed
+AGO40=$(date -u -d '-40 minutes' +%Y-%m-%dT%H:%M:%SZ)
+AGO5=$(date -u -d '-5 minutes' +%Y-%m-%dT%H:%M:%SZ)
+A=$(node a-novel-kit/repo-a 1 MERGED "$AGO40")
+B=$(node a-novel-kit/repo-b 2 CLOSED) # the abandoned member: closed unmerged, label removed
 C=$(node a-novel-kit/repo-c 3 OPEN)
-ABC='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-c","number":3}]'
-AC='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-c","number":3}]'
+BC='[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-c","number":3}]'
 FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
-FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"}]'  # repo-c sits in its queue → not a stray
+
+reset_fixtures() {
+  FX_LIVE_MERGED="[$A]" # A merged and still labeled: visible to the live search
+  FX_LIVE_CLOSED='[]'   # B is de-labeled, so live truth has forgotten it entirely
+  FX_LIVE_OPEN="[$C]"
+  FX_BODY=""
+  FX_REHYDRATE=""
+  printf 0 > "$WORK/rehydrate_fails"
+  FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"}]' # repo-c is queued → not a stray
+  FX_SEARCH_FAIL=false
+  FX_REST_FAIL=false
+  FX_QUEUE_FAIL=false
+}
+reset_fixtures
 
 # ---- assertions -------------------------------------------------------------------------
 pass=0
 fail=0
-check() { # name expected-decision [expected-membership-source]
-  local name="$1" want="$2" wantsrc="${3:-}" src
+note() { printf '  %s %s\n' "$1" "$2"; }
+ok() { note ✓ "$1"; pass=$((pass + 1)); }
+ko() { note ✗ "$1"; fail=$((fail + 1)); }
+
+check() { # name expected-decision [expected-membership] [expected merged/closed/open counts]
+  local name="$1" want="$2" wantsrc="${3:-}" wantcounts="${4:-}" src counts detail=""
   evaluate_epic 900 >/dev/null 2>&1
-  src=$(grep -o 'membership=[a-z]*' "$GITHUB_STEP_SUMMARY" | tail -1 | cut -d= -f2)
+  src=$(grep -o 'membership=[a-z+]*' "$GITHUB_STEP_SUMMARY" | tail -1 | cut -d= -f2)
+  counts="$EV_MERGED_COUNT/$EV_CLOSED_COUNT/$EV_OPEN_COUNT"
   : > "$GITHUB_STEP_SUMMARY"
-  if [ "$EV_DECISION" = "$want" ] && { [ -z "$wantsrc" ] || [ "$src" = "$wantsrc" ]; }; then
-    printf '  ✓ %-56s decision=%-7s membership=%s\n' "$name" "$EV_DECISION" "${src:-n/a}"
+  [ "$EV_DECISION" = "$want" ] || detail="decision=$EV_DECISION (want $want)"
+  { [ -z "$wantsrc" ] || [ "$src" = "$wantsrc" ]; } || detail="$detail membership=${src:-n/a} (want $wantsrc)"
+  { [ -z "$wantcounts" ] || [ "$counts" = "$wantcounts" ]; } || detail="$detail counts=$counts (want $wantcounts)"
+  if [ -z "$detail" ]; then
+    printf '  ✓ %-54s %-7s %-14s %s\n' "$name" "$EV_DECISION" "${src:-n/a}" "$counts"
     pass=$((pass + 1))
   else
-    printf '  ✗ %-56s decision=%-7s (want %s) membership=%s (want %s)\n' \
-      "$name" "$EV_DECISION" "$want" "${src:-n/a}" "${wantsrc:-any}"
+    printf '  ✗ %-54s %s\n' "$name" "$detail"
     fail=$((fail + 1))
   fi
 }
 
 echo "the regression: a member de-labeled and closed mid-landing"
-FX_LIVE_MERGED="[$A]"; FX_LIVE_CLOSED='[]'; FX_LIVE_OPEN="[$C]"   # live truth has forgotten B
-FX_BODY=""; FX_REHYDRATE=""
-check "without a snapshot, the abandonment is invisible" clear live
-FX_BODY=$(marker frozen "$ABC"); FX_REHYDRATE=$(rehydrate "$A" "$B" "$C")
-check "the frozen set catches it" frozen snapshot
+check "on the live set alone, the abandonment is invisible" clear live 1/0/1
+FX_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=$(rehydrate "$B" "$C")
+check "the snapshot supplies it, and the Epic freezes" frozen live+snapshot 1/1/1
+[ "$EV_REASON" = "a member was closed without merging" ] \
+  && ok "and for the right reason" || ko "wrong reason: $EV_REASON"
+
+echo
+echo "the snapshot is ADDED to the live set, never swapped for it"
+# The real capture shape: merge-gate freezes from open PRs, so an already-merged member is absent
+# from the snapshot. Substituting would zero the merged bucket that gates every decision.
+check "a merged member absent from the snapshot still counts" frozen live+snapshot 1/1/1
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 MERGED "$AGO5")" "$C")
+check "a member merged after the freeze is not double-counted" clear live+snapshot 2/0/1
 
 echo
 echo "unchanged behaviour"
-FX_BODY=$(marker frozen "$AC"); FX_REHYDRATE=$(rehydrate "$A" "$C")
-check "a healthy set under a snapshot still clears" clear snapshot
-FX_BODY=""; FX_LIVE_CLOSED="[$B]"
-check "the live path still trips on a closed member" frozen live
-FX_LIVE_CLOSED='[]'
-check "the live path still clears a healthy set" clear live
+reset_fixtures
+check "a healthy live set clears" clear live 1/0/1
+FX_LIVE_CLOSED="[$B]"
+check "a closed member still labeled trips without any snapshot" frozen live 1/1/1
+reset_fixtures
+FX_LIVE_MERGED='[]'
+check "nothing merged yet, so nothing can be partial" clear live 0/0/1
 
 echo
-echo "a degraded marker falls back to live — never a crash, never a freeze on garbage"
-FX_BODY=$(marker pending "$ABC")
-check "a pending marker (the set has not settled)" clear live
+echo "the stray + grace path, under a snapshot"
+reset_fixtures
+FX_QUEUE='[]' # repo-c left its queue
+FX_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 OPEN)" "$C")
+FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"open false","a-novel-kit/repo-c#3":"open false"}'
+check "a stray past grace freezes" frozen live+snapshot 1/0/2
+FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO5")]"
+check "the same stray within grace does not" clear live+snapshot 1/0/2
+reset_fixtures
+FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
+
+echo
+echo "a degraded marker falls back to the live floor — never a crash, never a freeze on garbage"
+FX_BODY=$(marker pending "$BC")
+check "a pending marker (the set has not settled)" clear live 1/0/1
 FX_BODY='<!-- epic-membership:snapshot:start -->
 {"status":"frozen","members":"nope"}
 <!-- epic-membership:snapshot:end -->'
-check "members of the wrong type" clear live
+check "members of the wrong type" clear live 1/0/1
 FX_BODY='<!-- epic-membership:snapshot:start -->
 {{{ not json
 <!-- epic-membership:snapshot:end -->'
-check "hand-edited garbage" clear live
-FX_BODY=FAIL404
-check "the Epic issue is absent" clear live
-FX_BODY=FAIL500
-check "the body read fails outright" clear live
+check "hand-edited garbage" clear live 1/0/1
+FX_BODY=$(marker frozen '[{"repo":"noslash","number":2}]')
+check "a member repo with no owner" clear live 1/0/1
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":"2"}]')
+check "a member number that is a string" clear live 1/0/1
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":1.5}]')
+check "a non-integer member number (a whole-document error)" clear live 1/0/1
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/x\"){pullRequest(number:1){number}}} evil: rateLimit{cost","number":1}]')
+check "a member repo carrying a GraphQL injection" clear live 1/0/1
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo\nEVIL: rateLimit{cost}","number":1}]')
+check "a member repo carrying a newline" clear live 1/0/1
 FX_BODY=$(marker frozen '[]')
-check "an empty frozen set" clear snapshot
+check "an empty frozen set" clear live 1/0/1
+FX_BODY=FAIL404
+check "the Epic issue is absent" clear live 1/0/1
+FX_BODY=FAIL500
+check "the body read fails outright" clear live 1/0/1
+FX_BODY=NOISE
+check "a gh notice prepended to the response is not parsed as body" clear live 1/0/1
 
 echo
-echo "a frozen set that cannot be re-read fails closed, rather than downgrading to live"
-FX_BODY=$(marker frozen "$ABC"); FX_REHYDRATE=FAIL
+echo "the marker is parsed as JSON, not as a single line of text"
+FX_BODY=$(printf '<!-- epic-membership:snapshot:start -->\n%s\n<!-- epic-membership:snapshot:end -->\n' \
+  "$(jq -n --argjson m "$BC" '{status:"frozen", members:$m}')") # pretty-printed
+FX_REHYDRATE=$(rehydrate "$B" "$C")
+check "a pretty-printed marker still freezes" frozen live+snapshot 1/1/1
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-c","number":3}]')
+check "a duplicated member is de-duplicated, not double-counted" frozen live+snapshot 1/1/1
+
+echo
+echo "a frozen set that cannot be resolved fails closed — it never decides on the live floor alone"
+FX_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=FAIL
 check "re-hydration fails outright" error
 # evaluate_epic returns before it logs anything on this path, so stderr is the only diagnosis.
-if evaluate_epic 900 2>&1 >/dev/null | grep -q 'could not re-read frozen member state'; then
-  printf '  ✓ %s\n' "the reason reaches the run log"
-  pass=$((pass + 1))
-else
-  printf '  ✗ %s\n' "the fail-closed pass is silent"
-  fail=$((fail + 1))
-fi
+evaluate_epic 900 2>&1 >/dev/null | grep -q 'could not re-read all 2 frozen member' \
+  && ok "the reason reaches the run log" || ko "the fail-closed pass is silent"
 : > "$GITHUB_STEP_SUMMARY"
+FX_REHYDRATE=$(jq -cn '{data:{m0:null,m1:null}, errors:[{message:"NOT_FOUND"}]}')
+check "every alias nulled (data has keys, but no members)" error
+FX_REHYDRATE=$(jq -cn --argjson b "$B" '{data:{m0:{pullRequest:$b}, m1:{pullRequest:null}}, errors:[{message:"timeout"}]}')
+check "one alias nulled — a short answer is not a clean set" error
+FX_REHYDRATE=$(rehydrate "$B" "$C" | jq -c '. + {errors:[{message:"something went wrong"}]}')
+check "a complete answer that still reports errors is not trusted" error
+FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/UNRELATED 4242 OPEN)")
+# Give the intruder full REST + queue backing, so `error` can only come from the identity check
+# rejecting it — not from the harness running out of fixtures for a PR it never expected.
+FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/UNRELATED#4242":"open false"}')
+FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"},{"number":4242,"state":"QUEUED","headOid":"sha4242"}]'
+check "a node for a pull request nobody asked about" error
+FX_REST=$(printf '%s' "$FX_REST" | jq -c 'del(."a-novel-kit/UNRELATED#4242")')
+FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"}]'
+FX_REHYDRATE=$(rehydrate "$B" "$(jq -cn --argjson c "$C" '$c | del(.state)')")
+check "a member whose state is missing" error
 
 echo
-echo "one unreadable member repo must not empty the set"
-FX_REHYDRATE=$(jq -cn --argjson a "$A" --argjson b "$B" \
-  '{data:{m0:{pullRequest:$a}, m1:{pullRequest:$b}, m2:{pullRequest:null}}, errors:[{message:"repo gone"}]}')
-check "the survivors still trip the freeze" frozen snapshot
+echo "transient failures retry, then the floor's own failures fail closed"
+FX_REHYDRATE=$(rehydrate "$B" "$C")
+printf 2 > "$WORK/rehydrate_fails"
+check "re-hydration recovers on the third attempt" frozen live+snapshot 1/1/1
+reset_fixtures
+FX_SEARCH_FAIL=true
+check "a failed label search" error
+reset_fixtures
+FX_REST_FAIL=true
+FX_LIVE_CLOSED="[$B]"
+check "a failed REST confirmation" error
+reset_fixtures
+FX_QUEUE_FAIL=true
+check "a failed merge-queue read" error
+
+echo
+echo "state does not leak between Epics in one sweep process"
+reset_fixtures
+FX_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=$(rehydrate "$B" "$C")
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+FX_BODY="" # the next Epic has no snapshot at all
+check "an Epic with no snapshot sees none of the previous one's" clear live 1/0/1
 
 echo
 printf '%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -31,7 +31,7 @@ extract() { # $1 = function name — lift it out of the run: block and de-indent
   ' "$ACTION" | sed 's/^        //'
 }
 
-for fn in snapshot_buckets union_nodes evaluate_epic; do
+for fn in snapshot_buckets union_buckets evaluate_epic; do
   out=$(extract "$fn")
   if [ -z "$out" ]; then
     echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
@@ -50,14 +50,16 @@ export ORG=a-novel-kit PLANNING_REPO=.github GRACE_MINUTES=30
 export GITHUB_STEP_SUMMARY="$WORK/summary.md"
 now_epoch=$(date -u +%s)
 grace_seconds=$((GRACE_MINUTES * 60)) # derived, so it cannot drift from the action's own arithmetic
-sleep() { :; }                        # retries are asserted by call count below, not by wall clock
+sleep() { :; }                        # retry COUNTS are asserted via the gh call log, not by wall clock
 
 # ---- stubbed leaves ---------------------------------------------------------------------
 # Every stub can fail on demand: the action's central promise is that it fails CLOSED, and stubs
 # that cannot fail leave that promise untested.
-GH_CALLS=0
 gh() {
-  GH_CALLS=$((GH_CALLS + 1))
+  # Record every call so the QUERY can be asserted, not just its answer: the document this action
+  # builds is the part no fixture would otherwise exercise, and a wrong field or alias in it is a
+  # total feature outage.
+  printf '%s\n' "$*" >> "$WORK/gh_calls"
   case "$*" in
     *graphql*)
       # The stub runs inside $( ), i.e. a subshell, so a shell-variable countdown would never reach
@@ -73,7 +75,7 @@ gh() {
       case "$FX_BODY" in
         FAIL404) echo "gh: Not Found (HTTP 404)" >&2; return 1 ;;
         FAIL500) echo "gh: HTTP 502" >&2; return 1 ;;
-        NOISE) printf 'gh: a deprecation notice\n%s' "$(jq -cn '{body:"irrelevant"}')" ;;
+        NOISE) echo "gh: a deprecation notice" >&2; jq -cn --arg b "$FX_MARKER_BODY" '{body: $b}' ;;
         *) jq -cn --arg b "$FX_BODY" '{body: $b}' ;;
       esac ;;
     *) echo "unexpected gh call: $*" >&2; return 1 ;;
@@ -129,15 +131,18 @@ A=$(node a-novel-kit/repo-a 1 MERGED "$AGO40")
 B=$(node a-novel-kit/repo-b 2 CLOSED) # the abandoned member: closed unmerged, label removed
 C=$(node a-novel-kit/repo-c 3 OPEN)
 BC='[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-c","number":3}]'
-FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
 
 reset_fixtures() {
+  # Every fixture the assertions read lives here: a section that edits one and forgets to restore it
+  # would silently redefine truth for every later assertion.
+  FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
   FX_LIVE_MERGED="[$A]" # A merged and still labeled: visible to the live search
   FX_LIVE_CLOSED='[]'   # B is de-labeled, so live truth has forgotten it entirely
   FX_LIVE_OPEN="[$C]"
   FX_BODY=""
   FX_REHYDRATE=""
   printf 0 > "$WORK/rehydrate_fails"
+  : > "$WORK/gh_calls"
   FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"}]' # repo-c is queued → not a stray
   FX_SEARCH_FAIL=false
   FX_REST_FAIL=false
@@ -187,6 +192,55 @@ FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 MERGED "$AGO5")" "$C")
 check "a member merged after the freeze is not double-counted" clear live+snapshot 2/0/1
 
 echo
+echo "the frozen member reaches the payload the freeze is posted on"
+# A decision is worthless if the head it names is missing: EV_OPEN is what sweep_post_freeze targets.
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 OPEN)" "$C")
+FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"open false","a-novel-kit/repo-c#3":"open false"}'
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/repo-b" and .number == 2)' >/dev/null \
+  && ok "a de-labeled open member is in EV_OPEN, so it gets a check" \
+  || ko "the de-labeled open member is missing from EV_OPEN"
+printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/repo-b" and (.liveMember | not))' >/dev/null \
+  && ok "and is tagged as no longer live-labeled" || ko "liveMember tag missing or wrong"
+printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/repo-c" and .liveMember)' >/dev/null \
+  && ok "while a still-labeled member is tagged live" || ko "a live member was mis-tagged"
+# The roll-forward reads exactly this filter; a de-labeled member must not be re-armed.
+printf '%s' "$EV_OPEN" | jq -e '[.[] | select((.isDraft | not) and .liveMember)] | length == 1' >/dev/null \
+  && ok "only the live-labeled member is a roll-forward target" || ko "roll-forward would touch a de-labeled member"
+reset_fixtures
+
+echo
+echo "the GraphQL document it builds"
+FX_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=$(rehydrate "$B" "$C")
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+q=$(cat "$WORK/gh_calls")
+for want in 'owner:"a-novel-kit", name:"repo-b"' 'number:2' 'owner:"a-novel-kit", name:"repo-c"' 'number:3' \
+            'm0:' 'm1:' 'state' 'headRefOid' 'mergedAt' 'baseRefName' 'isDraft' 'nameWithOwner'; do
+  case "$q" in
+    *"$want"*) ok "queries $want" ;;
+    *) ko "the re-read query is missing: $want" ;;
+  esac
+done
+# `2.0` is a valid integer to the guard (it equals its own floor) but jq preserves the literal a body
+# was written with, and `number:2.0` is an Int! violation that rejects the WHOLE document — no retry
+# clears it, so the Epic would wedge forever. It has to render canonically.
+reset_fixtures
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2.0}]')
+FX_REHYDRATE=$(rehydrate "$B")
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+q=$(cat "$WORK/gh_calls")
+case "$q" in
+  *"number:2.0"*) ko "a float-valued member number reaches the query verbatim" ;;
+  *"number:2"*) ok "a float-valued member number renders as a canonical integer" ;;
+  *) ko "the re-read query never rendered the member number" ;;
+esac
+reset_fixtures
+
+echo
 echo "unchanged behaviour"
 reset_fixtures
 check "a healthy live set clears" clear live 1/0/1
@@ -207,7 +261,6 @@ check "a stray past grace freezes" frozen live+snapshot 1/0/2
 FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO5")]"
 check "the same stray within grace does not" clear live+snapshot 1/0/2
 reset_fixtures
-FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
 
 echo
 echo "a degraded marker falls back to the live floor — never a crash, never a freeze on garbage"
@@ -231,14 +284,28 @@ FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/x\"){pullRequest(number:1){number
 check "a member repo carrying a GraphQL injection" clear live 1/0/1
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo\nEVIL: rateLimit{cost}","number":1}]')
 check "a member repo carrying a newline" clear live 1/0/1
+# One bad member must poison the whole set: validating with `any` instead of `all` would let the
+# injection through alongside a legitimate member.
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/x\"){evil","number":1}]')
+check "one evil member among valid ones" clear live 1/0/1
+# The repo pattern must be anchored at BOTH ends: a payload in the prefix still ends in a valid name.
+FX_BODY=$(marker frozen '[{"repo":"evil\"){x} a-novel-kit/repo-b","number":2}]')
+check "a member repo with an injected prefix" clear live 1/0/1
 FX_BODY=$(marker frozen '[]')
 check "an empty frozen set" clear live 1/0/1
 FX_BODY=FAIL404
 check "the Epic issue is absent" clear live 1/0/1
+# An unreadable body is IGNORANCE, not an answer: we cannot tell whether a snapshot exists, and a
+# `clear` would post success and lift a freeze an earlier pass set. Only a 404 is an answer.
 FX_BODY=FAIL500
-check "the body read fails outright" clear live 1/0/1
+check "the body read fails outright — decide nothing" error
+# A benign notice on stderr must not corrupt the payload — it costs a whole pass now that an
+# unreadable body no longer falls back to the live floor.
+FX_MARKER_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=$(rehydrate "$B" "$C")
 FX_BODY=NOISE
-check "a gh notice prepended to the response is not parsed as body" clear live 1/0/1
+check "a gh notice on stderr does not corrupt the body" frozen live+snapshot 1/1/1
+FX_REHYDRATE=""
 
 echo
 echo "the marker is parsed as JSON, not as a single line of text"
@@ -248,6 +315,15 @@ FX_REHYDRATE=$(rehydrate "$B" "$C")
 check "a pretty-printed marker still freezes" frozen live+snapshot 1/1/1
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-c","number":3}]')
 check "a duplicated member is de-duplicated, not double-counted" frozen live+snapshot 1/1/1
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-B","number":2},{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-c","number":3}]')
+check "a case-variant duplicate is one member, not two" frozen live+snapshot 1/1/1
+# Two DISTINCT members in one repository: cross-repo Epics reuse numbers, so the dedup key has to be
+# the pair. Keyed on repo alone these would collapse and the set would silently lose a member.
+FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/repo-b#4":"open false"}')
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-b","number":4}]')
+FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/repo-b 4 OPEN)")
+check "two members in one repository stay two" frozen live+snapshot 1/1/2
+reset_fixtures
 
 echo
 echo "a frozen set that cannot be resolved fails closed — it never decides on the live floor alone"
@@ -270,7 +346,6 @@ FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/UNRELATED 4242 OPEN)")
 FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/UNRELATED#4242":"open false"}')
 FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"},{"number":4242,"state":"QUEUED","headOid":"sha4242"}]'
 check "a node for a pull request nobody asked about" error
-FX_REST=$(printf '%s' "$FX_REST" | jq -c 'del(."a-novel-kit/UNRELATED#4242")')
 FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"}]'
 FX_REHYDRATE=$(rehydrate "$B" "$(jq -cn --argjson c "$C" '$c | del(.state)')")
 check "a member whose state is missing" error

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -90,6 +90,12 @@ search_prs() {
   # dropping either would silently make every open pull request in the org a member of every Epic.
   printf '%s\n' "$1" >> "$WORK/searches"
   [ "$FX_SEARCH_FAIL" = true ] && return 1
+  # Fail exactly one of the three searches, so each fail-closed guard is pinned separately.
+  case "$FX_SEARCH_FAIL_ON" in
+    merged) case "$1" in *is:merged*) return 1 ;; esac ;;
+    closed) case "$1" in *is:unmerged*) return 1 ;; esac ;;
+    open) case "$1" in *is:open*) return 1 ;; esac ;;
+  esac
   case "$1" in
     *is:merged*) printf '%s' "$FX_LIVE_MERGED" ;;
     *is:unmerged*) printf '%s' "$FX_LIVE_CLOSED" ;;
@@ -107,6 +113,7 @@ merge_queue_entries() { # $1=owner $2=repo $3=base
 }
 rest_pr_state() {
   [ "$FX_REST_FAIL" = true ] && return 1
+  [ "$FX_REST_FAIL_ON" = "$1#$2" ] && return 1
   printf '%s' "$FX_REST" | jq -er --arg k "$1#$2" '.[$k]' 2>/dev/null || {
     echo "harness gap: no REST fixture for $1#$2" >&2
     return 1
@@ -170,7 +177,9 @@ reset_fixtures() {
   : > "$WORK/searches"
   FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"}]' # repo-c is queued → not a stray
   FX_SEARCH_FAIL=false
+  FX_SEARCH_FAIL_ON=none
   FX_REST_FAIL=false
+  FX_REST_FAIL_ON=none
   FX_QUEUE_FAIL=false
 }
 reset_fixtures
@@ -231,7 +240,7 @@ printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/re
   && ok "while a still-labeled member is tagged live" || ko "a live member was mis-tagged"
 # The roll-forward reads exactly this filter; a de-labeled member must not be re-armed.
 printf '%s' "$EV_OPEN" | jq -e '[.[] | select((.isDraft | not) and .liveMember)] | length == 1' >/dev/null \
-  && ok "only the live-labeled member is a roll-forward target" || ko "roll-forward would touch a de-labeled member"
+  && ok "EV_OPEN offers exactly one roll-forward candidate" || ko "EV_OPEN would offer a de-labeled member to roll-forward"
 reset_fixtures
 
 echo
@@ -239,12 +248,28 @@ echo "the marker only widens membership to pull requests that were really member
 # The marker lives in an issue body, so its author is whoever can edit that issue, and every member it
 # names becomes a freeze target posted with an org-wide checks:write token. Membership has to be
 # corroborated against the permission-gated label, or one issue edit blocks merges across the org.
-FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel/VICTIM","number":4242}]')
-FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel/VICTIM 4242 OPEN '' none)")
-check "a named pull request that was never a member voids the marker" clear live 1/0/1
-printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel/VICTIM")' >/dev/null \
+# In-org, so it clears the owner check and really reaches corroboration.
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/VICTIM","number":4242}]')
+FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/VICTIM 4242 OPEN '' none)")
+# `error`, not `clear`: falling back to the live floor would POST success and lift a standing freeze,
+# so an untrustworthy marker must decide nothing rather than decide optimistically.
+check "a named pull request that was never a member decides nothing" error
+# A labeled intruder: corroboration must match THIS Epic's label, not merely "has some label", and
+# not a different Epic's.
+FX_REHYDRATE=$(rehydrate "$B" "$(jq -cn --argjson v "$(node a-novel-kit/VICTIM 4242 OPEN '' none)" \
+  '$v | .labels.nodes = [{name:"bug"}]')")
+check "an intruder carrying an unrelated label is still rejected" error
+FX_REHYDRATE=$(rehydrate "$B" "$(jq -cn --argjson v "$(node a-novel-kit/VICTIM 4242 OPEN '' none)" \
+  '$v | .timelineItems.nodes = [{label:{name:"epic:901"}}]')")
+check "an intruder labeled for a DIFFERENT Epic is rejected" error
+printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/VICTIM")' >/dev/null \
   && ko "the planted pull request reached the freeze target set" \
   || ok "and it never reaches the freeze target set"
+# A repository outside the org can never be a member: the live label search is org-scoped, so a marker
+# naming one would let its author corroborate in a repository they control.
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"attacker/anything","number":1}]')
+FX_REHYDRATE=$(rehydrate "$B" "$(node attacker/anything 1 OPEN)")
+check "a member outside the org is rejected outright" clear live 1/0/1
 FX_BODY=$(marker frozen "$BC")
 FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/repo-c 3 OPEN '' label)")
 check "a member still carrying the label is corroborated" frozen live+snapshot 1/1/1
@@ -268,10 +293,10 @@ FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO5")]"
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
 [ "$(printf '%s' "$EV_STRAYS" | jq '[.[] | select((.isDraft | not) and .liveMember)] | length')" = 1 ] \
-  && ok "no snapshot: a labeled stray is still rolled forward" \
+  && ok "no snapshot: EV_STRAYS still offers a roll-forward candidate" \
   || ko "no snapshot: the roll-forward selected nothing (untagged nodes)"
 [ "$(printf '%s' "$EV_STRAYS" | jq '[.[] | select((.isDraft | not) and (.liveMember | not))] | length')" = 0 ] \
-  && ok "no snapshot: nothing is falsely reported as de-labeled" \
+  && ok "no snapshot: EV_STRAYS reports nothing as de-labeled" \
   || ko "no snapshot: a labeled stray was warned about as de-labeled"
 reset_fixtures
 
@@ -315,6 +340,8 @@ check "a closed member still labeled trips without any snapshot" frozen live 1/1
 reset_fixtures
 FX_LIVE_MERGED='[]'
 check "nothing merged yet, so nothing can be partial" clear live 0/0/1
+FX_LIVE_CLOSED="[$B]" # a closed member, but nothing has landed: there is no partial landing to protect
+check "a closed member with nothing merged is not a partial landing" clear live 0/1/1
 
 echo
 echo "the stray + grace path, under a snapshot"
@@ -350,10 +377,16 @@ reset_fixtures
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
 for want in 'label:"epic:900"' 'org:a-novel-kit'; do
-  grep -qF -- "$want" "$WORK/searches" \
-    && ok "every member search is scoped by $want" \
+  # All THREE searches, not merely one: a grep over the file would pass while two of them ran unscoped.
+  [ "$(grep -cF -- "$want" "$WORK/searches")" = 3 ] \
+    && ok "all three member searches are scoped by $want" \
     || ko "a member search is missing $want — the set would be every open pull request"
 done
+: > "$WORK/searches"
+evaluate_epic 901 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+[ "$(grep -cF 'label:"epic:901"' "$WORK/searches")" = 3 ] \
+  && ok "and the label follows the Epic being evaluated" || ko "the Epic label is not interpolated"
 
 echo
 echo "the merge queue is read per (repo, base), and only members are dequeued"
@@ -377,6 +410,8 @@ echo "a freeze is confirmed against REST before it blocks anyone"
 FX_LIVE_CLOSED="[$B]"
 FX_REST='{"a-novel-kit/repo-a#1":"open false","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
 check "a 'merged' member REST says is open blocks the freeze" error live 1/1/1
+FX_REST='{"a-novel-kit/repo-a#1":"closed false","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
+check "a 'merged' member REST says is closed-unmerged blocks it too" error live 1/1/1
 FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"open false","a-novel-kit/repo-c#3":"open false"}'
 check "a 'closed' member REST says is open blocks the freeze" error live 1/1/1
 reset_fixtures
@@ -423,6 +458,11 @@ FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/x\"){pullRequest(number:1){number
 check "a member repo carrying a GraphQL injection" clear live 1/0/1
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo\nEVIL: rateLimit{cost}","number":1}]')
 check "a member repo carrying a newline" clear live 1/0/1
+# The case the whole-string anchors exist for: jq's `$` matches BEFORE a final newline, so a bare
+# trailing one passes `^…$`. It emits a raw line break inside a GraphQL string literal — a
+# document-level error that no retry clears, wedging the Epic forever.
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b\n","number":2}]')
+check "a member repo with a bare trailing newline" clear live 1/0/1
 # One bad member must poison the whole set: validating with `any` instead of `all` would let the
 # injection through alongside a legitimate member.
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/x\"){evil","number":1}]')
@@ -445,6 +485,22 @@ FX_REHYDRATE=$(rehydrate "$B" "$C")
 FX_BODY=NOISE
 check "a gh notice on stderr does not corrupt the body" frozen live+snapshot 1/1/1
 FX_REHYDRATE=""
+
+echo
+echo "a pseudo-fence cannot shadow the real marker"
+# Readers once matched the fence as a SUBSTRING while merge-gate's splice matches whole lines, so a
+# decoy fence inside an HTML comment was read as the marker yet was invisible to the writer — a tamper
+# that survived every self-heal pass.
+FX_BODY=$(printf '%s\n%s\n%s\n\n%s' \
+  '<!--- <!-- epic-membership:snapshot:start --> --->' \
+  '{"status":"frozen","members":[{"repo":"a-novel-kit/DECOY","number":4242}]}' \
+  '<!--- <!-- epic-membership:snapshot:end --> --->' \
+  "$(marker frozen "$BC")")
+FX_REHYDRATE=$(rehydrate "$B" "$C")
+check "a decoy fence in an HTML comment is ignored" frozen live+snapshot 1/1/1
+printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/DECOY")' >/dev/null \
+  && ko "the decoy marker was used" || ok "and the real marker is the one that was read"
+reset_fixtures
 
 echo
 echo "the marker is parsed as JSON, not as a single line of text"
@@ -475,6 +531,10 @@ evaluate_epic 900 2>&1 >/dev/null | grep -q 'could not re-read all 2 frozen memb
 : > "$GITHUB_STEP_SUMMARY"
 FX_REHYDRATE=$(jq -cn '{data:{m0:null,m1:null}, errors:[{message:"NOT_FOUND"}]}')
 check "every alias nulled (data has keys, but no members)" error
+# GitHub answers a pullRequest(number:) that does not exist with a null and NO errors array, so the
+# member count is the only thing standing between a short answer and a silent clear.
+FX_REHYDRATE=$(jq -cn --argjson b "$B" '{data:{m0:{pullRequest:$b}, m1:{pullRequest:null}}}')
+check "a short answer carrying no errors array" error
 FX_REHYDRATE=$(jq -cn --argjson b "$B" '{data:{m0:{pullRequest:$b}, m1:{pullRequest:null}}, errors:[{message:"timeout"}]}')
 check "one alias nulled — a short answer is not a clean set" error
 FX_REHYDRATE=$(rehydrate "$B" "$C" | jq -c '. + {errors:[{message:"something went wrong"}]}')
@@ -495,12 +555,29 @@ FX_REHYDRATE=$(rehydrate "$B" "$C")
 printf 2 > "$WORK/rehydrate_fails"
 check "re-hydration recovers on the third attempt" frozen live+snapshot 1/1/1
 reset_fixtures
+for which in merged closed open; do
+  reset_fixtures
+  FX_SEARCH_FAIL_ON="$which"
+  check "a failed '$which' member search fails closed" error
+done
 FX_SEARCH_FAIL=true
-check "a failed label search" error
+check "all searches failing fails closed" error
+reset_fixtures
+FX_LIVE_CLOSED="[$B]"
+FX_REST_FAIL_ON='a-novel-kit/repo-a#1'
+check "a failed REST read of the merged member fails closed" error
+reset_fixtures
+FX_LIVE_CLOSED="[$B]"
+FX_REST_FAIL_ON='a-novel-kit/repo-b#2'
+check "a failed REST read of the closed member fails closed" error
+reset_fixtures
+FX_QUEUE='[]'
+FX_REST_FAIL_ON='a-novel-kit/repo-c#3'
+check "a failed REST read of a candidate stray fails closed" error
 reset_fixtures
 FX_REST_FAIL=true
 FX_LIVE_CLOSED="[$B]"
-check "a failed REST confirmation" error
+check "every REST read failing fails closed" error
 reset_fixtures
 FX_QUEUE_FAIL=true
 check "a failed merge-queue read" error
@@ -520,8 +597,15 @@ printf '%d passed, %d failed\n' "$pass" "$fail"
 # A floor on the count, not just on failures: a suite that runs no assertions at all exits 0 and reads
 # as green, which is the one way a test file can protect nothing while looking like it protects
 # everything. Raise this when assertions are added; never lower it to make a run pass.
-if [ "$pass" -lt 75 ]; then
-  echo "::error::only $pass assertion(s) ran (expected at least 75) — the suite did not execute fully"
+# Report failures first: they are the useful diagnosis. The floor below is about assertions that never
+# RAN, so it counts executions (pass + fail) — counting passes alone would make any ordinary failure
+# masquerade as a truncated suite.
+ran=$((pass + fail))
+if [ "$fail" -gt 0 ]; then
+  echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-[ "$fail" -eq 0 ]
+if [ "$ran" -lt 95 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 95) — the suite did not execute fully"
+  exit 1
+fi

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -49,8 +49,11 @@ fi
 export ORG=a-novel-kit PLANNING_REPO=.github GRACE_MINUTES=30
 export GITHUB_STEP_SUMMARY="$WORK/summary.md"
 now_epoch=$(date -u +%s)
-grace_seconds=$((GRACE_MINUTES * 60)) # derived, so it cannot drift from the action's own arithmetic
-sleep() { :; }                        # retry COUNTS are asserted via the gh call log, not by wall clock
+# NOTE: the action computes these outside any extracted function, so the harness necessarily
+# REIMPLEMENTS them rather than deriving them. A change to the action's own arithmetic would not be
+# caught here — keep the two in sync by hand.
+grace_seconds=$((GRACE_MINUTES * 60))
+sleep() { :; } # retries are driven by the rehydrate_fails countdown; wall-clock delay is not useful here
 
 # ---- stubbed leaves ---------------------------------------------------------------------
 # Every stub can fail on demand: the action's central promise is that it fails CLOSED, and stubs
@@ -82,6 +85,10 @@ gh() {
   esac
 }
 search_prs() {
+  # Record the query. The stub dispatches on the `is:` token alone, so without this the rest of the
+  # search grammar — the label qualifier and the org scope that BOUND membership — is unasserted, and
+  # dropping either would silently make every open pull request in the org a member of every Epic.
+  printf '%s\n' "$1" >> "$WORK/searches"
   [ "$FX_SEARCH_FAIL" = true ] && return 1
   case "$1" in
     *is:merged*) printf '%s' "$FX_LIVE_MERGED" ;;
@@ -90,9 +97,13 @@ search_prs() {
     *) echo "unexpected search: $1" >&2; return 1 ;;
   esac
 }
-merge_queue_entries() {
+merge_queue_entries() { # $1=owner $2=repo $3=base
   [ "$FX_QUEUE_FAIL" = true ] && return 1
-  printf '%s' "$FX_QUEUE" | jq -c --arg repo "$1/$2" '[.[] | select(.repo == null or .repo == $repo)]'
+  # Honour all three arguments the real helper takes. A fixture that ignores them cannot catch an
+  # owner/repo split swapped the wrong way round or a hard-coded base, both of which would read the
+  # wrong queue for every member.
+  printf '%s' "$FX_QUEUE" | jq -c --arg repo "$1/$2" --arg base "$3" \
+    '[.[] | select((.repo // $repo) == $repo and (.base // $base) == $base)]'
 }
 rest_pr_state() {
   [ "$FX_REST_FAIL" = true ] && return 1
@@ -106,23 +117,36 @@ rest_pr_state() {
 . "$WORK/lib.sh"
 
 # ---- fixtures ---------------------------------------------------------------------------
-node() { # repo number state [mergedAt]
-  jq -cn --arg r "$1" --argjson n "$2" --arg s "$3" --arg m "${4:-}" \
+# A member node as the re-read returns it. `prov` is how the node proves it belongs to the Epic:
+#   timeline = de-labeled now, but its timeline records having been labeled (the regression case)
+#   label    = still carries the label
+#   none     = neither — a pull request named by the marker that was never a member
+node() { # repo number state [mergedAt] [prov: timeline|label|none]
+  jq -cn --arg r "$1" --argjson n "$2" --arg s "$3" --arg m "${4:-}" --arg p "${5:-timeline}" --arg e "epic:900" \
     '{number:$n, headRefOid:("sha"+($n|tostring)), mergedAt:(if $m=="" then null else $m end),
-      baseRefName:"master", isDraft:false, state:$s, repository:{nameWithOwner:$r}}'
+      baseRefName:"master", isDraft:false, state:$s, repository:{nameWithOwner:$r},
+      labels:{nodes:(if $p=="label" then [{name:$e}] else [] end)},
+      timelineItems:{nodes:(if $p=="timeline" then [{label:{name:$e}}] else [] end)}}'
 }
 rehydrate() { # the aliased re-read response, one alias per member
   jq -s -c '{data: ([.[] | {pullRequest: .}] | to_entries
     | map({key:("m"+(.key|tostring)), value:.value}) | from_entries)}' <<<"$*"
 }
-marker() { # status members-json — mirrors merge-gate's payload (frozen carries no `at`)
-  local payload
+# Builds the region EXACTLY as merge-gate writes it: fence, a human-readable note line, the compact
+# payload, fence. The note is the part that matters — it lives INSIDE the fence, and a reader that
+# parses the whole region as JSON chokes on it. A fixture that omits the note agrees with whatever the
+# reader happens to do and can never catch that, which is how a parser change once made the feature
+# silently inert end to end. Frozen payloads carry no `at`; only pending does.
+marker() { # status members-json
+  local payload note
   if [ "$1" = frozen ]; then
     payload=$(jq -cn --argjson m "$2" '{status:"frozen", members:$m}')
+    note='_Epic membership, FROZEN at activation by the merge-gate. The authoritative set for this landing — a later de-label, close, or relabel does not change it. Do not edit._'
   else
     payload=$(jq -cn --arg s "$1" --argjson m "$2" '{status:$s, at:"2026-07-20T10:00:00Z", members:$m}')
+    note='_Epic membership, PENDING — stabilizing before it freezes (the label index is eventually consistent). Do not edit._'
   fi
-  printf '<!-- epic-membership:snapshot:start -->\n%s\n<!-- epic-membership:snapshot:end -->\n' "$payload"
+  printf '<!-- epic-membership:snapshot:start -->\n%s\n%s\n<!-- epic-membership:snapshot:end -->\n' "$note" "$payload"
 }
 
 AGO40=$(date -u -d '-40 minutes' +%Y-%m-%dT%H:%M:%SZ)
@@ -143,6 +167,7 @@ reset_fixtures() {
   FX_REHYDRATE=""
   printf 0 > "$WORK/rehydrate_fails"
   : > "$WORK/gh_calls"
+  : > "$WORK/searches"
   FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"}]' # repo-c is queued → not a stray
   FX_SEARCH_FAIL=false
   FX_REST_FAIL=false
@@ -187,7 +212,6 @@ echo
 echo "the snapshot is ADDED to the live set, never swapped for it"
 # The real capture shape: merge-gate freezes from open PRs, so an already-merged member is absent
 # from the snapshot. Substituting would zero the merged bucket that gates every decision.
-check "a merged member absent from the snapshot still counts" frozen live+snapshot 1/1/1
 FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 MERGED "$AGO5")" "$C")
 check "a member merged after the freeze is not double-counted" clear live+snapshot 2/0/1
 
@@ -211,6 +235,47 @@ printf '%s' "$EV_OPEN" | jq -e '[.[] | select((.isDraft | not) and .liveMember)]
 reset_fixtures
 
 echo
+echo "the marker only widens membership to pull requests that were really members"
+# The marker lives in an issue body, so its author is whoever can edit that issue, and every member it
+# names becomes a freeze target posted with an org-wide checks:write token. Membership has to be
+# corroborated against the permission-gated label, or one issue edit blocks merges across the org.
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel/VICTIM","number":4242}]')
+FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel/VICTIM 4242 OPEN '' none)")
+check "a named pull request that was never a member voids the marker" clear live 1/0/1
+printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel/VICTIM")' >/dev/null \
+  && ko "the planted pull request reached the freeze target set" \
+  || ok "and it never reaches the freeze target set"
+FX_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/repo-c 3 OPEN '' label)")
+check "a member still carrying the label is corroborated" frozen live+snapshot 1/1/1
+FX_REHYDRATE=$(rehydrate "$B" "$C") # B is de-labeled: only its timeline proves membership
+check "a de-labeled member is corroborated by its timeline" frozen live+snapshot 1/1/1
+# GraphQL follows a rename and answers with the NEW name. A frozen marker is never rewritten, so
+# matching identity on the name would strand a renamed member's Epic at `error` forever.
+FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/repo-b-renamed#2":"closed false"}')
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b-renamed 2 CLOSED)" "$C")
+check "a member whose repository was renamed still resolves" frozen live+snapshot 1/1/1
+reset_fixtures
+
+echo
+echo "the roll-forward target set, on BOTH membership paths"
+# Every node must carry liveMember whichever path built it. jq reads a missing key as null, so an
+# untagged node silently drops out of the roll-forward filter and into its skip-warning — disabling
+# recovery for exactly the Epics that have no snapshot yet, which is all of them before activation.
+reset_fixtures
+FX_QUEUE='[]' # repo-c left its queue: a stray, still labeled, within grace
+FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO5")]"
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+[ "$(printf '%s' "$EV_STRAYS" | jq '[.[] | select((.isDraft | not) and .liveMember)] | length')" = 1 ] \
+  && ok "no snapshot: a labeled stray is still rolled forward" \
+  || ko "no snapshot: the roll-forward selected nothing (untagged nodes)"
+[ "$(printf '%s' "$EV_STRAYS" | jq '[.[] | select((.isDraft | not) and (.liveMember | not))] | length')" = 0 ] \
+  && ok "no snapshot: nothing is falsely reported as de-labeled" \
+  || ko "no snapshot: a labeled stray was warned about as de-labeled"
+reset_fixtures
+
+echo
 echo "the GraphQL document it builds"
 FX_BODY=$(marker frozen "$BC")
 FX_REHYDRATE=$(rehydrate "$B" "$C")
@@ -218,7 +283,8 @@ evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
 q=$(cat "$WORK/gh_calls")
 for want in 'owner:"a-novel-kit", name:"repo-b"' 'number:2' 'owner:"a-novel-kit", name:"repo-c"' 'number:3' \
-            'm0:' 'm1:' 'state' 'headRefOid' 'mergedAt' 'baseRefName' 'isDraft' 'nameWithOwner'; do
+            'm0:' 'm1:' 'state' 'headRefOid' 'mergedAt' 'baseRefName' 'isDraft' 'nameWithOwner' \
+            'labels(first:100)' 'LABELED_EVENT'; do
   case "$q" in
     *"$want"*) ok "queries $want" ;;
     *) ko "the re-read query is missing: $want" ;;
@@ -263,6 +329,73 @@ check "the same stray within grace does not" clear live+snapshot 1/0/2
 reset_fixtures
 
 echo
+echo "the snapshot is the fresher read, so it wins a collision"
+# Both sources describe repo-c#3. The freeze is posted on headRefOid, and the live search index lags a
+# direct read, so a stale head here is the "stranded on Expected" failure the action exists to avoid.
+reset_fixtures
+FX_LIVE_OPEN="[$(node a-novel-kit/repo-c 3 OPEN)]" # index still reports the old head
+FX_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=$(rehydrate "$B" "$(jq -cn --argjson c "$C" '$c | .headRefOid = "sha3-FRESH"')")
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+printf '%s' "$EV_OPEN" | jq -e 'any(.number == 3 and .headRefOid == "sha3-FRESH")' >/dev/null \
+  && ok "EV_OPEN carries the snapshot's head, not the index's" \
+  || ko "the freeze would be posted on the stale head"
+[ "$(printf '%s' "$EV_OPEN" | jq '[.[] | select(.number == 3)] | length')" = 1 ] \
+  && ok "and the member appears exactly once" || ko "the member was double-counted across sources"
+
+echo
+echo "membership is bounded by the label and the org"
+reset_fixtures
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+for want in 'label:"epic:900"' 'org:a-novel-kit'; do
+  grep -qF -- "$want" "$WORK/searches" \
+    && ok "every member search is scoped by $want" \
+    || ko "a member search is missing $want — the set would be every open pull request"
+done
+
+echo
+echo "the merge queue is read per (repo, base), and only members are dequeued"
+reset_fixtures
+# An unrelated pull request sits in the same queue: it must not become an Epic member.
+FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"},{"number":999,"state":"QUEUED","headOid":"sha999"}]'
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+[ "$(printf '%s' "$EV_QUEUE" | jq 'length')" = 1 ] \
+  && ok "an unrelated queue entry is not treated as a member" \
+  || ko "a non-member queue entry leaked into EV_QUEUE (it would be dequeued)"
+reset_fixtures
+FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3","repo":"a-novel-kit/repo-c","base":"master"}]'
+check "the queue is read with the member's own repo and base" clear live 1/0/1
+reset_fixtures
+
+echo
+echo "a freeze is confirmed against REST before it blocks anyone"
+# Each guard gets its own fixture: a single failure that trips all three at once proves only that at
+# least one survives, and any one of them could then be deleted unnoticed.
+FX_LIVE_CLOSED="[$B]"
+FX_REST='{"a-novel-kit/repo-a#1":"open false","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
+check "a 'merged' member REST says is open blocks the freeze" error live 1/1/1
+FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"open false","a-novel-kit/repo-c#3":"open false"}'
+check "a 'closed' member REST says is open blocks the freeze" error live 1/1/1
+reset_fixtures
+FX_QUEUE='[]' # repo-c looks like a stray to the index...
+FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"closed true"}'
+check "a candidate stray REST says is merged is not a stray" clear live 1/0/1
+reset_fixtures
+
+echo
+echo "the grace clock"
+FX_QUEUE='[]'
+FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO40"),$(node a-novel-kit/repo-d 4 MERGED "$AGO5")]"
+FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/repo-d#4":"closed true"}')
+check "grace runs from the FIRST merge, not the most recent" frozen live 2/0/1
+FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED 'not-a-date')]"
+check "an unparseable merge time never elapses grace" clear live 1/0/1
+reset_fixtures
+
+echo
 echo "a degraded marker falls back to the live floor — never a crash, never a freeze on garbage"
 FX_BODY=$(marker pending "$BC")
 check "a pending marker (the set has not settled)" clear live 1/0/1
@@ -280,6 +413,12 @@ FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":"2"}]')
 check "a member number that is a string" clear live 1/0/1
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":1.5}]')
 check "a non-integer member number (a whole-document error)" clear live 1/0/1
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":0}]')
+check "member number zero" clear live 1/0/1
+FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2147483648}]')
+check "a member number past Int range" clear live 1/0/1
+FX_BODY=$(marker frozen "$(jq -cn '[range(51) | {repo:"a-novel-kit/repo-b", number:(.+1)}]')")
+check "a frozen set over the member cap" clear live 1/0/1
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/x\"){pullRequest(number:1){number}}} evil: rateLimit{cost","number":1}]')
 check "a member repo carrying a GraphQL injection" clear live 1/0/1
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo\nEVIL: rateLimit{cost}","number":1}]')
@@ -378,4 +517,11 @@ check "an Epic with no snapshot sees none of the previous one's" clear live 1/0/
 
 echo
 printf '%d passed, %d failed\n' "$pass" "$fail"
+# A floor on the count, not just on failures: a suite that runs no assertions at all exits 0 and reads
+# as green, which is the one way a test file can protect nothing while looking like it protects
+# everything. Raise this when assertions are added; never lower it to make a run pass.
+if [ "$pass" -lt 75 ]; then
+  echo "::error::only $pass assertion(s) ran (expected at least 75) — the suite did not execute fully"
+  exit 1
+fi
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #313. Completes the activation-snapshot Epic (#253) — the frozen member set is now both written (merge-gate) and read (epic-membership, detect-partial-landing).

## The gap

`evaluate_epic` resolved an Epic's members from three live `epic:<N>` label searches. A member de-labeled and closed mid-landing disappeared from the set: the survivors looked like a clean landing, the detector cleared, and the rest of the wave merged on top of a hole. It is not closable from live truth — GitHub indexes no "ever carried label X" — which is why merge-gate persists the set.

## The change

The live label search stays as the **floor**. The frozen snapshot is **unioned onto it**, contributing the members live truth has forgotten and nothing else.

Union rather than substitution is the load-bearing decision, and the first cut got it wrong (see below). It makes the change **monotone**: no snapshot, however degraded or incomplete, can shrink what the detector already saw, so the worst case is the behaviour that predates this PR. It also covers a PR labeled *after* the freeze, which under substitution fell into neither the frozen set nor the label-based backstop and so never got an `epic-freeze` check posted at all.

The per-Epic summary line carries `membership=live|live+snapshot`, so any decision is traceable to the set it was made on.

## What self-review caught

Four independent reviewers (correctness/INV-1, bash & jq, rollout/permissions, test quality). The first cut had a **critical** defect and would have been worse than no change:

| # | Finding | Resolution |
| --- | --- | --- |
| 1 | **Substituting the live set disabled detection entirely.** The frozen set is not a superset: merge-gate captures from OPEN PRs and promotes after 120s of stability, but auto-merge is armed at ready-time, so members merge before the freeze, each merge shrinks the set and resets the clock, and the marker converges to the members that *couldn't* merge. That empties `merged`, and `merged >= 1` gates every decision → clear everything. | Union onto the live floor |
| 2 | **A short re-read was accepted as a clean set.** `.data \| length` counts *keys*, so an all-nulled response passed and a 3-member set silently became empty → `clear` → posts success. The guard was lifted from `epic-membership`, where a dropped member is fail-*safe*; here it is fail-*unsafe*. Same code, inverted polarity. | All-or-nothing re-read: no `errors`, full count, every node matched back to a requested member, every state known |
| 3 | **`test("^[^/]+/[^/]+$")` admitted quotes and newlines** (`[^/]` matches both) and `.repo` is interpolated into a GraphQL document → field injection under the org-wide read token; `type == "number"` admitted `1.5`, a whole-document validation error no retry clears | Tightened to GitHub's grammar + integer bounds, plus dedup and a length cap — in both readers |
| 4 | **`grep -m1 '^{'` silently required single-line compact JSON** — a pretty-printed marker killed the feature with no warning | The fenced region is parsed as JSON |
| 5 | A `gh` notice on stderr could be parsed as body text | The issue is read as validated JSON |
| 6 | merge-gate's nested `epic-membership` call dropped `planning_repo` — an override would split writer and reader across repos | Threaded |

Three comments claimed more than the code delivered and are corrected in place: the `rc=1` contract (fail-open per-PR, post-nothing in the sweep — not simply "fails closed"), the backstop ordering guarantee (the epic pass wins only where it *runs* — not on the paused or error branches), and the manifest's de-label claim (the snapshot rescues a forgotten member, not a forgotten Epic).

Cleared by review: token scopes are correct in both modes, `dry_run` is respected (both new calls are reads), and the `test-actions` job cannot pass vacuously.

## What the second self-review round caught

The union was right, but three mechanisms downstream still resolved membership by label while `evaluate_epic` had moved to label ∪ snapshot:

| # | Finding | Resolution |
| --- | --- | --- |
| 1 | **The roll-forward re-armed auto-merge on a de-labeled member** — resuming a landing a human stepped out of, on a PR both gates now classify as standalone, in a repo outside the enqueue token's label-derived scope (403 every sweep, forever) | Nodes carry `liveMember`; detection counts a de-labeled member, mutation skips it with a warning |
| 2 | **Per-PR mode greens a head the sweep froze** — it classifies by label alone, so any event on a de-labeled member posts `success` over the sweep's `failure` | Filed as #325 (needs label-free Epic lookup, same gap as #319); the ordering comment no longer claims a guarantee the sweep cannot make |
| 3 | **`merge-gate` still parsed the marker with `grep -m1 '^{'`** — on a pretty-printed marker it took the `pending` branch and *overwrote the frozen set with the current live one*, permanently erasing the abandoned member | Parses like the two readers |
| 4 | **An unreadable Epic body fell back to the live floor** — but a `clear` POSTS success and lifts a freeze an earlier pass set | Only a 404 is an answer; any other failure decides nothing |
| 5 | **Reconciliation matched on `nameWithOwner`**, and GraphQL follows renames silently — one renamed member wedged its Epic at `error` permanently, since a frozen marker is never rewritten | Identity is the alias index + number, both rename-stable |
| 6 | **`1.0` and `1e2` passed the `== floor` guard** and reached the query as `Int!` violations that reject the whole document | `\|floor` renders canonical integers |
| 7 | Case-variant repo names counted twice; stderr folded into the payload could corrupt it | Case-folded dedup; streams read separately |

**Union direction reversed.** The snapshot node now wins a collision — both describe the same PR, but the snapshot is a direct read issued this pass while the live node comes from the eventually-consistent search index, so it carries the fresher state and head SHA. It also keeps each PR in exactly one bucket; previously a disagreement between sources double-counted it and posted success on a merged head. This cannot weaken detection: `MERGED` is terminal, so a fresher read never demotes a member the index already reports merged.

## What the third (security-focused) round caught

| # | Finding | Severity | Resolution |
| --- | --- | --- | --- |
| 1 | **A crafted marker could aim the org-wide `checks:write` token at arbitrary pull requests.** Anyone able to edit an Epic issue body (write on the planning repo, or being the issue author) could name up to 50 PRs anywhere in the org; freeze targets come straight from that set, so the sweep posts merge-blocking `epic-freeze=failure` on all of them, every 15 min, forever. The inverse lifts a legitimate freeze. **No access to any victim repo needed.** | **Critical** | Membership is corroborated: a member must still carry `epic:<N>` **or** show a `LABELED_EVENT` for it in its timeline. A member that cannot voids the whole marker, loudly |
| 2 | **Every marker the writer emits was unparseable** — `merge-gate` writes a prose note *inside* the fence; `grep '^{'` skipped it, the round-2 `jq -s` did not. Both readers fell back to live forever, and the writer rewrote the body on every pass, refreshing the timestamp so it could never promote. The feature was **inert end to end** | **Critical** (round-2 regression) | All three skip to the first line that opens a value — keeps the note *and* pretty-print support |
| 3 | **`liveMember` was stamped only on the snapshot path**, so on every Epic without one — all of them — jq read the missing key as `null`: the roll-forward selected nothing, its skip-warning selected everything. The documented self-heal was dead | **Critical** (round-2 regression) | Every membership view goes through `union_buckets`, against an empty snapshot when there is none |
| 4 | The repo pattern admitted a **trailing newline** (jq's `$` matches before a final newline) → breaks the GraphQL document → wedges the Epic permanently | Major | Anchored `\A…\z` |
| 5 | Readers matched fences by **substring**, the writer by whole line — a pseudo-fence planted in an HTML comment shadowed the real marker invisibly and survived every self-heal | Major | Whole-line anchored in all three |
| 6 | **`epic-membership` accepted a partial re-read**, and `merge-gate` gates on that set — a vanished member is a member never evaluated | Major | All-or-nothing; an incomplete answer holds |
| 7 | The writer validated nothing (could emit a marker the readers reject and never rewrite); a corrupt `at` read as infinitely old and skipped stabilization; the member cap was 200 against a shared API budget; the snapshot-write token was org-wide `issues: write` | Minor | Validated, fixed, 50, scoped |

**On the design premise.** I had carried "a de-labeled member is unrecoverable from live truth" since the plan. That is true of *search* — you cannot enumerate them — but false *per pull request*, which can be verified via `timelineItems`. So the snapshot supplies **enumeration** and GitHub's timeline supplies **authority**. A writable issue body should never have been the authority for anything.

Confirmed sound under attack: no GraphQL injection survives the number validator; marker data never reaches a shell command or REST path; no log or check-run annotation injection; and **auto-merge cannot be armed from the marker at all** — double-gated by `liveMember` and the independently label-scoped enqueue token.

## What the fourth round caught

Scoped to round 3's changes only. **No new criticals in the product** — the first round where that held.

| # | Finding | Resolution |
| --- | --- | --- |
| 1 | **Corroboration failed OPEN.** An unverifiable member voided the marker and returned "no snapshot", so the pass decided on the live floor — the very blind spot the snapshot covers. A `clear` POSTS success, so one appended object **lifted a standing freeze**, permanently (frozen markers are never rewritten) and quietly (an `::error::` leaves a scheduled run green) | Returns "decide nothing" instead: any prior freeze stands, re-derived next pass |
| 2 | **Corroboration was bypassable.** The member regex accepted any owner while the live search is org-scoped — an author could name a repo they control, label a PR there, and drag it into this Epic's freeze set | Owner constrained to the workflow's org in all three validators |
| 3 | **The `at` fix swung too far.** Round 2 read a corrupt timestamp as epoch 0 (promote immediately); round 3 read it as now (never ages) — and with an unchanged member set the reset branch never fires either, so the marker **stalled forever** and the Epic silently kept live membership | Rewrites a fresh `pending`: refuses the premature freeze *and* repairs the marker |
| 4 | `merge-gate`'s comment and operator warning still said 200 after the cap moved to 50; the `reenqueue` token guard sat behind the dry-run return, so a rehearsal claimed it would roll a stray forward with a token it does not have | Fixed |

Verified sound with evidence I could not have produced by reading: corroboration's premise holds — labels **cannot** be attached at PR creation (`CreatePullRequestInput` has no `labelIds`; REST has no `labels`), so every label emits a `LabeledEvent`; 240 real labeled PRs sampled with zero counterexamples; the event survives de-labelling *and* deletion of the label; `last:250`/`first:100` sit exactly at GitHub's caps and paginate the **filtered** set; the query costs 1 rate-limit point at 17,500 nodes against a 500,000 ceiling.

## Tests

14 → 36 → **57 assertions**, driven by mutation testing rather than intuition. An external pass over **119 mutants killed only 54%** of them, and the survivors clustered exactly where fixtures could not see:

| Cluster | Why it survived | Now |
| --- | --- | --- |
| `EV_OPEN` emptied / captured pre-union | only its *count* was asserted — a decision naming no head is worthless, and pre-union capture means snapshot-only members never actually receive the check | contents asserted, plus the `liveMember` tagging |
| 8 mutants of the GraphQL document (fields dropped, aliases collapsed) | the `gh` stub discarded the query; each is a total feature outage | the query is recorded and asserted |
| identity, dedup, and repo-regex conjunctions | every fixture differed in *both* halves, so either half could be deleted unnoticed | decomposed: a mixed valid/evil set, an injected prefix, two members in one repo |
| float-valued member numbers | no fixture used `2.0` | asserted to render canonically |

57 → 79 → **95 assertions**. An independent 173-mutant pass **refuted three kills I had claimed** — the union's snapshot-wins direction, the rename-tolerant identity, and the search grammar were all unpinned, each passing for a different reason than its name suggested. Added since: the collision fixture proving the freeze is posted on the *fresher* head, a renamed-repository member, recorded search queries (the label and org qualifiers that bound membership were invisible), per-guard REST-confirmation fixtures (one failure had been tripping all three at once), the queue filter, the grace clock's first-merge anchor, and the numeric bounds.

A 172-mutant pass **refuted one more claimed kill**: the whole-line fence anchoring had no adversarial fixture, so a pseudo-fence planted in an HTML comment still shadowed the real marker undetected. That now has one — along with the bare trailing newline the `\A…\z` anchors actually exist for (the old fixture was already rejected by the old pattern), a corroboration intruder carrying an unrelated label and one labelled for a *different* Epic, per-search grammar assertions under two Epic numbers, and one fixture per fail-closed guard (a fixture tripping several at once proves only that one survives).

The assertion floor now counts assertions **executed** rather than passed, and failures report first — counting passes made every ordinary failure masquerade as a truncated suite.

The decisive structural fix: **`marker()` now builds the region exactly as `merge-gate` writes it**, note line included. The old fixture encoded my *belief* about the format rather than the writer's output, which is precisely why finding 2 passed CI. Against that break it now fails 33 assertions. Two comments claimed the harness derived what it reimplements and asserted what it never checked; both now say what is true. The suite enforces a floor on assertions executed, because a suite that runs none exits green.

The fixtures now model the **real capture shape** — the merged member absent from the frozen set — which is what the original suite got wrong: it tested my mental model rather than the system's behaviour, and would have passed against the critical defect. Counts and freeze reason are asserted alongside the decision, and every stub can fail, so the fail-closed branches are actually reachable.

> [!NOTE]
> `main.yaml` jobs become required checks on this repo via repocfg, so `test-actions` joins the merge gate. Intended — a test that can silently not run protects nothing — but it is a governance change.

> [!NOTE]
> Nothing here is live until release: merge-gate's capture (#315) is in no tag yet, every caller pins `v1.19.5`, and until markers exist this path is byte-identical to master plus one REST read per Epic.

Follow-ups filed rather than folded in, none of them blockers for this change:

- #319 — the sweep reaches Epics only through live labels (the remaining half of the de-label hole)
- #320 — no shellcheck anywhere in the repo
- #321 — merge-gate, the snapshot *writer*, has no `dry_run` rehearsal
- #322 — `planning_repo` is not threadable through `merge-gate-run`
- #323 — the Epic issue is read twice per pass
- #329 — corroboration proves *historical* membership, not membership in this landing
- #330 — **`test-actions` is not in the branch ruleset**, so the suite is advisory until repocfg republishes



