### PR TITLE
fix(release-train): fail closed on the two reads that could report success

### DIFF
--- a/generic-actions/release-train/action.yaml
+++ b/generic-actions/release-train/action.yaml
@@ -272,17 +272,43 @@ runs:
         # commits). Highest-wins: `!`/BREAKING footer → major; any feat → minor; else patch. Empty range
         # → "none" (skip). Subject-line scan for feat/`!` (a body line starting `feat:` is not a type);
         # full-body scan for the BREAKING-CHANGE footer. Uses the compare API (no checkout).
+        commit_messages() { # $1=api path  $2=jq filter  $3=paginate(true|false)
+          local out attempt
+          for attempt in 1 2 3; do
+            if [ "$3" = "true" ]; then
+              out=$(gh api "$1" --paginate --jq "$2" 2>/dev/null) && { printf '%s' "$out"; return 0; }
+            else
+              out=$(gh api "$1" --jq "$2" 2>/dev/null) && { printf '%s' "$out"; return 0; }
+            fi
+            [ "$attempt" -lt 3 ] && sleep 2
+          done
+          return 1
+        }
+
         derive_bump() { # $1=owner/repo $2=last_tag ("" = first release) $3=default_branch
-          local repo="$1" last="$2" head="$3" subjects bodies
+          local repo="$1" last="$2" head="$3" subjects bodies path paginate jq_bodies jq_subjects
           if [ -z "$last" ]; then
-            # First release: scan the recent default-branch history; default minor if quiet.
-            bodies=$(gh api "repos/$repo/commits" --jq '.[].commit.message' 2>/dev/null || echo "")
-            subjects=$(gh api "repos/$repo/commits" --jq '.[].commit.message | split("\n")[0]' 2>/dev/null || echo "")
-            [ -z "$(printf '%s' "$subjects" | tr -d '[:space:]')" ] && { printf 'minor'; return 0; }
+            # First release: scan the recent default-branch history; default minor if quiet. Not
+            # paginated — answering "is there anything here" does not need the whole history.
+            path="repos/$repo/commits"; paginate=false
+            jq_bodies='.[].commit.message'; jq_subjects='.[].commit.message | split("\n")[0]'
           else
-            bodies=$(gh api "repos/$repo/compare/${last}...${head}" --jq '.commits[].commit.message' 2>/dev/null || echo "")
-            subjects=$(gh api "repos/$repo/compare/${last}...${head}" --jq '.commits[].commit.message | split("\n")[0]' 2>/dev/null || echo "")
-            [ -z "$(printf '%s' "$subjects" | tr -d '[:space:]')" ] && { printf 'none'; return 0; }
+            # Paginated: the compare API pages its commit list, and a feat past the first page would
+            # otherwise be invisible — shipping a minor as a patch.
+            path="repos/$repo/compare/${last}...${head}"; paginate=true
+            jq_bodies='.commits[].commit.message'; jq_subjects='.commits[].commit.message | split("\n")[0]'
+          fi
+          # Fail-closed, like latest_tag and tag_contains. A read that failed is not an empty range;
+          # collapsing the two onto one value let a transient API error read as "nothing to release",
+          # so the repo was skipped, recorded as nochange, and the run stayed green — and because
+          # nothing recorded a failure, a re-dispatch recomputed the same skip forever.
+          if ! bodies=$(commit_messages "$path" "$jq_bodies" "$paginate") \
+            || ! subjects=$(commit_messages "$path" "$jq_subjects" "$paginate"); then
+            printf '__ERR__'; return 0
+          fi
+          if [ -z "$(printf '%s' "$subjects" | tr -d '[:space:]')" ]; then
+            [ -z "$last" ] && { printf 'minor'; return 0; }
+            printf 'none'; return 0
           fi
           if printf '%s\n' "$subjects" | grep -qE '^[[:alpha:]]+(\([^)]*\))?!:' \
             || printf '%s\n' "$bodies" | grep -qE '^BREAKING[ -]CHANGE:'; then printf 'major'
@@ -452,6 +478,11 @@ runs:
 
           # -- Not shipped: derive the bump ---------------------------------------------------------
           bump=$(derive_bump "$repo" "$last" "$default_branch")
+          if [ "$bump" = "__ERR__" ]; then
+            had_failure=true
+            receipts=$(jq -cn --argjson a "$receipts" --arg r "$repo" '$a + [{repo:$r, tag:null, status:"failed:bumpread"}]')
+            echo "- ❌ **${repo}** — commit-range read failed after retries; skipping (fail-closed, never assume nothing-to-release)." | tee -a "$GITHUB_STEP_SUMMARY"; continue
+          fi
           if [ "$bump" = "none" ]; then
             echo "- ⏭️  **${repo}** has nothing new since \`${last}\` — skipping." | tee -a "$GITHUB_STEP_SUMMARY"
             receipts=$(jq -cn --argjson a "$receipts" --arg r "$repo" '$a + [{repo:$r, tag:null, status:"nochange"}]')
@@ -538,11 +569,25 @@ runs:
         if [ "$dry" = "false" ]; then
           block=$(printf '<!-- release-train:receipts:start -->\n### 🚂 Release train — epic:#%s (%s)\n%s\n<!-- release-train:receipts:end -->' \
             "$EPIC" "$(date -u +%Y-%m-%dT%H:%MZ)" "$table")
-          cur=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null || echo "")
-          newbody=$(splice_body "$cur" "$block")
-          printf '%s' "$newbody" | GH_TOKEN="$ISSUE_TOKEN" gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" \
-            --method PATCH --field body=@- >/dev/null 2>&1 \
-            || echo "::warning::could not update the receipt block on epic:#${EPIC} (issues:write?) — the table is still in the run summary."
+          # Abort the write when the read that feeds it failed, as merge-gate and render-epic-status
+          # already do. `|| echo ""` here mapped a failed read onto an empty body, splice_body turned
+          # that into a body holding only the receipt block, and the PATCH then SUCCEEDED — so the
+          # error path never fired while the Epic's prose and its frozen activation snapshot were
+          # overwritten. That snapshot is what epic-membership, merge-gate and detect-partial-landing
+          # read, so losing it degrades the whole landing saga back to live-label membership.
+          #
+          # An empty body read successfully is a different thing and still splices normally; only the
+          # exit status distinguishes them, which is why the guard is on the status and not on "$cur".
+          # The receipts are a best-effort audit — the same table is already in the run summary — so
+          # declining to write is strictly safer than writing one derived from a failure.
+          if ! cur=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null); then
+            echo "::warning::could not read epic:#${EPIC} — leaving its body untouched; the receipt table is in the run summary."
+          else
+            newbody=$(splice_body "$cur" "$block")
+            printf '%s' "$newbody" | GH_TOKEN="$ISSUE_TOKEN" gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" \
+              --method PATCH --field body=@- >/dev/null 2>&1 \
+              || echo "::warning::could not update the receipt block on epic:#${EPIC} (issues:write?) — the table is still in the run summary."
+          fi
         fi
 
         # ================= 4. Final status =========================================================

