### PR TITLE
feat: retire a frozen snapshot once its wave is complete [DO NOT MERGE — design incomplete]

### DIFF
--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -441,6 +441,11 @@ runs:
         EPIC: ${{ steps.discover.outputs.epic_number }}
         MEMBERS: ${{ steps.membership.outputs.members }}
         STABILIZE_SECONDS: "120"
+        # How long a frozen wave may sit with a member that has neither merged nor closed before the
+        # gate says so. It only warns: expiring a snapshot on a clock would un-freeze membership
+        # mid-landing, which is the failure the snapshot exists to prevent, and it would fire exactly
+        # when an Epic is already unhealthy. A human closes the stray, or pauses the Epic.
+        STUCK_WAVE_HOURS: "72"
       run: |
         set -euo pipefail
         # The marker currently in the body, as JSON — empty when there is none or it is unusable.
@@ -467,6 +472,12 @@ runs:
         # a frozen marker is never rewritten, so one they refuse is a permanently dead snapshot that
         # silently degrades every Epic to live membership. Dedup is case-folded (GitHub resolves repo
         # names case-insensitively) and the 50-member cap matches theirs.
+        # Is every member of the CURRENT set terminal? When a frozen marker is in force, epic-membership
+        # returns that frozen set with each member's state re-read live, so this needs no extra call.
+        # Before activation every state is OPEN, so this is false and nothing retires prematurely.
+        all_terminal=$(printf '%s' "$MEMBERS" | jq -c \
+          '(length > 0) and all(.[]; .state == "MERGED" or .state == "CLOSED")' 2>/dev/null || echo false)
+
         cur=$(printf '%s' "$MEMBERS" | jq -c '
           [.[] | {repo, number}] | unique_by((.repo | ascii_downcase), .number) | sort_by(.repo, .number)')
         if ! printf '%s' "$cur" | jq -e '
@@ -491,9 +502,13 @@ runs:
         # frozen → skip; a valid pending → reset (members changed) / promote (unchanged + aged) / wait;
         # anything else (missing, malformed, other status) → write a fresh pending.
         do=$(jq -rn --argjson cur "$cur" --argjson mk "$marker" --arg now "$now" \
-          --argjson thr "${STABILIZE_SECONDS}" '
+          --argjson terminal "$all_terminal" --argjson thr "${STABILIZE_SECONDS}" '
           if ($mk | type) != "object" then "pending"
-          elif $mk.status == "frozen" then "skip"
+          # A frozen wave whose every member is terminal has done its job: the set it was frozen to
+          # remember is fully landed or fully abandoned, and there is nothing left to remember. Retire
+          # it so the next ready set captures its own — which is the "joins the next wave" behaviour
+          # epic-membership promises and nothing previously implemented.
+          elif $mk.status == "frozen" then (if $terminal then "retire" else "skip" end)
           elif ($mk.status == "pending" and ($mk.members | type == "array") and ($mk.at | type == "string"))
             then (
               if (($mk.members | sort_by(.repo, .number)) != $cur) then "pending"
@@ -509,13 +524,28 @@ runs:
           else "pending" end' 2>/dev/null || echo skip)
 
         if [ "$do" = "skip" ]; then
+          # A frozen wave that cannot finish is invisible otherwise: it holds every later-labelled pull
+          # request, and nothing retires it because retirement needs every member terminal. Name the
+          # members it is waiting on so a human can close a stray or pause the Epic.
+          stuck=$(printf '%s' "$MEMBERS" | jq -r '[.[] | select(.state != "MERGED" and .state != "CLOSED")
+            | "\(.repo)#\(.number)"] | join(", ")' 2>/dev/null || true)
+          if [ -n "$stuck" ] && printf '%s' "$marker" | jq -e '.status == "frozen"' >/dev/null 2>&1 \
+            && printf '%s' "$marker" | jq -e --arg now "$now" --argjson hrs "${STUCK_WAVE_HOURS}" \
+                 '(.at | try (fromdateiso8601 | true) catch false)
+                  and (($now | fromdateiso8601) - (.at | fromdateiso8601)) >= ($hrs * 3600)' >/dev/null 2>&1; then
+            echo "::warning::Epic #${EPIC}: the frozen wave has been open more than ${STUCK_WAVE_HOURS}h waiting on ${stuck}. Nothing else can freeze until it finishes — close the stray or label the Epic \`automation:paused\`." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
           echo "Epic #${EPIC}: snapshot already frozen, or stable but not yet aged — leaving it." \
             | tee -a "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
 
-        if [ "$do" = "frozen" ]; then
-          payload=$(printf '%s' "$cur" | jq -c '{status: "frozen", members: .}')
+        if [ "$do" = "retire" ]; then
+          payload=""
+          note=""
+        elif [ "$do" = "frozen" ]; then
+          payload=$(printf '%s' "$cur" | jq -c --arg at "$now" '{status: "frozen", at: $at, members: .}')
           note="_Epic membership, FROZEN at activation by the merge-gate. The authoritative set for this landing — a later de-label, close, or relabel does not change it. Do not edit._"
         else
           payload=$(printf '%s' "$cur" | jq -c --arg at "$now" '{status: "pending", at: $at, members: .}')
@@ -556,12 +586,19 @@ runs:
         # available guarantee is: splice into a body read moments ago, then confirm the write survived.
         # A losing writer retries against whatever landed instead of overwriting it.
         regionf=$(mktemp)
-        {
-          echo "$START"
-          echo "$note"
-          printf '%s\n' "$payload"
-          echo "$END"
-        } > "$regionf"
+        if [ "$do" = "retire" ]; then
+          # An EMPTY region, not an empty marker: splice emits the region file in place of everything
+          # between the fences AND drops the fence lines themselves, so an empty file removes the
+          # region outright. Writing empty strings between the fences would leave them standing.
+          : > "$regionf"
+        else
+          {
+            echo "$START"
+            echo "$note"
+            printf '%s\n' "$payload"
+            echo "$END"
+          } > "$regionf"
+        fi
 
         # Read-modify-VERIFY, as a function so the test harness can extract and drive it against a
         # stubbed gh. The sweep runs this gate as a matrix over every open member pull request with no
@@ -581,7 +618,9 @@ runs:
         # "The marker already says what we intend, AND it is a marker that can still make progress."
         # Used for BOTH the entry short-circuit and the post-write verify: if these two ever answer
         # differently, a repair that was clobbered reads as a repair that landed.
-        marker_settled() { # $1 = live marker json, $2 = our payload json
+        marker_settled() { # $1 = live marker json, $2 = our payload json ("" when retiring)
+          # Retiring wants ABSENCE: the region gone, not replaced.
+          if [ -z "$2" ]; then [ -z "$1" ]; return; fi
           same_marker "$1" "$2" || return 1
           # A frozen marker carries no `at` and needs none — it is terminal.
           [ "$(printf '%s' "$1" | jq -r '.status // ""')" = "frozen" ] && return 0
@@ -623,7 +662,19 @@ runs:
             # rewriting it mid-landing is the one thing "frozen" forbids. Yield, whatever we intended.
             # This narrows the window rather than closing it — a freeze landing between this check and
             # the write below is still clobbered, and no conditional-update API exists to prevent that.
-            if [ -n "$marker" ] && [ "$(printf '%s' "$marker" | jq -r '.status // ""')" = "frozen" ]; then
+            if [ "$do" = "retire" ]; then
+              # Re-derive the retirement too: only remove the frozen marker this pass judged complete.
+              # If it is no longer frozen, or its members moved, a peer has already opened the next
+              # wave and deleting the region would discard their work.
+              if ! jq -e -n --argjson m "${marker:-null}" --argjson cur "$cur" \
+                   '($m | type == "object") and $m.status == "frozen"
+                    and (($m.members // []) | sort_by(.repo, .number)) == $cur' >/dev/null 2>&1; then
+                echo "Epic #${EPIC}: the snapshot moved on before this pass could retire it — leaving it." \
+                  | tee -a "$GITHUB_STEP_SUMMARY"
+                rc=2
+                break
+              fi
+            elif [ -n "$marker" ] && [ "$(printf '%s' "$marker" | jq -r '.status // ""')" = "frozen" ]; then
               echo "Epic #${EPIC}: the snapshot is already frozen (a peer got there first) — leaving it." \
                 | tee -a "$GITHUB_STEP_SUMMARY"
               rc=2
@@ -670,7 +721,10 @@ runs:
         }
 
         write_marker "$regionf" && wm=0 || wm=$?
-        if [ "$wm" = 0 ]; then
+        if [ "$wm" = 0 ] && [ "$do" = "retire" ]; then
+          echo "Epic #${EPIC}: wave complete — activation snapshot retired; the next ready set will capture its own." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+        elif [ "$wm" = 0 ]; then
           n=$(printf '%s' "$cur" | jq 'length')
           echo "Epic #${EPIC}: ${do} activation snapshot in place — ${n} member(s)." | tee -a "$GITHUB_STEP_SUMMARY"
         elif [ "$wm" = 2 ]; then

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -60,9 +60,11 @@ export GITHUB_STEP_SUMMARY="$WORK/summary.md"
 START=$(sed -n "s/^ *START='\(.*\)'\$/\1/p" "$ACTION" | head -1)
 END=$(sed -n "s/^ *END='\(.*\)'\$/\1/p" "$ACTION" | head -1)
 [ -n "$START" ] && [ -n "$END" ] || die "could not read the fence literals from $ACTION"
+# Indentation-agnostic: the block moves when it is wrapped in a conditional, and an anchor tied to a
+# fixed indent would silently stop matching — the failure this whole derivation exists to prevent.
 REGION_BLOCK=$(awk '
-  /^        \{$/ { buf=""; inb=1; next }
-  inb && /^        \} > "\$regionf"$/ { printf "%s", buf; exit }
+  /^[[:space:]]*\{$/ { buf=""; inb=1; next }
+  inb && /^[[:space:]]*\} > "\$regionf"$/ { printf "%s", buf; exit }
   inb { buf = buf $0 "\n" }
 ' "$ACTION")
 [ -n "$REGION_BLOCK" ] || die "could not read the region block from $ACTION"
@@ -123,7 +125,7 @@ M2B='[{"repo":"a-novel-kit/repo-a","number":5},{"repo":"a-novel-kit/repo-c","num
 M2S='[{"repo":"a-novel-kit/repo-a","number":2},{"repo":"a-novel-kit/repo-a","number":9}]'
 
 pending_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --argjson m "$1" '{status:"pending", at:$at, members:$m}'; }
-frozen_json() { jq -cn --argjson m "$1" '{status:"frozen", members:$m}'; }
+frozen_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --argjson m "$1" '{status:"frozen", at:$at, members:$m}'; }
 
 # The note the action actually writes, read OUT OF THE MANIFEST. Restating it here is how a fixture
 # comes to encode a belief instead of the format: a note that ever began with `[` or `{` would make
@@ -139,6 +141,8 @@ region_file() { # $1 = payload json, $2 = frozen|pending -> the region the actio
   [ -n "$note" ] || die "could not read the note text from $ACTION"
   payload="$1"
   f=$(mktemp -p "$WORK"); regionf="$f"
+  # Retiring uses an empty region file — splice then drops the fences with it.
+  if [ -z "$payload" ]; then : > "$f"; printf '%s' "$f"; return; fi
   # Run the manifest's own assembly rather than a copy of it.
   # `$( )` strips the trailing newline, so the closing brace needs its own separator or bash
   # reads it as an argument to the last command.
@@ -155,6 +159,40 @@ server_body() { # $1 = marker json, or empty for a body with no marker
 }
 marker_now() { current_marker "$(cat "$WORK/body")"; }
 writes() { wc -c < "$WORK/writes" | tr -d ' '; }
+
+# The DECISION program, lifted from the manifest. Until now the suite set `do` and `payload` as
+# inputs, so nothing could see the step COMPUTE them — and #328's whole subject is a new decision.
+DECIDE_JQ=$(awk "
+  /do=\\\$\\(jq -rn/ { f=1 }
+  f && !st && /'\$/ { st=1; next }
+  st && /' 2>\\/dev\\/null \\|\\| echo skip\\)\$/ { sub(/'.*\$/, \"\"); print; exit }
+  st { print }
+" "$ACTION")
+[ -n "$DECIDE_JQ" ] || die "could not read the decision program from $ACTION"
+
+# The terminality test, also lifted — it is what decides a wave is over, and it lives in bash rather
+# than inside the decision program, so extracting only the latter would leave it unseen.
+TERMINAL_JQ=$(awk '/all_terminal=/{f=1;next} f{ sub(/^[[:space:]]*'"'"'/, ""); sub(/'"'"'.*$/, ""); print; exit }' "$ACTION")
+[ -n "$TERMINAL_JQ" ] || die "could not read the terminality test from $ACTION"
+terminal_of() { printf '%s' "$1" | jq -c "$TERMINAL_JQ" 2>/dev/null || echo false; }
+
+# The payload/note assembly, lifted whole. It is the last piece the suite used to supply as an input
+# rather than observe — so a frozen marker silently losing its timestamp, or a retirement writing
+# fences instead of nothing, were both invisible.
+PAYLOAD_BLOCK=$(awk '/if \[ "\$do" = "retire" \]; then/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
+[ -n "$PAYLOAD_BLOCK" ] || die "could not read the payload assembly from $ACTION"
+payload_for() { # $1 = do, $2 = cur -> echoes "<payload>" and sets NOTE_OUT
+  local do cur payload note
+  do="$1"; cur="$2"
+  eval "$PAYLOAD_BLOCK"
+  NOTE_OUT="$note"
+  printf '%s' "$payload"
+}
+
+decide() { # $1 = marker json (or null), $2 = all_terminal, $3 = cur members
+  jq -rn --argjson cur "${3:-$M2}" --argjson mk "$1" --arg now "$now" \
+    --argjson terminal "$2" --argjson thr "$STABILIZE_SECONDS" "$DECIDE_JQ" 2>/dev/null || echo skip
+}
 
 # shellcheck disable=SC1091
 . "$WORK/lib.sh"
@@ -314,6 +352,83 @@ do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
 eq "a reordered member array still freezes" "$(run)" 0
 eq "and the marker is frozen" "$(marker_now | jq -r .status)" frozen
 
+echo "a completed wave is retired so the next one can freeze"
+# The wave boundary. A frozen set whose members are all terminal has nothing left to remember, and
+# until it is retired a pull request labelled afterwards is held by the gate forever.
+reset
+server_body "$(frozen_json "$M2")"
+do=retire; cur="$M2"; payload=""
+eq "the frozen region is removed" "$(run)" 0
+eq "leaving no marker at all" "$(marker_now)" ""
+grep -q 'Some prose' "$WORK/body" && ok "and the human prose is untouched" || ko "prose was dropped retiring"
+grep -qF -- "$START" "$WORK/body" && ko "a fence was left behind" || ok "with both fences gone"
+
+echo
+echo "retirement re-derives like every other write"
+# Only the set this pass judged complete may be removed. If a peer already opened the next wave,
+# deleting the region would discard their work.
+reset
+server_body "$(pending_json "$M2" 2026-07-22T09:59:00Z)"     # a peer already started the next wave
+do=retire; cur="$M2"; payload=""
+eq "a marker that is no longer frozen is left alone" "$(run)" 2
+eq "and it still stands" "$(marker_now | jq -r .status)" pending
+eq "with nothing written" "$(writes)" 0
+reset
+server_body "$(frozen_json "$M2B")"                          # frozen, but not the set we judged
+do=retire; cur="$M2"; payload=""
+eq "a frozen set we did not judge is left alone" "$(run)" 2
+eq "and nothing is written" "$(writes)" 0
+
+echo
+echo "a retirement that is undone is retried"
+reset
+server_body "$(frozen_json "$M2")"
+printf 'Some prose.\n\n%s\n%s\n%s\n%s\n\nMore prose.\n' "$START" "$(note_of frozen)" "$(frozen_json "$M2")" "$END" > "$WORK/steal"
+do=retire; cur="$M2"; payload=""
+eq "the retirement is retried until it sticks" "$(run)" 0
+eq "which takes two writes" "$(writes)" 2
+eq "and the marker is finally gone" "$(marker_now)" ""
+
+echo "the frozen marker records when it froze"
+# Not for aging it — frozen is terminal — but so a wave that cannot finish can be measured and named.
+reset
+do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
+server_body "$(pending_json "$M2" 2026-07-22T09:00:00Z)"
+eq "a freeze is written" "$(run)" 0
+marker_now | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null \
+  && ok "carrying a parseable freeze time" || ko "the frozen marker has no usable timestamp"
+eq "and the members it froze" "$(marker_now | jq -c '.members')" "$M2"
+
+echo "the payload the step builds"
+eq "a frozen payload records the freeze time" \
+  "$(payload_for frozen "$M2" | jq -r 'has("at")')" true
+eq "and carries the members it froze" \
+  "$(payload_for frozen "$M2" | jq -c '.members')" "$M2"
+eq "a pending payload records its clock" \
+  "$(payload_for pending "$M2" | jq -r 'has("at")')" true
+eq "retiring builds no payload at all" "$(payload_for retire "$M2")" ""
+payload_for retire "$M2" >/dev/null; eq "and no note" "$NOTE_OUT" ""
+
+echo "what counts as a finished wave"
+st() { jq -cn --argjson s "$1" '[$s[] | {repo:"o/r", number:1, state:.}]'; }
+eq "every member merged is finished"     "$(terminal_of "$(st '["MERGED","MERGED"]')")" true
+eq "merged and closed is finished"       "$(terminal_of "$(st '["MERGED","CLOSED"]')")" true
+eq "one still open is not"               "$(terminal_of "$(st '["MERGED","OPEN"]')")" false
+eq "all still open is not"               "$(terminal_of "$(st '["OPEN"]')")" false
+eq "an empty set is not a finished wave" "$(terminal_of '[]')" false
+
+echo
+echo "the decision the step actually computes"
+# Driven through the manifest's own jq, so the retire rule is pinned where it is written rather than
+# assumed by fixtures that set `do` by hand.
+eq "no marker at all -> pending"            "$(decide null false)" pending
+eq "pending, aged -> frozen"                "$(decide "$(pending_json "$M2" 2026-07-22T09:00:00Z)" false)" frozen
+eq "pending, fresh -> skip"                 "$(decide "$(pending_json "$M2" 2026-07-22T09:59:30Z)" false)" skip
+eq "pending, members moved -> pending"      "$(decide "$(pending_json "$M2B" 2026-07-22T09:00:00Z)" false)" pending
+eq "frozen, members still open -> skip"     "$(decide "$(frozen_json "$M2")" false)" skip
+eq "frozen, every member terminal -> retire" "$(decide "$(frozen_json "$M2")" true)" retire
+eq "garbage marker -> pending"              "$(decide '"nonsense"' false)" pending
+
 echo
 echo "splice, on its own"
 # Driven directly, because the retry loop hides it: a broken splice writes a body with no fences, the
@@ -466,7 +581,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -ne 72 ]; then
-  echo "::error::$ran assertion(s) ran, expected exactly 72 — the suite did not execute fully (or an assertion was added without raising this)"
+if [ "$ran" -ne 104 ]; then
+  echo "::error::$ran assertion(s) ran, expected exactly 104 — the suite did not execute fully (or an assertion was added without raising this)"
   exit 1
 fi


### PR DESCRIPTION
Closes #328. Part of a-novel-kit/.github#130. Sequenced after #327 (merged), which is why it is safe to add another write to this body.

## The gap

Nothing ever cleared an activation snapshot, so the set frozen at activation was the set **forever**. A pull request labelled after the freeze was held by `merge-gate` indefinitely — with a message saying it *"belongs to a later wave, not this landing"*, a wave that could never begin. `epic-membership`'s own description promised the opposite: *"a PR labeled after landing begins joins the next wave"*.

## The rule

**A wave ends when every member is terminal** — merged or closed. At that point the snapshot has discharged its purpose: the set it was frozen to remember is fully landed or fully abandoned. The capture step retires it, and the next ready set captures its own.

- **No extra API call.** When a frozen marker is in force, `epic-membership` already returns that set with each member's `state` re-read live. Before activation every state is `OPEN`, so nothing retires prematurely.
- **The trigger falls out of the problem.** The held pull request is open and labelled, so the sweep runs the gate on it — and that pass is the one that retires. A completed Epic with *no* waiting pull request keeps a stale marker, which holds nobody and is retired the moment a next-wave PR appears.
- **Retirement re-derives**, like every other write on this body: only the frozen set *this pass judged complete* may be removed, so a peer that already opened the next wave is not discarded.
- **It writes an empty region, not an empty marker.** `splice` drops the fences along with the content; writing empty strings between them would leave them standing.

## A stuck wave is named, not expired

A frozen marker now records when it froze, and after **72h** with a member still neither merged nor closed the gate says which ones and what to do (close the stray, or `automation:paused`).

It only warns. A TTL was rejected: expiring a snapshot on a clock would un-freeze membership mid-landing — the failure the snapshot exists to prevent — and would fire exactly when an Epic is already unhealthy.

The `at` key is additive; both readers validate `status` + `members` and tolerate it, verified.

## Tests: 72 → 104

The suite now drives three things **out of the manifest** that it previously supplied as inputs — the decision program, the terminality test, and the payload assembly. That is why these all passed before:

| Mutant | Was | Now |
| --- | --- | --- |
| the retire rule never fires | green | 1 failed |
| `retire` also matches an open member | green | 2 failed |
| a frozen payload loses its timestamp | green | 1 failed |
| retiring writes fences instead of nothing | green | 1 failed |
| retirement skips its re-derive | — | 5 failed |

Deterministic across runs, no temp leakage, `detect-partial-landing` stays 95/95.