### PR TITLE
fix: stop concurrent writers losing the Epic body's snapshot

### DIFF
--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -578,6 +578,18 @@ runs:
         # Same marker for our purposes: same status and same member set. Deliberately ignores `at`,
         # which is per-writer — byte equality would make two writers with an identical set unable to
         # satisfy each other and ping-pong until both gave up, reporting a failure that never happened.
+        # "The marker already says what we intend, AND it is a marker that can still make progress."
+        # Used for BOTH the entry short-circuit and the post-write verify: if these two ever answer
+        # differently, a repair that was clobbered reads as a repair that landed.
+        marker_settled() { # $1 = live marker json, $2 = our payload json
+          same_marker "$1" "$2" || return 1
+          # A frozen marker carries no `at` and needs none — it is terminal.
+          [ "$(printf '%s' "$1" | jq -r '.status // ""')" = "frozen" ] && return 0
+          # A pending marker whose `at` cannot be parsed can never age, so it is not settled however
+          # equal its members look: the decision step routes exactly that case to a repairing write.
+          printf '%s' "$1" | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null 2>&1
+        }
+
         same_marker() { # $1 = marker json, $2 = marker json
           [ -n "$1" ] && [ -n "$2" ] && jq -e -n --argjson a "$1" --argjson b "$2" \
             '($a.status == $b.status) and (($a.members // []) == ($b.members // []))' >/dev/null 2>&1
@@ -590,6 +602,9 @@ runs:
             err=""   # or a later give-up reports an earlier attempt's error
             # Re-read every attempt, the first included.
             if ! body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
+              # Record it: a read failure has no diagnostic of its own, and clearing `err` each attempt
+              # would otherwise leave the give-up message empty when the last attempts fail here.
+              err="could not read ${ORG}/${PLANNING_REPO}#${EPIC} (attempt ${attempt})"
               [ "$attempt" -lt 3 ] && sleep 2
               continue
             fi
@@ -600,9 +615,7 @@ runs:
             # decision step routes exactly that case here to REPAIR it, because a timestamp that cannot
             # be read can never age, so the marker would sit pending forever and the Epic would keep
             # live membership with a success line in the log every sweep.
-            if same_marker "$marker" "$payload" \
-              && { [ "$(printf '%s' "$marker" | jq -r '.status // ""')" = "frozen" ] \
-                || printf '%s' "$marker" | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null 2>&1; }; then
+            if marker_settled "$marker" "$payload"; then
               rc=0
               break
             fi
@@ -621,11 +634,16 @@ runs:
             # RE-DERIVE the freeze. `do=frozen` means "the set has held still long enough", judged
             # against the marker this pass read at the start. If the marker has moved since — a peer
             # saw the set change and reset the clock — that judgement is stale, and freezing it would
-            # make a wrong set permanent. Abandon; the next pass decides on current truth.
+            # make a wrong set permanent. Age is re-checked too: without it a freeze can land seconds
+            # after a peer's reset, skipping the very window that lets the lagging label index surface
+            # a missing member. Abandon; the next pass decides on current truth.
             if [ "$do" = "frozen" ] \
               && ! jq -e -n --argjson m "${marker:-null}" --argjson cur "$cur" \
+                   --arg now "$now" --argjson thr "${STABILIZE_SECONDS}" \
                    '($m | type == "object") and $m.status == "pending"
-                    and (($m.members // []) | sort_by(.repo, .number)) == $cur' >/dev/null 2>&1; then
+                    and (($m.members // []) | sort_by(.repo, .number)) == $cur
+                    and ($m.at | try (fromdateiso8601 | true) catch false)
+                    and (($now | fromdateiso8601) - ($m.at | fromdateiso8601)) >= $thr' >/dev/null 2>&1; then
               echo "::warning::Epic #${EPIC}: the member set moved while this pass was deciding — not freezing a stale set; the next pass re-derives." \
                 | tee -a "$GITHUB_STEP_SUMMARY"
               rc=2
@@ -634,12 +652,12 @@ runs:
 
             printf '%s' "$body" > "$bodyf"
             splice "$bodyf" "$regionf" > "$outf"
-            err=$(gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" 2>&1) || true
+            err=$(gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" 2>&1 >/dev/null) || true
             # Verify rather than trust the edit's exit code: a peer write can land after ours. Compare
             # the REGION semantically — grepping the whole body would also match an orphaned payload
             # line that splice's recovery path leaves behind as prose.
             if body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r') \
-              && same_marker "$(current_marker "$body")" "$payload"; then
+              && marker_settled "$(current_marker "$body")" "$payload"; then
               rc=0
               break
             fi

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -443,6 +443,14 @@ runs:
         STABILIZE_SECONDS: "120"
       run: |
         set -euo pipefail
+        # The marker currently in the body, as JSON — empty when there is none or it is unusable.
+        current_marker() { # $1 = body
+          printf '%s\n' "$1" \
+            | awk -v s="$START" -v e="$END" '$0 == s {f=1;next} $0 == e {f=0} f' \
+            | sed -n '/^[[:space:]]*[{[]/,$p' \
+            | jq -s -c '.[0] // empty' 2>/dev/null || true
+        }
+
         START='<!-- epic-membership:snapshot:start -->'
         END='<!-- epic-membership:snapshot:end -->'
 
@@ -474,10 +482,7 @@ runs:
         # an unreadable FROZEN marker falls to the `pending` branch below, which OVERWRITES it with the
         # current live set — erasing exactly the de-labeled member the snapshot was frozen to remember.
         # All three participants extract identically.
-        marker=$(printf '%s\n' "$body" \
-          | awk -v s="$START" -v e="$END" '$0 == s {f=1;next} $0 == e {f=0} f' \
-          | sed -n '/^[[:space:]]*[{[]/,$p' \
-          | jq -s -c '.[0] // empty' 2>/dev/null || true)
+        marker=$(current_marker "$body")
         # An unparseable marker (hand-edited garbage) is treated as absent → a fresh pending, which
         # self-heals it rather than crashing or freezing corruption.
         if [ -z "$marker" ] || ! printf '%s' "$marker" | jq empty 2>/dev/null; then marker=null; fi
@@ -569,13 +574,6 @@ runs:
         # RE-DERIVE will happily freeze a member set the world has already moved past, and the retry
         # below would make it win. So each attempt re-checks the decision against what is actually there.
 
-        # The marker currently in the body, as JSON — empty when there is none or it is unusable.
-        current_marker() { # $1 = body
-          printf '%s\n' "$1" \
-            | awk -v s="$START" -v e="$END" '$0 == s {f=1;next} $0 == e {f=0} f' \
-            | sed -n '/^[[:space:]]*[{[]/,$p' \
-            | jq -s -c '.[0] // empty' 2>/dev/null || true
-        }
 
         # Same marker for our purposes: same status and same member set. Deliberately ignores `at`,
         # which is per-writer — byte equality would make two writers with an identical set unable to

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -562,45 +562,93 @@ runs:
         # stubbed gh. The sweep runs this gate as a matrix over every open member pull request with no
         # concurrency bound, and the read-model renderer edits the same body from another job, so
         # writers overlap by design. GitHub's issues API offers no conditional update — a GET returns an
-        # ETag, PATCH accepts no If-Match — so the closest available guarantee is to splice into a body
-        # read moments ago and then confirm the write survived, retrying against whatever landed.
-        write_marker() { # $1 = region file. 0 = the marker is in place, 1 = give up (caller warns)
-          local regionf="$1" bodyf outf attempt body rc=1
+        # ETag, PATCH accepts no If-Match — so the guarantee has to be built from reads.
+        #
+        # Re-reading is not enough on its own: the decision ($do / $payload) was computed from a body
+        # fetched earlier, and a peer may have moved the set since. A writer that re-reads but does not
+        # RE-DERIVE will happily freeze a member set the world has already moved past, and the retry
+        # below would make it win. So each attempt re-checks the decision against what is actually there.
+
+        # The marker currently in the body, as JSON — empty when there is none or it is unusable.
+        current_marker() { # $1 = body
+          printf '%s\n' "$1" \
+            | awk -v s="$START" -v e="$END" '$0 == s {f=1;next} $0 == e {f=0} f' \
+            | sed -n '/^[[:space:]]*[{[]/,$p' \
+            | jq -s -c '.[0] // empty' 2>/dev/null || true
+        }
+
+        # Same marker for our purposes: same status and same member set. Deliberately ignores `at`,
+        # which is per-writer — byte equality would make two writers with an identical set unable to
+        # satisfy each other and ping-pong until both gave up, reporting a failure that never happened.
+        same_marker() { # $1 = marker json, $2 = marker json
+          [ -n "$1" ] && [ -n "$2" ] && jq -e -n --argjson a "$1" --argjson b "$2" \
+            '($a.status == $b.status) and (($a.members // []) == ($b.members // []))' >/dev/null 2>&1
+        }
+
+        write_marker() { # $1 = region file. 0 = our marker is in place, 2 = yielded, 1 = gave up
+          local regionf="$1" bodyf outf attempt body marker err rc=1
           bodyf=$(mktemp); outf=$(mktemp)
           for attempt in 1 2 3; do
-            # Re-read every attempt, the first included: `body` was fetched before the decision was
-            # computed, and a sibling job may have written since.
+            # Re-read every attempt, the first included.
             if ! body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
               [ "$attempt" -lt 3 ] && sleep 2
               continue
             fi
-            # A marker that turned FROZEN under us is another writer's promotion, not a conflict to
-            # win: frozen is terminal, so leave it rather than reset it to pending.
-            if [ "$do" != "frozen" ] && printf '%s\n' "$body" \
-              | awk -v s="$START" -v e="$END" '$0 == s {f=1;next} $0 == e {f=0} f' \
-              | sed -n '/^[[:space:]]*[{[]/,$p' | jq -e 'select(.status == "frozen")' >/dev/null 2>&1; then
-              echo "Epic #${EPIC}: another writer froze the snapshot first — leaving it." | tee -a "$GITHUB_STEP_SUMMARY"
+            marker=$(current_marker "$body")
+
+            # Already says what we were going to say — nothing to write, by us or anyone.
+            if same_marker "$marker" "$payload"; then
               rc=0
               break
             fi
+
+            # A frozen marker is terminal: it is the authority every reader has been using, and
+            # rewriting it mid-landing is the one thing "frozen" forbids. Yield, whatever we intended.
+            if [ -n "$marker" ] && [ "$(printf '%s' "$marker" | jq -r '.status // ""')" = "frozen" ]; then
+              echo "Epic #${EPIC}: the snapshot is already frozen (a peer got there first) — leaving it." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+              rc=2
+              break
+            fi
+
+            # RE-DERIVE the freeze. `do=frozen` means "the set has held still long enough", judged
+            # against the marker this pass read at the start. If the marker has moved since — a peer
+            # saw the set change and reset the clock — that judgement is stale, and freezing it would
+            # make a wrong set permanent. Abandon; the next pass decides on current truth.
+            if [ "$do" = "frozen" ] \
+              && ! jq -e -n --argjson m "${marker:-null}" --argjson cur "$cur" \
+                   '($m | type == "object") and $m.status == "pending" and ($m.members == $cur)' >/dev/null 2>&1; then
+              echo "::warning::Epic #${EPIC}: the member set moved while this pass was deciding — not freezing a stale set; the next pass re-derives."
+              rc=2
+              break
+            fi
+
             printf '%s' "$body" > "$bodyf"
             splice "$bodyf" "$regionf" > "$outf"
-            gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" >/dev/null 2>&1 || true
-            # Verify rather than trust the exit code: a concurrent write can land after ours and undo it.
-            if gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r' \
-              | grep -qxF -- "$payload"; then
+            err=$(gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" 2>&1) || true
+            # Verify rather than trust the edit's exit code: a peer write can land after ours. Compare
+            # the REGION semantically — grepping the whole body would also match an orphaned payload
+            # line that splice's recovery path leaves behind as prose.
+            if body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r') \
+              && same_marker "$(current_marker "$body")" "$payload"; then
               rc=0
               break
             fi
             [ "$attempt" -lt 3 ] && sleep 2
           done
+          if [ "$rc" = 1 ] && [ -n "${err:-}" ]; then
+            echo "::warning::Epic #${EPIC}: last write error — ${err}"
+          fi
           rm -f "$bodyf" "$outf"
           return "$rc"
         }
 
-        if write_marker "$regionf"; then
+        write_marker "$regionf" && wm=0 || wm=$?
+        if [ "$wm" = 0 ]; then
           n=$(printf '%s' "$cur" | jq 'length')
-          echo "Epic #${EPIC}: wrote ${do} activation snapshot — ${n} member(s)." | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Epic #${EPIC}: ${do} activation snapshot in place — ${n} member(s)." | tee -a "$GITHUB_STEP_SUMMARY"
+        elif [ "$wm" = 2 ]; then
+          : # yielded deliberately; write_marker already said why
         else
           echo "::warning::Epic #${EPIC}: could not write the ${do} activation snapshot after 3 attempts; membership stays live-derived."
         fi

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -589,6 +589,7 @@ runs:
           local regionf="$1" bodyf outf attempt body marker err rc=1
           bodyf=$(mktemp); outf=$(mktemp)
           for attempt in 1 2 3; do
+            err=""   # or a later give-up reports an earlier attempt's error
             # Re-read every attempt, the first included.
             if ! body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
               [ "$attempt" -lt 3 ] && sleep 2
@@ -596,14 +597,22 @@ runs:
             fi
             marker=$(current_marker "$body")
 
-            # Already says what we were going to say — nothing to write, by us or anyone.
-            if same_marker "$marker" "$payload"; then
+            # Already says what we were going to say — nothing to write, by us or anyone. A `pending`
+            # marker whose `at` does not parse is NOT equivalent, however close its members look: the
+            # decision step routes exactly that case here to REPAIR it, because a timestamp that cannot
+            # be read can never age, so the marker would sit pending forever and the Epic would keep
+            # live membership with a success line in the log every sweep.
+            if same_marker "$marker" "$payload" \
+              && { [ "$(printf '%s' "$marker" | jq -r '.status // ""')" = "frozen" ] \
+                || printf '%s' "$marker" | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null 2>&1; }; then
               rc=0
               break
             fi
 
             # A frozen marker is terminal: it is the authority every reader has been using, and
             # rewriting it mid-landing is the one thing "frozen" forbids. Yield, whatever we intended.
+            # This narrows the window rather than closing it — a freeze landing between this check and
+            # the write below is still clobbered, and no conditional-update API exists to prevent that.
             if [ -n "$marker" ] && [ "$(printf '%s' "$marker" | jq -r '.status // ""')" = "frozen" ]; then
               echo "Epic #${EPIC}: the snapshot is already frozen (a peer got there first) — leaving it." \
                 | tee -a "$GITHUB_STEP_SUMMARY"
@@ -617,8 +626,10 @@ runs:
             # make a wrong set permanent. Abandon; the next pass decides on current truth.
             if [ "$do" = "frozen" ] \
               && ! jq -e -n --argjson m "${marker:-null}" --argjson cur "$cur" \
-                   '($m | type == "object") and $m.status == "pending" and ($m.members == $cur)' >/dev/null 2>&1; then
-              echo "::warning::Epic #${EPIC}: the member set moved while this pass was deciding — not freezing a stale set; the next pass re-derives."
+                   '($m | type == "object") and $m.status == "pending"
+                    and (($m.members // []) | sort_by(.repo, .number)) == $cur' >/dev/null 2>&1; then
+              echo "::warning::Epic #${EPIC}: the member set moved while this pass was deciding — not freezing a stale set; the next pass re-derives." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
               rc=2
               break
             fi

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -544,19 +544,63 @@ runs:
           fi
         }
 
-        bodyf=$(mktemp); regionf=$(mktemp); outf=$(mktemp)
-        printf '%s' "$body" > "$bodyf"
+        # Write under a read-modify-verify loop. The reconcile sweep runs this gate as a matrix over
+        # every open member pull request with no concurrency bound, and the read-model renderer edits
+        # the same body from another job, so several writers overlap by design. GitHub's issues API has
+        # no conditional update — a GET returns an ETag but PATCH accepts no If-Match — so the closest
+        # available guarantee is: splice into a body read moments ago, then confirm the write survived.
+        # A losing writer retries against whatever landed instead of overwriting it.
+        regionf=$(mktemp)
         {
           echo "$START"
           echo "$note"
           printf '%s\n' "$payload"
           echo "$END"
         } > "$regionf"
-        splice "$bodyf" "$regionf" > "$outf"
 
-        if gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" >/dev/null; then
+        # Read-modify-VERIFY, as a function so the test harness can extract and drive it against a
+        # stubbed gh. The sweep runs this gate as a matrix over every open member pull request with no
+        # concurrency bound, and the read-model renderer edits the same body from another job, so
+        # writers overlap by design. GitHub's issues API offers no conditional update — a GET returns an
+        # ETag, PATCH accepts no If-Match — so the closest available guarantee is to splice into a body
+        # read moments ago and then confirm the write survived, retrying against whatever landed.
+        write_marker() { # $1 = region file. 0 = the marker is in place, 1 = give up (caller warns)
+          local regionf="$1" bodyf outf attempt body rc=1
+          bodyf=$(mktemp); outf=$(mktemp)
+          for attempt in 1 2 3; do
+            # Re-read every attempt, the first included: `body` was fetched before the decision was
+            # computed, and a sibling job may have written since.
+            if ! body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
+              [ "$attempt" -lt 3 ] && sleep 2
+              continue
+            fi
+            # A marker that turned FROZEN under us is another writer's promotion, not a conflict to
+            # win: frozen is terminal, so leave it rather than reset it to pending.
+            if [ "$do" != "frozen" ] && printf '%s\n' "$body" \
+              | awk -v s="$START" -v e="$END" '$0 == s {f=1;next} $0 == e {f=0} f' \
+              | sed -n '/^[[:space:]]*[{[]/,$p' | jq -e 'select(.status == "frozen")' >/dev/null 2>&1; then
+              echo "Epic #${EPIC}: another writer froze the snapshot first — leaving it." | tee -a "$GITHUB_STEP_SUMMARY"
+              rc=0
+              break
+            fi
+            printf '%s' "$body" > "$bodyf"
+            splice "$bodyf" "$regionf" > "$outf"
+            gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" >/dev/null 2>&1 || true
+            # Verify rather than trust the exit code: a concurrent write can land after ours and undo it.
+            if gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r' \
+              | grep -qxF -- "$payload"; then
+              rc=0
+              break
+            fi
+            [ "$attempt" -lt 3 ] && sleep 2
+          done
+          rm -f "$bodyf" "$outf"
+          return "$rc"
+        }
+
+        if write_marker "$regionf"; then
           n=$(printf '%s' "$cur" | jq 'length')
           echo "Epic #${EPIC}: wrote ${do} activation snapshot — ${n} member(s)." | tee -a "$GITHUB_STEP_SUMMARY"
         else
-          echo "::warning::Epic #${EPIC}: could not write the ${do} activation snapshot; membership stays live-derived."
+          echo "::warning::Epic #${EPIC}: could not write the ${do} activation snapshot after 3 attempts; membership stays live-derived."
         fi

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -599,7 +599,6 @@ runs:
           local regionf="$1" bodyf outf attempt body marker err rc=1
           bodyf=$(mktemp); outf=$(mktemp)
           for attempt in 1 2 3; do
-            err=""   # or a later give-up reports an earlier attempt's error
             # Re-read every attempt, the first included.
             if ! body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
               # Record it: a read failure has no diagnostic of its own, and clearing `err` each attempt

--- a/generic-actions/render-epic-status/action.yaml
+++ b/generic-actions/render-epic-status/action.yaml
@@ -437,6 +437,21 @@ runs:
             return 0
           fi
 
+          # Splice into a FRESHLY read body, not the one fetched at the top of this pass. Everything
+          # between those two points — the member searches, the tag walks, the compares — takes seconds
+          # to tens of seconds, and merge-gate writes the activation snapshot into this same body from
+          # a matrix of concurrent jobs. Rewriting the stale copy would carry the whole body back,
+          # erasing a frozen member set with a cosmetic table. A re-read costs one API call and leaves
+          # only same-region collisions, which for this display-only writer are self-correcting.
+          local fresh
+          if fresh=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${epic}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
+            body="$fresh"
+          else
+            echo "::warning::could not re-read Epic ${ORG}/${PLANNING_REPO}#${epic} before writing — skipping this pass rather than writing a stale body." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            return 0
+          fi
+
           local region_file body_file spliced_file
           region_file=$(mktemp); body_file=$(mktemp); spliced_file=$(mktemp)
           {

--- a/generic-actions/render-epic-status/action.yaml
+++ b/generic-actions/render-epic-status/action.yaml
@@ -416,6 +416,21 @@ runs:
           region_inner=$(printf '### Epic status — display-only, derived from live GitHub truth (not authority)\n\n_Rendered %s UTC by the reconcile sweep. A lost or hand-edited table is cosmetic — every decision reads live state._\n\n%s\n\n| Repo | PR | State | SHA | Released |\n|------|----|-------|-----|----------|\n%s' \
             "$ts" "$counts" "$rows")
 
+          # Re-read before deciding anything. The body fetched at the top of this pass is stale by now:
+          # the member searches, tag walks and compares between here and there take seconds to tens of
+          # seconds, and merge-gate writes the activation snapshot into this same body from a matrix of
+          # concurrent jobs. Rewriting the stale copy would carry the whole body back and erase a frozen
+          # member set with a cosmetic table. It has to happen BEFORE the compare too, or the compare
+          # answers about a body nobody is going to write.
+          local fresh
+          if fresh=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${epic}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
+            body="$fresh"
+          else
+            echo "::warning::could not re-read Epic ${ORG}/${PLANNING_REPO}#${epic} — skipping this pass rather than deciding on a stale body." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            return 0
+          fi
+
           # Compare-before-write: material content already in the body (region between markers, minus
           # the volatile stamp) vs. the fresh render. Equal → the table is current, so no edit and no
           # notification.
@@ -437,21 +452,9 @@ runs:
             return 0
           fi
 
-          # Splice into a FRESHLY read body, not the one fetched at the top of this pass. Everything
-          # between those two points — the member searches, the tag walks, the compares — takes seconds
-          # to tens of seconds, and merge-gate writes the activation snapshot into this same body from
-          # a matrix of concurrent jobs. Rewriting the stale copy would carry the whole body back,
-          # erasing a frozen member set with a cosmetic table. A re-read costs one API call and leaves
-          # only same-region collisions, which for this display-only writer are self-correcting.
-          local fresh
-          if fresh=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${epic}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
-            body="$fresh"
-          else
-            echo "::warning::could not re-read Epic ${ORG}/${PLANNING_REPO}#${epic} before writing — skipping this pass rather than writing a stale body." \
-              | tee -a "$GITHUB_STEP_SUMMARY"
-            return 0
-          fi
-
+          # A window remains between the re-read above and this write — narrow now, not closed. If a
+          # snapshot write lands inside it this table wins and the marker is lost; merge-gate's own
+          # verify-and-retry is what recovers that, not anything here.
           local region_file body_file spliced_file
           region_file=$(mktemp); body_file=$(mktemp); spliced_file=$(mktemp)
           {

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -82,21 +82,34 @@ gh() {
 
 M1='[{"repo":"a-novel-kit/repo-a","number":1}]'
 M2='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-b","number":2}]'
+# Same size as M2, different members: without this, every "members differ" case also differs in
+# COUNT, and comparing lengths would be indistinguishable from comparing sets.
+M2B='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-c","number":3}]'
 
 pending_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --argjson m "$1" '{status:"pending", at:$at, members:$m}'; }
 frozen_json() { jq -cn --argjson m "$1" '{status:"frozen", members:$m}'; }
 
-region_file() { # $1 = payload json -> a region file built exactly as the action builds it
-  local f
+# The note the action actually writes, read OUT OF THE MANIFEST. Restating it here is how a fixture
+# comes to encode a belief instead of the format: a note that ever began with `[` or `{` would make
+# current_marker latch onto it and read every marker as absent, and a paraphrase could never show it.
+note_of() { # frozen|pending
+  local key=FROZEN
+  [ "$1" = frozen ] || key=PENDING
+  sed -n "s/^ *note=\"\(_Epic membership, $key.*\)\"$/\1/p" "$ACTION" | head -1
+}
+region_file() { # $1 = payload json, $2 = frozen|pending -> the region exactly as the action builds it
+  local f note
+  note=$(note_of "${2:-pending}")
+  [ -n "$note" ] || { echo "::error::could not read the note text from $ACTION"; exit 1; }
   f=$(mktemp -p "$WORK")
-  { echo "$START"; echo "_Epic membership. Do not edit._"; printf '%s\n' "$1"; echo "$END"; } > "$f"
+  { echo "$START"; printf '%s\n' "$note"; printf '%s\n' "$1"; echo "$END"; } > "$f"
   printf '%s' "$f"
 }
 server_body() { # $1 = marker json, or empty for a body with no marker
   if [ -z "${1:-}" ]; then
     printf 'Some prose.\n\nMore prose.\n' > "$WORK/body"
   else
-    printf 'Some prose.\n\n%s\n_note_\n%s\n%s\n\nMore prose.\n' "$START" "$1" "$END" > "$WORK/body"
+    printf 'Some prose.\n\n%s\n%s\n%s\n%s\n\nMore prose.\n' "$START" "$(note_of pending)" "$1" "$END" > "$WORK/body"
   fi
 }
 marker_now() { current_marker "$(cat "$WORK/body")"; }
@@ -118,7 +131,7 @@ reset() {
 }
 # Capture the function's own output so it cannot be mistaken for the exit code, and so both tee'd
 # and plain log lines can be asserted from one place.
-run() { write_marker "$(region_file "$payload")" > "$WORK/out" 2>&1 && echo 0 || echo $?; }
+run() { write_marker "$(region_file "$payload" "$do")" > "$WORK/out" 2>&1 && echo 0 || echo $?; }
 said() { grep -q "$1" "$WORK/out"; }
 
 echo "the ordinary write"
@@ -233,7 +246,7 @@ echo "splice, on its own"
 # splice defect therefore reads as a green suite unless it is exercised on its own.
 sp() { # $1 = body text, $2 = payload -> the spliced result
   local b r
-  b=$(mktemp -p "$WORK"); r=$(region_file "$2")
+  b=$(mktemp -p "$WORK"); r=$(region_file "$2" frozen)
   printf '%s\n' "$1" > "$b"
   splice "$b" "$r"
 }
@@ -263,6 +276,43 @@ out=$(sp "$(printf '%s\nstray end first\n%s\n' "$END" "$START")" "$P")
 one_region "$out" && ok "inverted fences are healed to one region" || ko "inverted fences survived"
 
 echo
+echo "same status, different members of the same size"
+# Without this, every members-differ case also differs in COUNT, so comparing lengths would pass for
+# comparing sets — in both the equivalence check and the re-derive guard.
+reset
+server_body "$(pending_json "$M2B" 2026-07-22T09:00:00Z)"
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
+eq "an equal-size but different set is corrected" "$(run)" 0
+eq "which takes a write" "$(writes)" 1
+eq "and our members are what stand" "$(marker_now | jq -c '.members')" "$M2"
+reset
+server_body "$(pending_json "$M2B" 2026-07-22T09:00:00Z)"
+do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
+eq "and a freeze against an equal-size peer set abandons" "$(run)" 2
+eq "writing nothing" "$(writes)" 0
+
+echo
+echo "a region holding more than one value"
+# jq -s '.[0]' takes the first. If a hand-edit leaves two, the first wins — including an empty frozen
+# set, which would pin the Epic to no members at all.
+reset
+# BOTH values sit inside the fences — that is what makes "first" meaningful.
+printf 'prose\n%s\n%s\n%s\n%s\n%s\n' "$START" "$(note_of pending)" \
+  "$(pending_json "$M1")" "$(jq -cn '{status:"frozen",members:[]}')" "$END" > "$WORK/body"
+eq "the first value in the region is the one read" "$(marker_now | jq -r '.status')" pending
+eq "not the last" "$(marker_now | jq -r '.members | length')" 1
+
+echo
+
+echo
+echo "a failing edit"
+reset
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
+printf 'x' > "$WORK/edit_fails"
+eq "an edit that errors is retried, then given up on" "$(run)" 1
+eq "after three attempts" "$(writes)" 3
+said 'last write error' && ok "and the API error is surfaced, not swallowed" || ko "the edit error was discarded"
+
 echo
 echo "read failures"
 reset
@@ -271,8 +321,12 @@ printf 2 > "$WORK/read_fails"
 eq "two failed reads still converge on the third attempt" "$(run)" 0
 reset
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
+printf 'Important human prose.\n\nA hand-written plan.\n' > "$WORK/body"
 printf 99 > "$WORK/read_fails"
 eq "a total read failure gives up rather than claiming success" "$(run)" 1
+eq "and writes nothing at all" "$(writes)" 0
+grep -q 'A hand-written plan' "$WORK/body" \
+  && ok "leaving the Epic body untouched" || ko "the body was written blind after a failed read"
 
 echo
 printf '%d passed, %d failed\n' "$pass" "$fail"
@@ -281,7 +335,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -lt 39 ]; then
-  echo "::error::only $ran assertion(s) ran (expected at least 39) — the suite did not execute fully"
+if [ "$ran" -ne 52 ]; then
+  echo "::error::$ran assertion(s) ran, expected exactly 52 — the suite did not execute fully (or an assertion was added without raising this)"
   exit 1
 fi

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -202,6 +202,31 @@ do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
 eq "a write that never landed is not masked by the orphan" "$(run)" 1
 eq "and the region still says what it did" "$(marker_now | jq -r .status)" pending
 
+echo "a marker that cannot age must be repaired, not accepted"
+# The decision step routes a corrupt or missing `at` here on purpose: a timestamp that cannot be read
+# can never age, so the marker would sit pending forever and the Epic would keep live membership —
+# with a success line every sweep. An equivalence test that ignores `at` must not swallow that.
+for bad in '"not-a-date"' 'null'; do
+  reset
+  server_body "$(jq -cn --argjson m "$M2" --argjson at "$bad" '{status:"pending", at:$at, members:$m}')"
+  do=pending; cur="$M2"; payload=$(pending_json "$M2")
+  eq "an unreadable at ($bad) is rewritten" "$(run)" 0
+  eq "which takes exactly one write" "$(writes)" 1
+  marker_now | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null \
+    && ok "and the marker can age again" || ko "the marker still cannot age"
+done
+
+echo
+echo "member order is not a reason to abandon"
+# The decision step compares members sorted; the re-derive guard must too, or a marker the decision
+# calls stable is judged moved and the freeze is refused on every sweep forever.
+reset
+server_body "$(jq -cn --argjson m "$M2" '{status:"pending", at:"2026-07-22T09:00:00Z", members:($m | reverse)}')"
+do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
+eq "a reordered member array still freezes" "$(run)" 0
+eq "and the marker is frozen" "$(marker_now | jq -r .status)" frozen
+
+echo
 echo "splice, on its own"
 # Driven directly, because the retry loop hides it: a broken splice writes a body with no fences, the
 # next attempt takes the fallback branch, appends a correct region, and the verify passes. Every
@@ -256,7 +281,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -lt 31 ]; then
-  echo "::error::only $ran assertion(s) ran (expected at least 31) — the suite did not execute fully"
+if [ "$ran" -lt 39 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 39) — the suite did not execute fully"
   exit 1
 fi

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -27,7 +27,7 @@ extract() { # $1 = function name — lift it out of the run: block and de-indent
     f && /^        \}$/ {exit}
   ' "$ACTION" | sed 's/^        //'
 }
-for fn in splice current_marker same_marker write_marker; do
+for fn in splice current_marker same_marker marker_settled write_marker; do
   out=$(extract "$fn")
   if [ -z "$out" ]; then
     echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
@@ -41,6 +41,9 @@ if ! bash -n "$WORK/lib.sh"; then
 fi
 
 export ORG=a-novel-kit PLANNING_REPO=.github EPIC=900
+# The re-derive guard re-checks AGE, so the harness must supply the same clock the step does.
+export STABILIZE_SECONDS=120
+now=2026-07-22T10:00:00Z
 export GITHUB_STEP_SUMMARY="$WORK/summary.md"
 START='<!-- epic-membership:snapshot:start -->'
 END='<!-- epic-membership:snapshot:end -->'
@@ -72,6 +75,9 @@ gh() {
       printf 'x' >> "$WORK/writes"
       # A write that silently does not land — the API returned success but the body is unchanged.
       [ -s "$WORK/noop" ] || cp "$f" "$WORK/body"
+      # Real `gh issue edit` prints the issue URL on success. Without it, capturing the command's
+      # stdout into the error variable is invisible.
+      echo "https://github.com/${ORG}/${PLANNING_REPO}/issues/${EPIC}"
       # File-backed for the same reason as read_fails: the write runs inside $( ), so clearing a
       # shell variable here would never reach the parent and the peer would strike on every attempt.
       if [ -s "$WORK/steal" ]; then cp "$WORK/steal" "$WORK/body"; : > "$WORK/steal"; fi
@@ -209,7 +215,8 @@ orphan=$(frozen_json "$M2")
 # The body carries our exact payload as loose prose (what splice's recovery path leaves behind) plus
 # a region saying something else. The write does not land, so a correct verify must fail — a
 # whole-body grep would match the orphan and report success.
-printf 'Some prose.\n%s\n\n%s\n_note_\n%s\n%s\n' "$orphan" "$START" "$(pending_json "$M2")" "$END" > "$WORK/body"
+printf 'Some prose.\n%s\n\n%s\n%s\n%s\n%s\n' "$orphan" "$START" "$(note_of pending)" \
+  "$(pending_json "$M2" 2026-07-22T09:00:00Z)" "$END" > "$WORK/body"
 printf 'x' > "$WORK/noop"
 do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
 eq "a write that never landed is not masked by the orphan" "$(run)" 1
@@ -228,6 +235,18 @@ for bad in '"not-a-date"' 'null'; do
   marker_now | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null \
     && ok "and the marker can age again" || ko "the marker still cannot age"
 done
+
+echo
+echo "a freeze must not skip the stabilization window"
+# The decision step only says `frozen` once the marker has held still past STABILIZE_SECONDS. If the
+# guard does not re-check age, a peer's clock reset can be overtaken seconds later — freezing before
+# the lagging label index has had its window to surface a missing member.
+reset
+server_body "$(pending_json "$M2" 2026-07-22T09:59:30Z)"   # 30s old, threshold is 120s
+do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
+eq "a freeze against a freshly reset clock abandons" "$(run)" 2
+eq "writing nothing" "$(writes)" 0
+eq "and the marker stays pending" "$(marker_now | jq -r .status)" pending
 
 echo
 echo "member order is not a reason to abandon"
@@ -304,6 +323,29 @@ eq "not the last" "$(marker_now | jq -r '.members | length')" 1
 
 echo
 
+echo "a clobbered repair is retried, not reported as done"
+# The entry check knows an unreadable `at` is not equivalent; the VERIFY must know it too. If it
+# falls back to a plain equivalence test, a repair that a peer immediately undid reads as landed —
+# the marker never ages, and the log says success.
+reset
+bad=$(jq -cn --argjson m "$M2" '{status:"pending", at:"not-a-date", members:$m}')
+server_body "$bad"
+printf 'Some prose.\n\n%s\n%s\n%s\n%s\n\nMore prose.\n' "$START" "$(note_of pending)" "$bad" "$END" > "$WORK/steal"
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
+eq "the repair is retried until it sticks" "$(run)" 0
+eq "which takes two writes" "$(writes)" 2
+marker_now | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null \
+  && ok "and the marker can age at the end of it" || ko "the marker still cannot age"
+
+echo
+echo "a give-up message carries the error, not the success output"
+reset
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
+printf 'x' > "$WORK/noop"          # every edit returns success but changes nothing
+eq "an unlandable write gives up" "$(run)" 1
+said 'https://' && ko "the edit's success output was captured as an error" \
+  || ok "the success URL is not mistaken for an error"
+
 echo
 echo "a failing edit"
 reset
@@ -335,7 +377,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -ne 52 ]; then
-  echo "::error::$ran assertion(s) ran, expected exactly 52 — the suite did not execute fully (or an assertion was added without raising this)"
+if [ "$ran" -ne 60 ]; then
+  echo "::error::$ran assertion(s) ran, expected exactly 60 — the suite did not execute fully (or an assertion was added without raising this)"
   exit 1
 fi

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Regression tests for merge-gate's activation-snapshot write path.
+#
+# Same approach as tests/detect-partial-landing.sh: the functions under test are EXTRACTED verbatim
+# from the action manifest and sourced, so the shipped code is what runs here. Only `gh` is stubbed.
+#
+# What this covers is the lost-update race. The reconcile sweep runs merge-gate as a matrix over
+# every open member pull request with no concurrency bound, and render-epic-status edits the same
+# issue body from a job that does not wait for it — so several writers overlap by design, against an
+# API with no conditional update. The guard is read-modify-verify, and its failure modes (a writer
+# undoing a peer's frozen marker, or reporting success on a write that was reverted) are the kind
+# that reasoning alone gets wrong.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION="${1:-$ROOT/generic-actions/merge-gate/action.yaml}"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+extract() { # $1 = function name — lift it out of the run: block and de-indent
+  awk -v n="$1" '
+    $0 ~ "^        "n"\\(\\) \\{" {f=1}
+    f {print}
+    f && /^        \}$/ {exit}
+  ' "$ACTION" | sed 's/^        //'
+}
+for fn in splice write_marker; do
+  out=$(extract "$fn")
+  if [ -z "$out" ]; then
+    echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
+    exit 1
+  fi
+  printf '%s\n' "$out" >> "$WORK/lib.sh"
+done
+if ! bash -n "$WORK/lib.sh"; then
+  echo "::error::extracted functions do not parse — extraction truncated a definition"
+  exit 1
+fi
+
+export ORG=a-novel-kit PLANNING_REPO=.github EPIC=900
+export GITHUB_STEP_SUMMARY="$WORK/summary.md"
+START='<!-- epic-membership:snapshot:start -->'
+END='<!-- epic-membership:snapshot:end -->'
+sleep() { :; }
+
+# ---- the stubbed body store ---------------------------------------------------------------
+# BODY_FILE is the "issue body" on the server. FX_STEAL, when set, simulates a concurrent writer
+# that lands immediately AFTER our edit, on the given attempt — the case an exit-code check misses.
+gh() {
+  case "$*" in
+    *"issues/${EPIC}"*)
+      # File-backed: reads happen inside $( ), so a shell-variable countdown would never reach the
+      # parent and every read would keep failing.
+      if [ "$(< "$WORK/read_fails")" -gt 0 ]; then
+        printf '%s' "$(($(< "$WORK/read_fails") - 1))" > "$WORK/read_fails"
+        return 1
+      fi
+      cat "$WORK/body"
+      ;;
+    *"issue edit"*)
+      # NOTE: ${*##pattern} strips per-positional-parameter and rejoins — join first, then strip.
+      local all="$*" f
+      f="${all##*--body-file }"; f="${f%% *}"
+      cp "$f" "$WORK/body"
+      # A peer write landing after ours, exactly once, on the nominated attempt.
+      if [ -n "$FX_STEAL" ]; then
+        printf '%s\n' "$FX_STEAL" > "$WORK/body"
+        FX_STEAL=""
+      fi
+      ;;
+    *) echo "unexpected gh call: $*" >&2; return 1 ;;
+  esac
+}
+
+region() { # status members-json -> a region file, exactly as the action builds it
+  local payload note f
+  if [ "$1" = frozen ]; then
+    payload=$(jq -cn --argjson m "$2" '{status:"frozen", members:$m}')
+    note='_Epic membership, FROZEN at activation by the merge-gate. Do not edit._'
+  else
+    payload=$(jq -cn --arg s "$1" --argjson m "$2" '{status:$s, at:"2026-07-22T10:00:00Z", members:$m}')
+    note='_Epic membership, PENDING — stabilizing before it freezes. Do not edit._'
+  fi
+  f=$(mktemp)
+  { echo "$START"; echo "$note"; printf '%s\n' "$payload"; echo "$END"; } > "$f"
+  printf '%s' "$f"
+}
+body_with() { # a server body already carrying a marker
+  printf 'Some prose.\n\n%s\n_note_\n%s\n%s\n\nMore prose.\n' "$START" "$1" "$END" > "$WORK/body"
+}
+marker_now() { # what the marker on the server says
+  awk -v s="$START" -v e="$END" '$0==s{f=1;next} $0==e{f=0} f' "$WORK/body" \
+    | sed -n '/^[[:space:]]*[{[]/,$p' | jq -c '.' 2>/dev/null
+}
+
+M2='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-b","number":2}]'
+M1='[{"repo":"a-novel-kit/repo-a","number":1}]'
+
+# shellcheck disable=SC1091
+. "$WORK/lib.sh"
+
+pass=0
+fail=0
+ok() { printf '  ✓ %s\n' "$1"; pass=$((pass + 1)); }
+ko() { printf '  ✗ %s\n' "$1"; fail=$((fail + 1)); }
+
+reset() { printf 0 > "$WORK/read_fails"; FX_STEAL=""; printf 'Some prose.\n\nMore prose.\n' > "$WORK/body"; : > "$GITHUB_STEP_SUMMARY"; }
+
+echo "the ordinary write"
+reset
+do=pending; payload=$(jq -cn --arg at "2026-07-22T10:00:00Z" --argjson m "$M2" '{status:"pending", at:$at, members:$m}')
+write_marker "$(region pending "$M2")" && ok "a pending marker is written" || ko "the write failed"
+[ "$(marker_now | jq -r .status)" = pending ] && ok "and the server carries it" || ko "server body has no pending marker"
+grep -q 'Some prose' "$WORK/body" && ok "human prose either side is preserved" || ko "prose was dropped"
+
+echo
+echo "a peer that writes after us"
+# The edit succeeds, then a concurrent writer overwrites it. An exit-code check would call this a win.
+reset
+body_with "$(jq -cn --argjson m "$M2" '{status:"pending", at:"2026-07-22T09:00:00Z", members:$m}')"
+do=frozen; payload=$(jq -cn --argjson m "$M2" '{status:"frozen", members:$m}')
+FX_STEAL=$(printf 'Some prose.\n\n%s\n_note_\n%s\n%s\n' "$START" "$(jq -cn --argjson m "$M1" '{status:"pending", at:"2026-07-22T09:30:00Z", members:$m}')" "$END")
+write_marker "$(region frozen "$M2")" && ok "the write is retried until it survives" || ko "gave up despite a retry being available"
+[ "$(marker_now | jq -r .status)" = frozen ] && ok "and frozen is what finally stands" || ko "the peer's write won"
+
+echo
+echo "frozen is terminal — a pending writer must not undo it"
+reset
+body_with "$(jq -cn --argjson m "$M2" '{status:"frozen", members:$m}')"
+do=pending; payload=$(jq -cn --arg at "2026-07-22T10:00:00Z" --argjson m "$M1" '{status:"pending", at:$at, members:$m}')
+write_marker "$(region pending "$M1")" && ok "the pending writer reports success" || ko "it failed instead of yielding"
+[ "$(marker_now | jq -r .status)" = frozen ] && ok "and the frozen marker is left intact" || ko "a pending write clobbered frozen"
+[ "$(marker_now | jq -r '.members | length')" = 2 ] && ok "with its member set untouched" || ko "the frozen member set changed"
+grep -q 'another writer froze the snapshot first' "$GITHUB_STEP_SUMMARY" \
+  && ok "and it says so in the run log" || ko "the yield is silent"
+
+echo
+echo "a frozen writer may still write frozen"
+reset
+body_with "$(jq -cn --argjson m "$M2" '{status:"frozen", members:$m}')"
+do=frozen; payload=$(jq -cn --argjson m "$M2" '{status:"frozen", members:$m}')
+write_marker "$(region frozen "$M2")" && ok "an idempotent re-write succeeds" || ko "it refused its own value"
+
+echo
+echo "read failures"
+reset
+do=pending; payload=$(jq -cn --arg at "2026-07-22T10:00:00Z" --argjson m "$M2" '{status:"pending", at:$at, members:$m}')
+printf 2 > "$WORK/read_fails"
+write_marker "$(region pending "$M2")" && ok "two failed reads still converge on the third attempt" || ko "gave up too early"
+reset
+printf 99 > "$WORK/read_fails"
+do=pending; payload=$(jq -cn --arg at "2026-07-22T10:00:00Z" --argjson m "$M2" '{status:"pending", at:$at, members:$m}')
+write_marker "$(region pending "$M2")" && ko "reported success with every read failing" || ok "a total read failure gives up rather than claiming success"
+
+echo
+printf '%d passed, %d failed\n' "$pass" "$fail"
+ran=$((pass + fail))
+if [ "$fail" -gt 0 ]; then
+  echo "::error::$fail assertion(s) failed"
+  exit 1
+fi
+if [ "$ran" -lt 12 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 12) — the suite did not execute fully"
+  exit 1
+fi

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -6,10 +6,13 @@
 #
 # What this covers is the lost-update race. The reconcile sweep runs merge-gate as a matrix over
 # every open member pull request with no concurrency bound, and render-epic-status edits the same
-# issue body from a job that does not wait for it — so several writers overlap by design, against an
-# API with no conditional update. The guard is read-modify-verify, and its failure modes (a writer
-# undoing a peer's frozen marker, or reporting success on a write that was reverted) are the kind
-# that reasoning alone gets wrong.
+# issue body from a job that does not wait for it — so writers overlap by design, against an API with
+# no conditional update.
+#
+# The subtle half is not the write, it is the DECISION. `$do` and `$payload` are computed from a body
+# read before the loop; a writer that re-reads but does not re-derive will freeze a member set the
+# world has already moved past, and a retry loop makes it win. Several cases below exist only to pin
+# that: a writer must abandon rather than make a stale freeze permanent.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -24,7 +27,7 @@ extract() { # $1 = function name — lift it out of the run: block and de-indent
     f && /^        \}$/ {exit}
   ' "$ACTION" | sed 's/^        //'
 }
-for fn in splice write_marker; do
+for fn in splice current_marker same_marker write_marker; do
   out=$(extract "$fn")
   if [ -z "$out" ]; then
     echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
@@ -44,13 +47,12 @@ END='<!-- epic-membership:snapshot:end -->'
 sleep() { :; }
 
 # ---- the stubbed body store ---------------------------------------------------------------
-# BODY_FILE is the "issue body" on the server. FX_STEAL, when set, simulates a concurrent writer
-# that lands immediately AFTER our edit, on the given attempt — the case an exit-code check misses.
+# $WORK/body is the issue body on the server. $WORK/steal, when non-empty, is a peer write that lands
+# immediately AFTER ours, once — the case an exit-code check calls a win.
 gh() {
   case "$*" in
     *"issues/${EPIC}"*)
-      # File-backed: reads happen inside $( ), so a shell-variable countdown would never reach the
-      # parent and every read would keep failing.
+      # File-backed: reads run inside $( ), so a shell-variable countdown would never reach the parent.
       if [ "$(< "$WORK/read_fails")" -gt 0 ]; then
         printf '%s' "$(($(< "$WORK/read_fails") - 1))" > "$WORK/read_fails"
         return 1
@@ -61,40 +63,38 @@ gh() {
       # NOTE: ${*##pattern} strips per-positional-parameter and rejoins — join first, then strip.
       local all="$*" f
       f="${all##*--body-file }"; f="${f%% *}"
-      cp "$f" "$WORK/body"
-      # A peer write landing after ours, exactly once, on the nominated attempt.
-      if [ -n "$FX_STEAL" ]; then
-        printf '%s\n' "$FX_STEAL" > "$WORK/body"
-        FX_STEAL=""
-      fi
+      printf 'x' >> "$WORK/writes"
+      # A write that silently does not land — the API returned success but the body is unchanged.
+      [ -s "$WORK/noop" ] || cp "$f" "$WORK/body"
+      # File-backed for the same reason as read_fails: the write runs inside $( ), so clearing a
+      # shell variable here would never reach the parent and the peer would strike on every attempt.
+      if [ -s "$WORK/steal" ]; then cp "$WORK/steal" "$WORK/body"; : > "$WORK/steal"; fi
       ;;
     *) echo "unexpected gh call: $*" >&2; return 1 ;;
   esac
 }
 
-region() { # status members-json -> a region file, exactly as the action builds it
-  local payload note f
-  if [ "$1" = frozen ]; then
-    payload=$(jq -cn --argjson m "$2" '{status:"frozen", members:$m}')
-    note='_Epic membership, FROZEN at activation by the merge-gate. Do not edit._'
-  else
-    payload=$(jq -cn --arg s "$1" --argjson m "$2" '{status:$s, at:"2026-07-22T10:00:00Z", members:$m}')
-    note='_Epic membership, PENDING — stabilizing before it freezes. Do not edit._'
-  fi
-  f=$(mktemp)
-  { echo "$START"; echo "$note"; printf '%s\n' "$payload"; echo "$END"; } > "$f"
+M1='[{"repo":"a-novel-kit/repo-a","number":1}]'
+M2='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-b","number":2}]'
+
+pending_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --argjson m "$1" '{status:"pending", at:$at, members:$m}'; }
+frozen_json() { jq -cn --argjson m "$1" '{status:"frozen", members:$m}'; }
+
+region_file() { # $1 = payload json -> a region file built exactly as the action builds it
+  local f
+  f=$(mktemp -p "$WORK")
+  { echo "$START"; echo "_Epic membership. Do not edit._"; printf '%s\n' "$1"; echo "$END"; } > "$f"
   printf '%s' "$f"
 }
-body_with() { # a server body already carrying a marker
-  printf 'Some prose.\n\n%s\n_note_\n%s\n%s\n\nMore prose.\n' "$START" "$1" "$END" > "$WORK/body"
+server_body() { # $1 = marker json, or empty for a body with no marker
+  if [ -z "${1:-}" ]; then
+    printf 'Some prose.\n\nMore prose.\n' > "$WORK/body"
+  else
+    printf 'Some prose.\n\n%s\n_note_\n%s\n%s\n\nMore prose.\n' "$START" "$1" "$END" > "$WORK/body"
+  fi
 }
-marker_now() { # what the marker on the server says
-  awk -v s="$START" -v e="$END" '$0==s{f=1;next} $0==e{f=0} f' "$WORK/body" \
-    | sed -n '/^[[:space:]]*[{[]/,$p' | jq -c '.' 2>/dev/null
-}
-
-M2='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-b","number":2}]'
-M1='[{"repo":"a-novel-kit/repo-a","number":1}]'
+marker_now() { current_marker "$(cat "$WORK/body")"; }
+writes() { wc -c < "$WORK/writes" | tr -d ' '; }
 
 # shellcheck disable=SC1091
 . "$WORK/lib.sh"
@@ -103,54 +103,105 @@ pass=0
 fail=0
 ok() { printf '  ✓ %s\n' "$1"; pass=$((pass + 1)); }
 ko() { printf '  ✗ %s\n' "$1"; fail=$((fail + 1)); }
+eq() { [ "$2" = "$3" ] && ok "$1" || ko "$1 (got '$2', want '$3')"; }
 
-reset() { printf 0 > "$WORK/read_fails"; FX_STEAL=""; printf 'Some prose.\n\nMore prose.\n' > "$WORK/body"; : > "$GITHUB_STEP_SUMMARY"; }
+reset() {
+  printf 0 > "$WORK/read_fails"; : > "$WORK/writes"; : > "$WORK/steal"; : > "$WORK/noop"
+  : > "$GITHUB_STEP_SUMMARY"; server_body ""
+}
+# Capture the function's own output so it cannot be mistaken for the exit code, and so both tee'd
+# and plain log lines can be asserted from one place.
+run() { write_marker "$(region_file "$payload")" > "$WORK/out" 2>&1 && echo 0 || echo $?; }
+said() { grep -q "$1" "$WORK/out"; }
 
 echo "the ordinary write"
 reset
-do=pending; payload=$(jq -cn --arg at "2026-07-22T10:00:00Z" --argjson m "$M2" '{status:"pending", at:$at, members:$m}')
-write_marker "$(region pending "$M2")" && ok "a pending marker is written" || ko "the write failed"
-[ "$(marker_now | jq -r .status)" = pending ] && ok "and the server carries it" || ko "server body has no pending marker"
-grep -q 'Some prose' "$WORK/body" && ok "human prose either side is preserved" || ko "prose was dropped"
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
+eq "a fresh pending marker is written" "$(run)" 0
+eq "and the server carries it" "$(marker_now | jq -r .status)" pending
+grep -q 'Some prose' "$WORK/body" && ok "human prose either side survives" || ko "prose was dropped"
 
 echo
 echo "a peer that writes after us"
-# The edit succeeds, then a concurrent writer overwrites it. An exit-code check would call this a win.
 reset
-body_with "$(jq -cn --argjson m "$M2" '{status:"pending", at:"2026-07-22T09:00:00Z", members:$m}')"
-do=frozen; payload=$(jq -cn --argjson m "$M2" '{status:"frozen", members:$m}')
-FX_STEAL=$(printf 'Some prose.\n\n%s\n_note_\n%s\n%s\n' "$START" "$(jq -cn --argjson m "$M1" '{status:"pending", at:"2026-07-22T09:30:00Z", members:$m}')" "$END")
-write_marker "$(region frozen "$M2")" && ok "the write is retried until it survives" || ko "gave up despite a retry being available"
-[ "$(marker_now | jq -r .status)" = frozen ] && ok "and frozen is what finally stands" || ko "the peer's write won"
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
+# The peer reverts the body, discarding our write. Nothing about that invalidates a pending decision,
+# so we should notice and retry rather than trust the edit's exit code.
+printf 'Some prose.\n\nMore prose.\n' > "$WORK/steal"
+eq "we retry until our write survives" "$(run)" 0
+eq "and our marker is what finally stands" "$(marker_now | jq -r '.members | length')" 2
+eq "which took two writes, not one" "$(writes)" 2
 
 echo
-echo "frozen is terminal — a pending writer must not undo it"
+echo "a wiped marker invalidates a freeze in flight"
+# A freeze means "the set held still since this pending marker". If the marker is gone, that premise
+# cannot be re-established, so the pass abandons rather than freezing on faith.
 reset
-body_with "$(jq -cn --argjson m "$M2" '{status:"frozen", members:$m}')"
-do=pending; payload=$(jq -cn --arg at "2026-07-22T10:00:00Z" --argjson m "$M1" '{status:"pending", at:$at, members:$m}')
-write_marker "$(region pending "$M1")" && ok "the pending writer reports success" || ko "it failed instead of yielding"
-[ "$(marker_now | jq -r .status)" = frozen ] && ok "and the frozen marker is left intact" || ko "a pending write clobbered frozen"
-[ "$(marker_now | jq -r '.members | length')" = 2 ] && ok "with its member set untouched" || ko "the frozen member set changed"
-grep -q 'another writer froze the snapshot first' "$GITHUB_STEP_SUMMARY" \
-  && ok "and it says so in the run log" || ko "the yield is silent"
+server_body "$(pending_json "$M2" 2026-07-22T09:00:00Z)"
+do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
+printf 'Some prose.\n\nMore prose.\n' > "$WORK/steal"
+eq "the freeze is abandoned once its pending basis disappears" "$(run)" 2
 
 echo
-echo "a frozen writer may still write frozen"
+echo "frozen is terminal"
 reset
-body_with "$(jq -cn --argjson m "$M2" '{status:"frozen", members:$m}')"
-do=frozen; payload=$(jq -cn --argjson m "$M2" '{status:"frozen", members:$m}')
-write_marker "$(region frozen "$M2")" && ok "an idempotent re-write succeeds" || ko "it refused its own value"
+server_body "$(frozen_json "$M2")"
+do=pending; cur="$M1"; payload=$(pending_json "$M1")
+eq "a pending writer yields rather than resetting it" "$(run)" 2
+eq "the frozen marker is left intact" "$(marker_now | jq -r .status)" frozen
+eq "with its member set untouched" "$(marker_now | jq -r '.members | length')" 2
+eq "and nothing was written" "$(writes)" 0
+said 'already frozen' && ok "and it says so in the run log" || ko "the yield is silent"
+
+echo
+echo "a stale freeze must not become permanent"
+# THE case this rewrite exists for. Our pass decided `frozen` against members=M2. A peer has since
+# seen the set change to M1 and reset the clock. Freezing M2 now would make a superseded set
+# terminal — and the member it drops is then held forever by the gate.
+reset
+server_body "$(pending_json "$M1" 2026-07-22T10:05:00Z)"
+do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
+eq "the writer abandons instead of freezing a superseded set" "$(run)" 2
+eq "the peer's pending marker stands" "$(marker_now | jq -r .status)" pending
+eq "with the peer's member set" "$(marker_now | jq -r '.members | length')" 1
+eq "and nothing was written" "$(writes)" 0
+said 'member set moved' && ok "and the abandonment is explained" || ko "abandoning is silent"
+
+echo
+echo "equivalent writers agree instead of fighting"
+# Two writers with the same member set differ only in `at`. Byte-equality would leave neither able to
+# satisfy the other: they would ping-pong to exhaustion and both report a failure that never happened.
+reset
+server_body "$(pending_json "$M2" 2026-07-22T09:59:00Z)"
+do=pending; cur="$M2"; payload=$(pending_json "$M2" 2026-07-22T10:00:00Z)
+eq "an equivalent marker already present counts as done" "$(run)" 0
+eq "and no redundant write is issued" "$(writes)" 0
+
+echo
+echo "an orphaned payload line does not satisfy the verify"
+# splice's recovery path strips fence lines but leaves old JSON behind as prose. A whole-body grep
+# would match that orphan and report success while the region says something else.
+reset
+orphan=$(frozen_json "$M2")
+# The body carries our exact payload as loose prose (what splice's recovery path leaves behind) plus
+# a region saying something else. The write does not land, so a correct verify must fail — a
+# whole-body grep would match the orphan and report success.
+printf 'Some prose.\n%s\n\n%s\n_note_\n%s\n%s\n' "$orphan" "$START" "$(pending_json "$M2")" "$END" > "$WORK/body"
+printf 'x' > "$WORK/noop"
+do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
+eq "a write that never landed is not masked by the orphan" "$(run)" 1
+eq "and the region still says what it did" "$(marker_now | jq -r .status)" pending
 
 echo
 echo "read failures"
 reset
-do=pending; payload=$(jq -cn --arg at "2026-07-22T10:00:00Z" --argjson m "$M2" '{status:"pending", at:$at, members:$m}')
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
 printf 2 > "$WORK/read_fails"
-write_marker "$(region pending "$M2")" && ok "two failed reads still converge on the third attempt" || ko "gave up too early"
+eq "two failed reads still converge on the third attempt" "$(run)" 0
 reset
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
 printf 99 > "$WORK/read_fails"
-do=pending; payload=$(jq -cn --arg at "2026-07-22T10:00:00Z" --argjson m "$M2" '{status:"pending", at:$at, members:$m}')
-write_marker "$(region pending "$M2")" && ko "reported success with every read failing" || ok "a total read failure gives up rather than claiming success"
+eq "a total read failure gives up rather than claiming success" "$(run)" 1
 
 echo
 printf '%d passed, %d failed\n' "$pass" "$fail"
@@ -159,7 +210,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -lt 12 ]; then
-  echo "::error::only $ran assertion(s) ran (expected at least 12) — the suite did not execute fully"
+if [ "$ran" -lt 20 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 20) — the suite did not execute fully"
   exit 1
 fi

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -13,7 +13,7 @@
 # read before the loop; a writer that re-reads but does not re-derive will freeze a member set the
 # world has already moved past, and a retry loop makes it win. Several cases below exist only to pin
 # that: a writer must abandon rather than make a stale freeze permanent.
-set -uo pipefail
+set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ACTION="${1:-$ROOT/generic-actions/merge-gate/action.yaml}"
@@ -48,7 +48,10 @@ sleep() { :; }
 
 # ---- the stubbed body store ---------------------------------------------------------------
 # $WORK/body is the issue body on the server. $WORK/steal, when non-empty, is a peer write that lands
-# immediately AFTER ours, once — the case an exit-code check calls a win.
+# immediately AFTER ours, once — the case an exit-code check calls a win. It models what the real peer
+# (render-epic-status) does: keep what it found and add its own section OUTSIDE our region. A stub
+# that replaced the whole body would delete that prose, and then no assertion could observe a lost
+# update at all — which is the one thing this suite exists to see.
 gh() {
   case "$*" in
     *"issues/${EPIC}"*)
@@ -57,9 +60,12 @@ gh() {
         printf '%s' "$(($(< "$WORK/read_fails") - 1))" > "$WORK/read_fails"
         return 1
       fi
-      cat "$WORK/body"
+      # GitHub stores bodies with CRLF. Serving LF would leave every `tr -d '\r'` in the action
+      # untested while its comments assert the strip is load-bearing.
+      sed 's/$/\r/' "$WORK/body"
       ;;
     *"issue edit"*)
+      [ -s "$WORK/edit_fails" ] && { printf 'x' >> "$WORK/writes"; echo "gh: HTTP 422" >&2; return 1; }
       # NOTE: ${*##pattern} strips per-positional-parameter and rejoins — join first, then strip.
       local all="$*" f
       f="${all##*--body-file }"; f="${f%% *}"
@@ -107,6 +113,7 @@ eq() { [ "$2" = "$3" ] && ok "$1" || ko "$1 (got '$2', want '$3')"; }
 
 reset() {
   printf 0 > "$WORK/read_fails"; : > "$WORK/writes"; : > "$WORK/steal"; : > "$WORK/noop"
+  : > "$WORK/edit_fails"
   : > "$GITHUB_STEP_SUMMARY"; server_body ""
 }
 # Capture the function's own output so it cannot be mistaken for the exit code, and so both tee'd
@@ -127,10 +134,13 @@ reset
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
 # The peer reverts the body, discarding our write. Nothing about that invalidates a pending decision,
 # so we should notice and retry rather than trust the edit's exit code.
-printf 'Some prose.\n\nMore prose.\n' > "$WORK/steal"
+{ cat "$WORK/body"; printf '\n<!-- rendered by the peer -->\n'; } > "$WORK/steal"
 eq "we retry until our write survives" "$(run)" 0
 eq "and our marker is what finally stands" "$(marker_now | jq -r '.members | length')" 2
 eq "which took two writes, not one" "$(writes)" 2
+grep -q 'rendered by the peer' "$WORK/body" \
+  && ok "and the peer's own edit outside our region survives" \
+  || ko "LOST UPDATE: we overwrote the peer's edit"
 
 echo
 echo "a wiped marker invalidates a freeze in flight"
@@ -139,7 +149,7 @@ echo "a wiped marker invalidates a freeze in flight"
 reset
 server_body "$(pending_json "$M2" 2026-07-22T09:00:00Z)"
 do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
-printf 'Some prose.\n\nMore prose.\n' > "$WORK/steal"
+printf 'Some prose.\n\nMore prose.\n' > "$WORK/steal"   # a peer that removes the marker outright
 eq "the freeze is abandoned once its pending basis disappears" "$(run)" 2
 
 echo
@@ -192,6 +202,42 @@ do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
 eq "a write that never landed is not masked by the orphan" "$(run)" 1
 eq "and the region still says what it did" "$(marker_now | jq -r .status)" pending
 
+echo "splice, on its own"
+# Driven directly, because the retry loop hides it: a broken splice writes a body with no fences, the
+# next attempt takes the fallback branch, appends a correct region, and the verify passes. Every
+# splice defect therefore reads as a green suite unless it is exercised on its own.
+sp() { # $1 = body text, $2 = payload -> the spliced result
+  local b r
+  b=$(mktemp -p "$WORK"); r=$(region_file "$2")
+  printf '%s\n' "$1" > "$b"
+  splice "$b" "$r"
+}
+one_region() { [ "$(grep -cxF -- "$START" <<< "$1")" = 1 ] && [ "$(grep -cxF -- "$END" <<< "$1")" = 1 ]; }
+inner() { awk -v s="$START" -v e="$END" '$0==s{f=1;next} $0==e{f=0} f' <<< "$1" | sed -n '/^[[:space:]]*[{[]/,$p'; }
+
+P=$(frozen_json "$M2")
+out=$(sp "$(printf 'top\n\n%s\n_note_\n%s\n%s\n\nbottom\n' "$START" "$(pending_json "$M1")" "$END")" "$P")
+eq "an existing region is replaced in place" "$(inner "$out" | jq -r .status)" frozen
+one_region "$out" && ok "leaving exactly one region" || ko "region count wrong"
+grep -q '^top$' <<< "$out" && grep -q '^bottom$' <<< "$out" \
+  && ok "with the prose either side intact" || ko "prose was dropped by the in-place branch"
+# The replaced payload must be GONE, not merely out of the region: a stale copy left loose in the
+# body is what lets a whole-body match report a marker that is not there.
+grep -qF -- "$(pending_json "$M1")" <<< "$out" \
+  && ko "the replaced payload is still in the body" \
+  || ok "and the payload it replaced is gone entirely"
+
+out=$(sp "$(printf 'only prose\n')" "$P")
+eq "a body with no region gains one" "$(inner "$out" | jq -r .status)" frozen
+grep -q '^only prose$' <<< "$out" && ok "and keeps the prose" || ko "prose lost on append"
+
+out=$(sp "$(printf '%s\nA\n%s\ntext\n%s\nB\n%s\n' "$START" "$END" "$START" "$END")" "$P")
+one_region "$out" && ok "duplicate fences are healed to one region" || ko "duplicate fences survived"
+
+out=$(sp "$(printf '%s\nstray end first\n%s\n' "$END" "$START")" "$P")
+one_region "$out" && ok "inverted fences are healed to one region" || ko "inverted fences survived"
+
+echo
 echo
 echo "read failures"
 reset
@@ -210,7 +256,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -lt 20 ]; then
-  echo "::error::only $ran assertion(s) ran (expected at least 20) — the suite did not execute fully"
+if [ "$ran" -lt 31 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 31) — the suite did not execute fully"
   exit 1
 fi

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -9,11 +9,19 @@
 # issue body from a job that does not wait for it — so writers overlap by design, against an API with
 # no conditional update.
 #
-# The subtle half is not the write, it is the DECISION. `$do` and `$payload` are computed from a body
-# read before the loop; a writer that re-reads but does not re-derive will freeze a member set the
-# world has already moved past, and a retry loop makes it win. Several cases below exist only to pin
-# that: a writer must abandon rather than make a stale freeze permanent.
+# The subtle half is not the write, it is what the write DOES WITH a decision made earlier. `$do` and
+# `$payload` are computed from a body read before the loop; a writer that re-reads but does not
+# re-derive will freeze a member set the world has already moved past, and a retry loop makes it win.
+# Several cases below exist only to pin that.
+#
+# Scope: this drives `write_marker` and its helpers. The decision step that PRODUCES `$do`/`$payload`
+# (the `do=` jq, and the MEMBERS normalization above it) is not extracted and is not covered here —
+# the fixtures set those as inputs. Their reachable range was checked by hand against that jq; adding
+# a decision-step suite is the obvious next increment.
 set -euo pipefail
+
+TOP_PID=$$
+die() { echo "::error::$1" >&2; kill -s TERM "$TOP_PID"; exit 1; }
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ACTION="${1:-$ROOT/generic-actions/merge-gate/action.yaml}"
@@ -45,8 +53,19 @@ export ORG=a-novel-kit PLANNING_REPO=.github EPIC=900
 export STABILIZE_SECONDS=120
 now=2026-07-22T10:00:00Z
 export GITHUB_STEP_SUMMARY="$WORK/summary.md"
-START='<!-- epic-membership:snapshot:start -->'
-END='<!-- epic-membership:snapshot:end -->'
+# Fences and region layout, read OUT OF THE MANIFEST. The fence literal is shared by merge-gate,
+# epic-membership and detect-partial-landing, so a restated copy here could not see the writer drift
+# away from both readers; and the ORDER inside the region matters — put the payload above the note
+# and `current_marker` reads every marker as absent.
+START=$(sed -n "s/^ *START='\(.*\)'\$/\1/p" "$ACTION" | head -1)
+END=$(sed -n "s/^ *END='\(.*\)'\$/\1/p" "$ACTION" | head -1)
+[ -n "$START" ] && [ -n "$END" ] || die "could not read the fence literals from $ACTION"
+REGION_BLOCK=$(awk '
+  /^        \{$/ { buf=""; inb=1; next }
+  inb && /^        \} > "\$regionf"$/ { printf "%s", buf; exit }
+  inb { buf = buf $0 "\n" }
+' "$ACTION")
+[ -n "$REGION_BLOCK" ] || die "could not read the region block from $ACTION"
 sleep() { :; }
 
 # ---- the stubbed body store ---------------------------------------------------------------
@@ -59,8 +78,14 @@ gh() {
   case "$*" in
     *"issues/${EPIC}"*)
       # File-backed: reads run inside $( ), so a shell-variable countdown would never reach the parent.
+      printf 'r' >> "$WORK/reads"
       if [ "$(< "$WORK/read_fails")" -gt 0 ]; then
         printf '%s' "$(($(< "$WORK/read_fails") - 1))" > "$WORK/read_fails"
+        return 1
+      fi
+      # Fail every read from the Nth onward — lets a read failure follow an edit failure, which is
+      # the only order in which the per-attempt `err` reset is observable.
+      if [ -s "$WORK/read_fail_from" ] && [ "$(wc -c < "$WORK/reads")" -ge "$(< "$WORK/read_fail_from")" ]; then
         return 1
       fi
       # GitHub stores bodies with CRLF. Serving LF would leave every `tr -d '\r'` in the action
@@ -86,11 +111,16 @@ gh() {
   esac
 }
 
-M1='[{"repo":"a-novel-kit/repo-a","number":1}]'
-M2='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-b","number":2}]'
+# repo-a carries the HIGHER number on purpose: sorting by repo and sorting by number then give
+# different answers, so a guard using the wrong key is observable.
+M1='[{"repo":"a-novel-kit/repo-a","number":5}]'
+M2='[{"repo":"a-novel-kit/repo-a","number":5},{"repo":"a-novel-kit/repo-b","number":2}]'
 # Same size as M2, different members: without this, every "members differ" case also differs in
 # COUNT, and comparing lengths would be indistinguishable from comparing sets.
-M2B='[{"repo":"a-novel-kit/repo-a","number":1},{"repo":"a-novel-kit/repo-c","number":3}]'
+M2B='[{"repo":"a-novel-kit/repo-a","number":5},{"repo":"a-novel-kit/repo-c","number":3}]'
+# Two members in ONE repo, numbers out of input order: sorting by repo alone is stable and leaves them
+# as given, so only the composite (repo, number) key produces the canonical order.
+M2S='[{"repo":"a-novel-kit/repo-a","number":2},{"repo":"a-novel-kit/repo-a","number":9}]'
 
 pending_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --argjson m "$1" '{status:"pending", at:$at, members:$m}'; }
 frozen_json() { jq -cn --argjson m "$1" '{status:"frozen", members:$m}'; }
@@ -103,12 +133,17 @@ note_of() { # frozen|pending
   [ "$1" = frozen ] || key=PENDING
   sed -n "s/^ *note=\"\(_Epic membership, $key.*\)\"$/\1/p" "$ACTION" | head -1
 }
-region_file() { # $1 = payload json, $2 = frozen|pending -> the region exactly as the action builds it
-  local f note
+region_file() { # $1 = payload json, $2 = frozen|pending -> the region the action itself would build
+  local f note payload regionf
   note=$(note_of "${2:-pending}")
-  [ -n "$note" ] || { echo "::error::could not read the note text from $ACTION"; exit 1; }
-  f=$(mktemp -p "$WORK")
-  { echo "$START"; printf '%s\n' "$note"; printf '%s\n' "$1"; echo "$END"; } > "$f"
+  [ -n "$note" ] || die "could not read the note text from $ACTION"
+  payload="$1"
+  f=$(mktemp -p "$WORK"); regionf="$f"
+  # Run the manifest's own assembly rather than a copy of it.
+  # `$( )` strips the trailing newline, so the closing brace needs its own separator or bash
+  # reads it as an argument to the last command.
+  eval "{ $REGION_BLOCK
+} > \"\$regionf\""
   printf '%s' "$f"
 }
 server_body() { # $1 = marker json, or empty for a body with no marker
@@ -132,13 +167,26 @@ eq() { [ "$2" = "$3" ] && ok "$1" || ko "$1 (got '$2', want '$3')"; }
 
 reset() {
   printf 0 > "$WORK/read_fails"; : > "$WORK/writes"; : > "$WORK/steal"; : > "$WORK/noop"
-  : > "$WORK/edit_fails"
+  : > "$WORK/edit_fails"; : > "$WORK/read_fail_from"; : > "$WORK/reads"
   : > "$GITHUB_STEP_SUMMARY"; server_body ""
 }
 # Capture the function's own output so it cannot be mistaken for the exit code, and so both tee'd
 # and plain log lines can be asserted from one place.
 run() { write_marker "$(region_file "$payload" "$do")" > "$WORK/out" 2>&1 && echo 0 || echo $?; }
 said() { grep -q "$1" "$WORK/out"; }
+
+echo "the marker contract is shared by three actions"
+# A derived fixture follows merge-gate's fences rather than catching a change in them; what it cannot
+# see is the writer drifting away from the two READERS. Assert the contract across all three.
+for d in epic-membership detect-partial-landing; do
+  f="$ROOT/generic-actions/$d/action.yaml"
+  if [ ! -f "$f" ]; then ko "$d/action.yaml is missing"; continue; fi
+  if grep -qF -- "$START" "$f" && grep -qF -- "$END" "$f"; then
+    ok "$d uses the same fences as the writer"
+  else
+    ko "$d has drifted from merge-gate's fences — the snapshot would be invisible to it"
+  fi
+done
 
 echo "the ordinary write"
 reset
@@ -237,6 +285,14 @@ for bad in '"not-a-date"' 'null'; do
 done
 
 echo
+echo "the sort key is the pair, not either half"
+reset
+server_body "$(jq -cn --argjson m "$M2S" '{status:"pending", at:"2026-07-22T09:00:00Z", members:($m | reverse)}')"
+do=frozen; cur="$M2S"; payload=$(frozen_json "$M2S")
+eq "two members in one repo, reordered, still freeze" "$(run)" 0
+eq "and the marker is frozen" "$(marker_now | jq -r .status)" frozen
+
+echo
 echo "a freeze must not skip the stabilization window"
 # The decision step only says `frozen` once the marker has held still past STABILIZE_SECONDS. If the
 # guard does not re-check age, a peer's clock reset can be overtaken seconds later — freezing before
@@ -288,11 +344,22 @@ out=$(sp "$(printf 'only prose\n')" "$P")
 eq "a body with no region gains one" "$(inner "$out" | jq -r .status)" frozen
 grep -q '^only prose$' <<< "$out" && ok "and keeps the prose" || ko "prose lost on append"
 
-out=$(sp "$(printf '%s\nA\n%s\ntext\n%s\nB\n%s\n' "$START" "$END" "$START" "$END")" "$P")
+out=$(sp "$(printf 'HUMAN-A\n%s\nA\n%s\ntext\n%s\nB\n%s\nHUMAN-B\n' "$START" "$END" "$START" "$END")" "$P")
 one_region "$out" && ok "duplicate fences are healed to one region" || ko "duplicate fences survived"
+grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
+  && ok "without dropping the prose around them" || ko "prose was destroyed healing duplicate fences"
 
-out=$(sp "$(printf '%s\nstray end first\n%s\n' "$END" "$START")" "$P")
+# Prose BETWEEN a stray fence and the end is the shape that discriminates: an in-place replace spans
+# from the first START to the END and discards everything inside, while the recovery path strips the
+# fence lines and keeps it. A malformed region must take the recovery path.
+out=$(sp "$(printf '%s\nHUMAN-A\n%s\nHUMAN-B\n%s\n' "$START" "$START" "$END")" "$P")
+one_region "$out" && ok "an unbalanced fence pair is healed to one region" || ko "unbalanced fences survived"
+grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
+  && ok "keeping prose that was trapped inside it" || ko "prose between stray fences was destroyed"
+out=$(sp "$(printf 'HUMAN-A\n%s\nstray end first\n%s\nHUMAN-B\n' "$END" "$START")" "$P")
 one_region "$out" && ok "inverted fences are healed to one region" || ko "inverted fences survived"
+grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
+  && ok "keeping the prose around those too" || ko "prose was destroyed healing inverted fences"
 
 echo
 echo "same status, different members of the same size"
@@ -309,6 +376,16 @@ server_body "$(pending_json "$M2B" 2026-07-22T09:00:00Z)"
 do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
 eq "and a freeze against an equal-size peer set abandons" "$(run)" 2
 eq "writing nothing" "$(writes)" 0
+
+echo
+echo "a shorter peer set is a difference, not a match"
+# The index-lag shape: a peer wrote a strict subset. If the comparison is a subset test rather than
+# equality, no writer ever corrects it.
+reset
+server_body "$(pending_json "$M1" 2026-07-22T09:00:00Z)"
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
+eq "a subset marker is corrected, not accepted" "$(run)" 0
+eq "and our full set is what stands" "$(marker_now | jq -r '.members | length')" 2
 
 echo
 echo "a region holding more than one value"
@@ -353,7 +430,19 @@ do=pending; cur="$M2"; payload=$(pending_json "$M2")
 printf 'x' > "$WORK/edit_fails"
 eq "an edit that errors is retried, then given up on" "$(run)" 1
 eq "after three attempts" "$(writes)" 3
-said 'last write error' && ok "and the API error is surfaced, not swallowed" || ko "the edit error was discarded"
+said 'HTTP 422' && ok "and the API's own error text is surfaced, not swallowed" || ko "the edit error was discarded"
+
+echo
+echo "a give-up after mixed failures names a real cause"
+# err is cleared each attempt so a give-up cannot quote an earlier attempt's error. That reset is
+# only observable when the LAST attempts fail somewhere that sets no error of its own.
+reset
+do=pending; cur="$M2"; payload=$(pending_json "$M2")
+printf 'x' > "$WORK/edit_fails"
+printf 2 > "$WORK/read_fail_from"   # attempt 1 reads, edits, fails; every later read fails too
+eq "the pass gives up" "$(run)" 1
+said 'could not read' && ok "and names the failure that actually ended it" \
+  || ko "the give-up quotes a stale error from an earlier attempt"
 
 echo
 echo "read failures"
@@ -377,7 +466,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -ne 60 ]; then
-  echo "::error::$ran assertion(s) ran, expected exactly 60 — the suite did not execute fully (or an assertion was added without raising this)"
+if [ "$ran" -ne 72 ]; then
+  echo "::error::$ran assertion(s) ran, expected exactly 72 — the suite did not execute fully (or an assertion was added without raising this)"
   exit 1
 fi


### PR DESCRIPTION
Closes #327. Part of a-novel-kit/.github#130.

## The race

Two writers edit the same Epic issue body, and the sweep runs them concurrently by design:

- **`regate`** — a matrix over every open member pull request, `fail-fast: false`, **no `max-parallel`, no `concurrency`**. Each job's merge-gate may write the activation snapshot.
- **`render`** — **no `needs:`**, so it runs alongside `regate`. It reads the body, then does paginated GraphQL searches and tag comparisons (`render-epic-status:175–227`), then writes at `:450` — a read-modify-write window of seconds to tens of seconds.

Both rewrite the **whole body** to change their own fenced region, so the later write discards whatever landed in between. The damaging direction is `render`: a table documented as *"display-only … a lost table is cosmetic"* could erase an authoritative frozen member set.

## Why not a lock

There is no conditional write available. GitHub returns an `ETag` on `GET /issues/{n}` but the issues API accepts **no `If-Match` on PATCH** — verified. A per-Epic `concurrency` group was rejected for a worse reason: GitHub keeps only one pending run per group and **cancels** the rest, so in a matrix it would silently drop gate evaluations — trading a rare race for routine lost work.

So: **read-modify-verify.**

| Writer | Change |
| --- | --- |
| `render-epic-status` | Re-reads the body immediately before splicing, instead of reusing the copy from the top of the pass. This alone ends the cross-region damage — each writer now only rewrites its own region in a body it just read |
| `merge-gate` capture | Retries against whatever landed; confirms its payload survived rather than trusting the edit's exit code; and treats a marker that turned **frozen** underneath it as a peer's promotion to leave alone — frozen is terminal, so a pending writer must never reset it |

## Tests

The write loop is a **function** rather than inline step code specifically so the harness can extract and drive it. That is the point: this is a race, and reasoning alone is what gets races wrong.

`tests/merge-gate-snapshot-write.sh` stubs the body store and covers the cases that matter — 12 assertions, and every guard is pinned:

| Mutant | Result |
| --- | --- |
| trust the exit code instead of verifying | 1 failed |
| drop the frozen-is-terminal guard | 3 failed |
| don't re-read inside the loop | aborts (unbound) |
| single attempt, no retry | 3 failed |

Both suites run under the existing `test-actions` job — its `tests/*.sh` glob picks the new one up with no workflow change. `detect-partial-landing` stays at 95/95.

> [!NOTE]
> This unblocks #328 (retire-on-complete), which adds another write to the same body and was deliberately sequenced behind this fix.