--- a/tests/release-train.sh
+++ b/tests/release-train.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Regression tests for release-train's fail-closed reads.
+#
+# Same discipline as detect-partial-landing.sh: the functions under test are EXTRACTED verbatim from
+# the manifest and sourced, so what runs here is what ships. Only `gh` is stubbed, and it can fail on
+# demand — the whole point being that a read failure must not be readable as a benign outcome.
+#
+# Two defects are covered, and they share a shape. derive_bump mapped a failed commit-range read onto
+# the same value as an empty range ("none"), so a transient API error skipped a repo, recorded it as
+# nochange, and left the run green — and since nothing marked a failure, a re-dispatch recomputed the
+# same skip forever. splice_body is the other end of it: fed the empty body a failed read produced, it
+# returns a body holding only the receipt block, which the PATCH would then write over the Epic's
+# prose and its frozen activation snapshot.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION="${1:-$ROOT/generic-actions/release-train/action.yaml}"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+extract() { # $1 = function name — lift it out of the run: block and de-indent
+  awk -v n="$1" '
+    $0 ~ "^        "n"\\(\\) \\{" {f=1}
+    f {print}
+    f && /^        \}$/ {exit}
+  ' "$ACTION" | sed 's/^        //'
+}
+
+for fn in commit_messages derive_bump splice_body; do
+  out=$(extract "$fn")
+  if [ -z "$out" ]; then
+    echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
+    exit 1
+  fi
+  printf '%s\n' "$out" >> "$WORK/lib.sh"
+done
+# Extraction stops at the first 8-space `}`. If that ever lands mid-function the result is invalid
+# bash, and without this check the suite fails later with a confusing unbound-variable abort.
+if ! bash -n "$WORK/lib.sh"; then
+  echo "::error::extracted functions do not parse — extraction truncated a definition"
+  exit 1
+fi
+
+sleep() { :; } # the retry loop's wall-clock delay is not useful here
+
+# ---- stubbed leaf -----------------------------------------------------------------------
+# GH_FAIL=1 makes every read fail, which is the condition both defects hid behind.
+# GH_SUBJECTS holds the commit messages a successful read returns.
+GH_FAIL=0
+GH_SUBJECTS=""
+gh() {
+  if [ "$GH_FAIL" = "1" ]; then
+    return 22 # gh's exit status for a failed API call
+  fi
+  printf '%s' "$GH_SUBJECTS"
+}
+
+# shellcheck source=/dev/null
+. "$WORK/lib.sh"
+
+fails=0
+check() { # $1=label $2=expected $3=actual
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected [$2], got [$3]"
+    fails=$((fails + 1))
+  fi
+}
+
+echo "== derive_bump: a failed read is not an empty range =="
+
+GH_FAIL=1
+check "read failure yields __ERR__, not none" "__ERR__" "$(derive_bump a/b v1.0.0 master)"
+check "read failure on a first release yields __ERR__, not minor" "__ERR__" "$(derive_bump a/b '' master)"
+
+GH_FAIL=0
+GH_SUBJECTS=""
+check "a genuinely empty range still yields none" "none" "$(derive_bump a/b v1.0.0 master)"
+check "a quiet first release still yields minor" "minor" "$(derive_bump a/b '' master)"
+
+GH_SUBJECTS="fix(dao): tighten a predicate"
+check "fix yields patch" "patch" "$(derive_bump a/b v1.0.0 master)"
+
+GH_SUBJECTS="feat(core): add an endpoint"
+check "feat yields minor" "minor" "$(derive_bump a/b v1.0.0 master)"
+
+GH_SUBJECTS="feat(proto)!: drop a field"
+check "bang yields major" "major" "$(derive_bump a/b v1.0.0 master)"
+
+GH_SUBJECTS="fix(x): y
+BREAKING CHANGE: z"
+check "BREAKING footer yields major" "major" "$(derive_bump a/b v1.0.0 master)"
+
+echo "== commit_messages: retries, then reports failure rather than an empty result =="
+
+GH_FAIL=1
+commit_messages "repos/a/b/commits" '.[]' false
+check "returns non-zero when every attempt fails" "1" "$?"
+
+echo "== splice_body: an empty body is a body-shaped hole =="
+
+BLOCK='<!-- release-train:receipts:start -->
+### receipts
+<!-- release-train:receipts:end -->'
+
+# This is what the PATCH used to write when the read failed. The assertion is not that splice_body is
+# wrong — given an empty body it can only produce this — but that the result is destructive, which is
+# why the caller has to refuse to reach it.
+spliced=$(splice_body "" "$BLOCK")
+case "$spliced" in
+  *"human prose"*) check "empty input keeps prose" "impossible" "kept" ;;
+  *) echo "  ok   an empty body yields a block-only body (the destructive case the caller must avoid)" ;;
+esac
+
+# The healthy paths still behave: prose survives, and the region is replaced rather than appended.
+BODY='Some human prose.
+
+<!-- release-train:receipts:start -->
+### old receipts
+<!-- release-train:receipts:end -->'
+spliced=$(splice_body "$BODY" "$BLOCK")
+case "$spliced" in
+  *"Some human prose."*) echo "  ok   prose survives a replace" ;;
+  *) echo "  FAIL prose was dropped on replace"; fails=$((fails + 1)) ;;
+esac
+case "$spliced" in
+  *"old receipts"*) echo "  FAIL stale receipts accumulated"; fails=$((fails + 1)) ;;
+  *) echo "  ok   the stale region was replaced, not appended" ;;
+esac
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "::error::$fails assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
Closes #332
Closes #333

