### PR TITLE
fix: canonicalize member repository names so a set compares equal to itself

### DIFF
--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -177,7 +177,7 @@ runs:
               | .value.pullRequest | select(. != null)
               | select($members[$i] != null and .number == ($members[$i].number | floor))
               | {repo: .repository.nameWithOwner, number, headRefOid, isDraft, reviewDecision, state} ]
-            | sort_by(.repo, .number)' 2>/dev/null || printf '[]')
+            | sort_by((.repo | ascii_downcase), .number)' 2>/dev/null || printf '[]')
           if [ "$(printf '%s' "$members" | jq 'length')" -ne "$want" ]; then
             echo "::warning::Epic #${EPIC}: could not re-read all ${want} frozen member(s) — reporting an empty set, which holds the Epic rather than gating on a partial one."
             members='[]'
@@ -271,7 +271,7 @@ runs:
           isDraft,
           reviewDecision,
           state: "OPEN"
-        }] | sort_by(.repo, .number)')
+        }] | sort_by((.repo | ascii_downcase), .number)')
         count=$(printf '%s' "$members" | jq 'length')
 
         {

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -463,12 +463,20 @@ runs:
         # here). GitHub stores bodies with CRLF; strip \r so the exact marker matches (grep + splice).
         body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' | tr -d '\r')
 
+        # Repository names are CANONICALIZED to lower case, not merely deduped case-insensitively.
+        # GitHub resolves them case-insensitively and can answer with either casing, so folding only in
+        # the dedup left the surviving element carrying whatever spelling arrived first — two passes
+        # then computed byte-different sets for the same members. The decision reads that as "members
+        # moved", resets the stabilization clock, and the Epic never freezes. Lower case is safe to
+        # store: every lookup built from it is case-insensitive, and both readers match members by
+        # alias index and number rather than by name.
         # Normalize exactly as the readers validate, so the writer cannot emit a marker they reject —
         # a frozen marker is never rewritten, so one they refuse is a permanently dead snapshot that
         # silently degrades every Epic to live membership. Dedup is case-folded (GitHub resolves repo
         # names case-insensitively) and the 50-member cap matches theirs.
         cur=$(printf '%s' "$MEMBERS" | jq -c '
-          [.[] | {repo, number}] | unique_by((.repo | ascii_downcase), .number) | sort_by(.repo, .number)')
+          [.[] | {repo: (.repo | ascii_downcase), number}]
+          | unique_by(.repo, .number) | sort_by(.repo, .number)')
         if ! printf '%s' "$cur" | jq -e '
               length > 0 and length <= 50
               and all(.[]; (.repo | test("\\A[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+\\z"))
@@ -496,7 +504,7 @@ runs:
           elif $mk.status == "frozen" then "skip"
           elif ($mk.status == "pending" and ($mk.members | type == "array") and ($mk.at | type == "string"))
             then (
-              if (($mk.members | sort_by(.repo, .number)) != $cur) then "pending"
+              if (($mk.members | sort_by((.repo | ascii_downcase), .number)) != $cur) then "pending"
               # An unparseable `at` rewrites a fresh pending rather than promoting or waiting. Reading it
               # as epoch 0 made a corrupt timestamp infinitely old and promoted on the next pass, skipping
               # the stabilization window; reading it as "now" never ages, and since the member set is
@@ -640,7 +648,7 @@ runs:
               && ! jq -e -n --argjson m "${marker:-null}" --argjson cur "$cur" \
                    --arg now "$now" --argjson thr "${STABILIZE_SECONDS}" \
                    '($m | type == "object") and $m.status == "pending"
-                    and (($m.members // []) | sort_by(.repo, .number)) == $cur
+                    and (($m.members // []) | sort_by((.repo | ascii_downcase), .number)) == $cur
                     and ($m.at | try (fromdateiso8601 | true) catch false)
                     and (($now | fromdateiso8601) - ($m.at | fromdateiso8601)) >= $thr' >/dev/null 2>&1; then
               echo "::warning::Epic #${EPIC}: the member set moved while this pass was deciding — not freezing a stale set; the next pass re-derives." \

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -175,6 +175,27 @@ reset() {
 run() { write_marker "$(region_file "$payload" "$do")" > "$WORK/out" 2>&1 && echo 0 || echo $?; }
 said() { grep -q "$1" "$WORK/out"; }
 
+# The MEMBERS normalization, lifted from the manifest. It decides what `$cur` IS, so the
+# members-moved branch and both re-derive guards all rest on it — and it had no coverage.
+NORMALIZE_JQ=$(awk '/^ *cur=\$\(printf/{f=1;next} f{print} f&&/\)$/{exit}' "$ACTION" \
+  | sed "s/^[[:space:]]*'//; s/')$//")
+[ -n "$NORMALIZE_JQ" ] || die "could not read the member normalization from $ACTION"
+normalize() { printf '%s' "$1" | jq -c "$NORMALIZE_JQ" 2>/dev/null || echo '[]'; }
+
+echo "the member set is canonical, whatever casing GitHub answers with"
+# GitHub resolves repository names case-insensitively and may answer with either spelling. If the
+# normalized set differs between passes the decision reads "members moved", resets the stabilization
+# clock, and the Epic never freezes — silently, forever.
+mixed='[{"repo":"A-Novel-Kit/repo-b","number":2},{"repo":"a-novel-kit/repo-a","number":1}]'
+lower='[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-a","number":1}]'
+eq "two casings of one set normalize identically" "$(normalize "$mixed")" "$(normalize "$lower")"
+eq "and the stored names are canonical" \
+  "$(normalize "$mixed" | jq -r '[.[].repo] | join(",")')" "a-novel-kit/repo-a,a-novel-kit/repo-b"
+eq "input order does not change the set" \
+  "$(normalize "$lower")" "$(normalize "$(printf '%s' "$lower" | jq -c 'reverse')")"
+eq "a case-variant duplicate is one member" \
+  "$(normalize '[{"repo":"a-novel-kit/R","number":1},{"repo":"a-novel-kit/r","number":1}]' | jq 'length')" 1
+
 echo "the marker contract is shared by three actions"
 # A derived fixture follows merge-gate's fences rather than catching a change in them; what it cannot
 # see is the writer drifting away from the two READERS. Assert the contract across all three.
@@ -466,7 +487,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -ne 72 ]; then
-  echo "::error::$ran assertion(s) ran, expected exactly 72 — the suite did not execute fully (or an assertion was added without raising this)"
+if [ "$ran" -ne 76 ]; then
+  echo "::error::$ran assertion(s) ran, expected exactly 76 — the suite did not execute fully (or an assertion was added without raising this)"
   exit 1
 fi


### PR DESCRIPTION
A latent defect in released code, found while reviewing #339 but independent of it.

## The bug

GitHub resolves repository names case-insensitively and may answer with either spelling. The member set was deduped case-insensitively but kept **whatever casing arrived first**, and sorted **case-sensitively**:

```
["A-Novel-Kit/repo-b", "a-novel-kit/repo-a"]  ->  ["A-Novel-Kit/repo-b", "a-novel-kit/repo-a"]
["a-novel-kit/repo-b", "a-novel-kit/repo-a"]  ->  ["a-novel-kit/repo-a", "a-novel-kit/repo-b"]
```

ASCII sorts uppercase first, so the same two members produce two different arrays.

## Why it matters

Everything downstream compares that set — the decision's members-moved branch, and both re-derive guards in `write_marker`. A difference in *spelling* therefore reads as **"the members changed"**, which resets the stabilization clock on every pass.

So the snapshot never freezes, the Epic silently keeps live membership, and there is no warning — from each individual pass's point of view nothing is wrong. It is the same silent-absorbing-state shape as the corrupt-`at` stall and the unsorted-guard stall, arriving from a third direction.

## The fix

Names are lower-cased when the set is **built**, not merely folded for the dedup, so the stored set is canonical. Safe because every lookup built from it is case-insensitive, and both readers match members by alias index and number rather than by name. The sorts elsewhere are case-folded to match.

## Tests

The suite now lifts the **MEMBERS normalization** out of the manifest — it decides what `$cur` *is*, and had no coverage at all. 72 → 76 assertions.

| Mutant | Result |
| --- | --- |
| restore the original fold-dedup-but-sort-case-sensitively | 2 failed |
| drop the dedup | 1 failed |

> [!NOTE]
> `sort_by` after `unique_by` is a no-op — jq's `unique_by` already sorts by its key — so a mutant removing it survives as an **equivalent**, verified by execution. The explicit sort is kept as documentation of intent.