### PR TITLE
docs(detect-partial-landing): name automation:paused as the freeze override

### DIFF
--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -38,6 +38,13 @@ description: >
   — a freeze is not a latch a human must clear. It never reverts a merged PR. `dry_run`
   defaults on: it logs every intended freeze, unfreeze, and re-enqueue without calling GitHub.
 
+  To stop a landing rather than let it resume, label the Epic issue `automation:paused`. That is the
+  latch: a permission-gated marker that holds the Epic whatever the predicate reads, where a freeze is
+  only ever a statement about the Epic's current shape and lifts the moment that shape is healthy
+  again. Re-arming is safe on its own terms — auto-merge parks against a red required check, and
+  merge-gate holds the whole set until every member is ready — so a resumed landing still cannot merge
+  an unready set. The pause is for the case where a human wants the landing stopped regardless.
+
 inputs:
   client_id:
     required: true
@@ -920,7 +927,10 @@ runs:
         sweep_post_clear() { # $1 = epic
           local epic="$1"
           if [ "$EV_MERGED_COUNT" -ge 1 ] && [ "$EV_STRAY_COUNT" -ge 1 ]; then
-            echo "epic #$epic: $EV_STRAY_COUNT stray sibling(s) within grace — rolling forward." | tee -a "$GITHUB_STEP_SUMMARY"
+            # Name the escape hatch here, not just in the manifest: this line is what an operator sees
+            # when a landing they thought was stopped starts moving again, and the pause is the only
+            # thing that would have held it.
+            echo "epic #$epic: $EV_STRAY_COUNT stray sibling(s) within grace — rolling forward (re-arms auto-merge; label the Epic \`automation:paused\` to stop the landing instead)." | tee -a "$GITHUB_STEP_SUMMARY"
             # Roll forward only strays the live `epic:<N>` label search still returns. A snapshot-only
             # member is one a human de-labeled, and re-arming auto-merge on it would do three wrong
             # things at once: resume a landing a human stepped out of (the one thing epic-freeze must

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -38,12 +38,8 @@ description: >
   — a freeze is not a latch a human must clear. It never reverts a merged PR. `dry_run`
   defaults on: it logs every intended freeze, unfreeze, and re-enqueue without calling GitHub.
 
-  To stop a landing rather than let it resume, label the Epic issue `automation:paused`. That is the
-  latch: a permission-gated marker that holds the Epic whatever the predicate reads, where a freeze is
-  only ever a statement about the Epic's current shape and lifts the moment that shape is healthy
-  again. Re-arming is safe on its own terms — auto-merge parks against a red required check, and
-  merge-gate holds the whole set until every member is ready — so a resumed landing still cannot merge
-  an unready set. The pause is for the case where a human wants the landing stopped regardless.
+  `automation:paused` on the Epic issue is the latch: it holds whatever the predicate reads. A freeze
+  only describes the Epic's current shape, so it lifts as soon as that shape is healthy.
 
 inputs:
   client_id:
@@ -927,10 +923,7 @@ runs:
         sweep_post_clear() { # $1 = epic
           local epic="$1"
           if [ "$EV_MERGED_COUNT" -ge 1 ] && [ "$EV_STRAY_COUNT" -ge 1 ]; then
-            # Name the escape hatch here, not just in the manifest: this line is what an operator sees
-            # when a landing they thought was stopped starts moving again, and the pause is the only
-            # thing that would have held it.
-            echo "epic #$epic: $EV_STRAY_COUNT stray sibling(s) within grace — rolling forward (re-arms auto-merge; label the Epic \`automation:paused\` to stop the landing instead)." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "epic #$epic: $EV_STRAY_COUNT stray sibling(s) within grace — rolling forward (re-arms auto-merge; \`automation:paused\` stops it)." | tee -a "$GITHUB_STEP_SUMMARY"
             # Roll forward only strays the live `epic:<N>` label search still returns. A snapshot-only
             # member is one a human de-labeled, and re-arming auto-merge on it would do three wrong
             # things at once: resume a landing a human stepped out of (the one thing epic-freeze must


### PR DESCRIPTION
Closes #326. Part of a-novel-kit/.github#130.

## The decision

**A freeze is not a latch** — settled on the issue. The current behaviour stands; this PR changes no code path.

A latch would be stored state, and this saga earns each stored flag individually: the activation snapshot only justified persistence because a de-labeled member is genuinely unrecoverable from live truth. "This Epic was frozen earlier" does not clear that bar — if the partial-landing predicate no longer trips, the evidence for freezing is gone.

Re-arming auto-merge on a resume is also safe on its own terms, which is the part that makes the decision easy: `enable-auto-merge` parks the request against a red required check, and `merge-gate` holds the whole set until every member is merge-ready. A reopened-but-unready member keeps the gate red, so armed siblings sit parked. **Arming is not merging.**

## What was actually missing

The override. A human who wants the landing *stopped* rather than resumed has `automation:paused` on the Epic issue — permission-gated, honoured by both `merge-gate` and this action — and nothing said so where a reader of the freeze semantics would find it. It was documented only as a pause mechanism.

- The manifest now states it beside the freeze/unfreeze paragraph, framed as the contrast it is: a freeze describes the Epic's current shape; the pause holds it regardless.
- The roll-forward log names it too. That line is what an operator sees when a landing they believed stopped starts moving again, so it is the right place to say what would have held it.

## Rejected

An implicit latch derived from prior check-run state — `sweep_post_clear` would have to read back each head's previous `epic-freeze` conclusion, adding a read and a failure mode per head per pass, to buy protection `merge-gate` already provides.

> [!NOTE]
> No behavioural change, so no new test. The existing 95-assertion suite stays green.