Both defects live in the same 50 lines of `release-train/action.yaml` and are the same shape — a
failed read mapped onto the encoding of a benign outcome — so they land together rather than as two
PRs conflicting over one file.

## #332 — a failed commit-range read read as "nothing to release"

`derive_bump` was the only read in the action that was not fail-closed. Its siblings all retry three
times and signal the failure: `latest_tag` returns `__ERR__`, `tag_contains` returns 2,
`default_branch` aborts the repo — each setting `had_failure`. `derive_bump` had no retry, discarded
stderr, and returned the same `"none"` a genuinely empty range produces.

The consequence is worse than a skipped repo. `"none"` takes the *skip* branch, which records the
repo as `nochange` and **does not set `had_failure`** — so the run prints "Release train complete" and
goes green with the Epic shipped in three repos out of four. And because nothing recorded a failure,
the documented "re-dispatch to resume" recovery recomputes the same skip forever.

Now retried and returning `__ERR__`, mapped by the caller to `failed:bumpread` + `had_failure`.

## #333 — a failed body read overwrote the Epic

```bash
cur=$(gh api ".../issues/${EPIC}" --jq '.body // ""' 2>/dev/null || echo "")
newbody=$(splice_body "$cur" "$block")
printf '%s' "$newbody" | gh api ... --method PATCH ... || echo "::warning::..."
```

`|| echo ""` turns a failed read into an empty body; `splice_body` given an empty body can only return
a body holding the receipt block alone; and the PATCH then **succeeds** — so the `|| echo "::warning::"`
never fires while the Epic's human prose and its `<!-- epic-membership:snapshot:start -->` frozen
activation snapshot are overwritten.

That snapshot is what `epic-membership`, `merge-gate` and `detect-partial-landing` read. Losing it
silently degrades the landing saga back to live-label membership — reintroducing exactly the failure
`epic-membership`'s docs describe, where a member abandoned mid-landing can vanish from the set.

The write is now skipped when the read fails, matching `merge-gate` and `render-epic-status`, which
both already refuse to write on a failed read.

**Guarded on the exit status, not on `"$cur"`.** An Epic whose body is genuinely empty is a different
thing and must still splice normally; only the status separates them. I did not add the defensive
guard inside `splice_body` that the issue suggested, because `splice_body` cannot distinguish the two
either — the caller is the only place that can.

## Also

The compare read is now `--paginate`. Previously a `feat` past the first page was invisible, so a
minor could ship as a patch. The first-release scan is deliberately *not* paginated — answering "is
there anything here at all" does not need the whole history.

## Test plan

The action had **no test suite**. `tests/release-train.sh` follows `detect-partial-landing.sh`:
functions extracted verbatim from the manifest, only `gh` stubbed, and the stub can fail on demand —
since failing closed is the property under test.

- [x] Both `__ERR__` assertions **fail against the previous collapse**, returning `none` and `minor`
      for a read that never succeeded (verified by restoring the old `|| echo ""`)
- [x] A genuinely empty range still yields `none`; a quiet first release still yields `minor`
- [x] `fix`/`feat`/`!`/`BREAKING CHANGE` still map to patch/minor/major
- [x] `splice_body` still preserves prose and replaces rather than accumulates the stale region
- [x] `test-actions` globs `tests/*.sh`, so the suite is picked up with no wiring
- [x] No `vars`/`secrets`/`needs`/`matrix` context introduced — `lint-action-manifests` stays green
- [x] `prettier --check` passes
- [ ] CI green

**Not covered:** the `had_failure` wiring and the receipt-write branch are caller-level control flow
in the main `run:` block, not extractable functions. The suite proves `derive_bump` reports the
failure; that the caller acts on it is a read.