### PR TITLE
fix(detect-partial-landing): scope history to the current wave

### DIFF
--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -26,6 +26,17 @@ description: >
   REACHES an Epic through live labels, so an Epic whose last labeled open pull request is de-labeled
   drops out of enumeration altogether — the snapshot rescues a forgotten member, not a forgotten Epic.
 
+  HISTORY is scoped to the WAVE, membership is not. A merged pull request keeps its `epic:<N>` label
+  for good, so an unbounded `is:merged` search reports every wave the Epic has ever landed: `merged >= 1`
+  would be permanently true and the grace clock would run from the first merge EVER, making the first
+  sibling of a second wave a stray past grace on the pass it appears — frozen by a required check, every
+  sweep, forever. The marker therefore carries a WAVE BOUNDARY (`since`), the instant a previous wave
+  retired; terminal pull requests before it are not this wave's history. It scopes the two history
+  searches and nothing else: the open search is unscoped (an open pull request is not history), and the
+  frozen set is never time-filtered — it IS the current wave, so the union above widens membership
+  without widening history. No boundary (before the first retirement, or a marker carrying none) means
+  the Epic's whole history is one wave, which is exactly right for the first one.
+
   The freeze is a check-run, not a status: an `epic-freeze` check-run (checks:write) posted with
   `conclusion: failure` — never `neutral`, which GitHub counts as a passing required check — on a
   different context from `merge-gate` so the two required checks never clobber. Posted on a live
@@ -467,13 +478,17 @@ runs:
         # commonly omits them. Substituting it would empty the `merged` bucket that gates all detection.
         #
         # Prints nothing; fills SNAP_MERGED / SNAP_CLOSED / SNAP_OPEN with the node shape search_prs
-        # returns (repository.nameWithOwner, number, headRefOid, mergedAt, baseRefName, isDraft).
+        # returns (repository.nameWithOwner, number, headRefOid, mergedAt, baseRefName, isDraft), plus
+        # SNAP_SINCE with the wave boundary. The boundary is read on EVERY rc, including the ones that
+        # report no usable frozen set: a `retired` tombstone names no members and exists only to carry it.
         # Returns 0 = frozen set resolved, 2 = no usable snapshot (the live floor stands on its own),
         # 1 = a frozen set exists but could NOT be resolved. On 1 the caller leaves EV_DECISION=error,
         # which the sweep treats as "post nothing this pass" (a standing freeze survives) and per-PR as
         # fail-open on the head — so 1 costs a pass, never a false clear in the sweep.
-        # The marker contract (fence names, `status`, `members`) is shared with epic-membership and
-        # merge-gate — a change to its shape has to land in all three.
+        # The marker contract (fence names, `status`, `members`, `since`) is shared with epic-membership
+        # and merge-gate — a change to its shape has to land in all three. `since` is additive and both
+        # membership readers ignore it: they select on `status` and `members` alone, so a marker carrying
+        # it resolves there exactly as one without.
         snapshot_buckets() { # $1 = epic number
           # The fence strings, matched as WHOLE LINES. An unanchored match would let a pseudo-fence
           # planted inside an HTML comment shadow the real region on every read while staying
@@ -483,7 +498,9 @@ runs:
           SNAP_MERGED='[]'
           SNAP_CLOSED='[]'
           SNAP_OPEN='[]'
+          SNAP_SINCE=''
           local resp="" err="" errf body="" ok=false marker frozen want alias_q rh out nodes
+          local since="" since_epoch="" shown=""
           errf=$(mktemp)
           for attempt in 1 2 3; do
             # Keep the streams apart: stdout is the payload, stderr is diagnosis. Folding them together
@@ -529,6 +546,45 @@ runs:
             | awk -v s="$START_M" -v e="$END_M" '$0 == s {f=1;next} $0 == e {f=0} f' \
             | sed -n '/^[[:space:]]*[{[]/,$p' \
             | jq -s -c '.[0] // empty' 2>/dev/null || true)
+
+          # The WAVE BOUNDARY, read from ANY well-formed marker whatever its `status`, and read HERE —
+          # ahead of the frozen-only returns below — because the paths that report no frozen set need it
+          # most. A `retired` tombstone names no members and exists ONLY to carry this instant; a
+          # pending/frozen marker carries it forward from the tombstone it replaced, since merge-gate
+          # splices the whole region and a boundary not carried forward dies with the next capture.
+          # Canonicalized once, right here: the caller appends it to a search query and never re-parses it.
+          since=$(printf '%s' "$marker" | jq -r 'if type == "object" then (.since // empty) else empty end' 2>/dev/null || true)
+          if [ -n "$since" ]; then
+            # A malformed time qualifier is the dangerous input, not an obviously broken one: GitHub
+            # answers `merged:>=garbage` — and `merged:>=2026-13-45T99:00:00Z`, which passes any
+            # shape-only check — with ZERO results and NO `errors` array, so nothing in search_prs can
+            # tell it from a genuinely empty bucket. That bucket is what every decision hangs on, and an
+            # empty one reads as "nothing has landed" → `clear`, which POSTS success and lifts a standing
+            # freeze. A future instant does the same while looking well-formed. So only a value in the
+            # exact form merge-gate emits, that a calendar accepts, and that is not ahead of this run
+            # reaches a query; anything else is dropped for unbounded history, which errs toward freezing.
+            # Everything shown below is attacker-controlled — the marker lives in an issue body. jq -r
+            # renders an embedded \n as a REAL newline and GitHub reads workflow commands line by line,
+            # so echoing the raw value would let a crafted boundary forge its own `::error::` or
+            # `::stop-commands::` line on the very path that REJECTS it. Show one bounded line instead.
+            shown=$(printf '%s' "$since" | tr -d '\r\n' | cut -c1-64)
+            if ! [[ "$since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+              echo "::warning::epic #$1: the snapshot's wave boundary \"${shown}\" is not an ISO-8601 UTC instant (YYYY-MM-DDTHH:MM:SSZ) — ignoring it and scoping to the Epic's whole history."
+            elif ! since_epoch=$(date -u -d "$since" +%s 2>/dev/null); then
+              echo "::warning::epic #$1: the snapshot's wave boundary \"${shown}\" is not a real date — ignoring it and scoping to the Epic's whole history."
+            # Compared against the clock this STEP started on, plus a skew allowance: a sweep can be
+            # minutes into the step by the time it reaches an Epic, so a tombstone merge-gate wrote
+            # moments ago would otherwise read as "the future" and be discarded for no reason — costing
+            # a pass of unbounded history, which re-freezes the next wave until the following sweep.
+            # What this check is actually for is a boundary far enough ahead to hide REAL history, and
+            # a few minutes hides a few minutes of merges, well inside the grace window either way.
+            elif [ "$since_epoch" -gt "$(( now_epoch + 300 ))" ]; then
+              echo "::warning::epic #$1: the snapshot's wave boundary \"${shown}\" is in the FUTURE — ignoring it (it would hide every merge this Epic has) and scoping to the Epic's whole history."
+            else
+              SNAP_SINCE="$since"
+            fi
+          fi
+
           [ -n "$marker" ] || return 2
           # Only a well-formed FROZEN marker counts. A pending marker (the set has not settled yet), a
           # hand-edited one, or the wrong shape falls back to the live floor rather than crashing.
@@ -747,22 +803,16 @@ runs:
           local EPIC="$1"
           local base_q="label:\"epic:${EPIC}\" org:${ORG}"
 
-          # The live label set is the FLOOR. Widened resolve, three passes: is:closed is:unmerged
-          # catches the closed-without-merge blind spot; is:merged and is:open complete the picture.
-          # Any failure → EV_DECISION stays error.
+          # The snapshot is resolved FIRST because it carries the wave boundary the searches below are
+          # scoped by. It is otherwise added ON TOP of the live floor, never swapped for it: it
+          # contributes the members live truth has forgotten — a de-labeled one stays a member — and
+          # nothing else. The union is what makes MEMBERSHIP monotone: no snapshot, however degraded or
+          # incomplete, can shrink the member set the detector already saw, so the worst case is the
+          # behaviour that predates it. A straight substitution would not be safe, because a frozen set
+          # is not a superset of the live one: merge-gate captures it from OPEN pull requests after the
+          # set holds still, while auto-merge is armed earlier, so already-merged members are commonly
+          # absent from it — and `merged >= 1` is the precondition every decision below hangs on.
           local merged closed_unmerged open membership=live snap_rc=0
-          if ! merged=$(search_prs "is:pr is:merged $base_q"); then return 0; fi
-          if ! closed_unmerged=$(search_prs "is:pr is:closed is:unmerged $base_q"); then return 0; fi
-          if ! open=$(search_prs "is:pr is:open $base_q"); then return 0; fi
-
-          # The frozen snapshot is added ON TOP of that floor, never swapped for it. It contributes the
-          # members live truth has forgotten — a de-labeled one stays a member — and nothing else. The
-          # union is what makes this monotone: no snapshot, however degraded or incomplete, can shrink
-          # what the detector already saw, so the worst case is the behaviour that predates it. A
-          # straight substitution would not be safe, because a frozen set is not a superset of the live
-          # one: merge-gate captures it from OPEN pull requests after the set holds still, while
-          # auto-merge is armed earlier, so already-merged members are commonly absent from it — and
-          # `merged >= 1` is the precondition every decision below hangs on.
           snapshot_buckets "$EPIC" || snap_rc=$?
           case "$snap_rc" in
             0) membership=live+snapshot ;;
@@ -771,6 +821,9 @@ runs:
             # `liveMember` is present on every node no matter which path produced it. Tagging only on the
             # snapshot path once left these nodes untagged, and since jq reads a missing key as null, the
             # roll-forward silently selected nothing while its skip-warning selected everything.
+            # SNAP_SINCE is deliberately NOT reset alongside these: rc 2 is exactly the tombstone case —
+            # a `retired` marker has no members to bucket and exists only to carry the boundary — so
+            # clearing it here for symmetry would discard the one thing that path is there to deliver.
             2) SNAP_MERGED='[]'; SNAP_CLOSED='[]'; SNAP_OPEN='[]' ;;
             *)
               # A frozen set exists (or might) and could not be resolved. Deciding on the live floor
@@ -781,6 +834,29 @@ runs:
               return 0
               ;;
           esac
+
+          # The live label set is the FLOOR. Widened resolve, three passes: is:closed is:unmerged
+          # catches the closed-without-merge blind spot; is:merged and is:open complete the picture.
+          # Any failure → EV_DECISION stays error.
+          # The two TERMINAL passes are bounded by the wave boundary, so a previous wave's merges and
+          # abandonments are not read as this wave's. Everything else follows from that one scope:
+          # `first_merged_at` is already a `min` over the merged bucket, so grace starts at THIS wave's
+          # first merge, and strays are already gated on `merged >= 1`, so a sibling of a wave that has
+          # not started landing is not a stray at all. The open pass is deliberately unbounded — an open
+          # pull request is not history, and a member can have been opened long before its wave began.
+          local merged_floor="" closed_floor=""
+          if [ -n "${SNAP_SINCE:-}" ]; then
+            merged_floor=" merged:>=${SNAP_SINCE}"
+            closed_floor=" closed:>=${SNAP_SINCE}"
+          fi
+          if ! merged=$(search_prs "is:pr is:merged $base_q$merged_floor"); then return 0; fi
+          if ! closed_unmerged=$(search_prs "is:pr is:closed is:unmerged $base_q$closed_floor"); then return 0; fi
+          if ! open=$(search_prs "is:pr is:open $base_q"); then return 0; fi
+          # The snapshot's own buckets enter UNFILTERED by the boundary, and must: a frozen set is the
+          # current wave by construction (retirement is what writes a boundary, and it removes the set it
+          # retires), so every member it names belongs here whenever it merged. Filtering them would let
+          # the boundary shrink MEMBERSHIP — the one thing the union exists to prevent — and would drop
+          # exactly the abandoned member the snapshot is kept for.
           local buckets
           if ! buckets=$(union_buckets "$merged" "$closed_unmerged" "$open" \
             "$SNAP_MERGED" "$SNAP_CLOSED" "$SNAP_OPEN"); then
@@ -856,7 +932,11 @@ runs:
             fi
           fi
 
-          echo "epic #$EPIC: membership=$membership merged=$EV_MERGED_COUNT closed_unmerged=$EV_CLOSED_COUNT open=$EV_OPEN_COUNT stray=$EV_STRAY_COUNT grace_elapsed=$grace_elapsed" \
+          # wave_since is logged separately from `membership`, not folded into it: a tombstone yields a
+          # boundary and NO frozen set, so `membership=live` alongside a boundary is the normal shape
+          # between waves, and a pass that read the marker would otherwise be indistinguishable from one
+          # that found nothing.
+          echo "epic #$EPIC: membership=$membership wave_since=${SNAP_SINCE:-none} merged=$EV_MERGED_COUNT closed_unmerged=$EV_CLOSED_COUNT open=$EV_OPEN_COUNT stray=$EV_STRAY_COUNT grace_elapsed=$grace_elapsed" \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
           # Predicate: needs >=1 merged sibling (nothing has landed otherwise); then a closed-unmerged

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -96,12 +96,25 @@ search_prs() {
     closed) case "$1" in *is:unmerged*) return 1 ;; esac ;;
     open) case "$1" in *is:open*) return 1 ;; esac ;;
   esac
+  local bucket floor
   case "$1" in
-    *is:merged*) printf '%s' "$FX_LIVE_MERGED" ;;
-    *is:unmerged*) printf '%s' "$FX_LIVE_CLOSED" ;;
-    *is:open*) printf '%s' "$FX_LIVE_OPEN" ;;
+    *is:merged*) bucket="$FX_LIVE_MERGED" ;;
+    *is:unmerged*) bucket="$FX_LIVE_CLOSED" ;;
+    *is:open*) bucket="$FX_LIVE_OPEN" ;;
     *) echo "unexpected search: $1" >&2; return 1 ;;
   esac
+  # Apply the time qualifier the way GITHUB does, not the way the action hopes it does. Asserting the
+  # substring `merged:>=…` appears in the query would pass just as well if the qualifier were inert —
+  # and it is not: a bad one silently returns zero rows. Filtering here is what lets the wave-boundary
+  # assertions below run the real predicate against real truth.
+  # ISO-8601 UTC sorts chronologically, so a string compare IS the date compare (the action's own grace
+  # clock leans on the same property). A node with no terminal timestamp is KEPT: GitHub always has one,
+  # so an undated fixture means "not what this assertion is about", and dropping it would quietly
+  # rewrite the meaning of every fixture written before the boundary existed.
+  floor=$(printf '%s' "$1" | sed -n 's/.*\(merged\|closed\):>=\([^ ]*\).*/\2/p')
+  [ -n "$floor" ] && bucket=$(printf '%s' "$bucket" | jq -c --arg f "$floor" \
+    '[.[] | select((.mergedAt // .closedAt // "9999") >= $f)]')
+  printf '%s' "$bucket"
 }
 merge_queue_entries() { # $1=owner $2=repo $3=base
   [ "$FX_QUEUE_FAIL" = true ] && return 1
@@ -128,9 +141,15 @@ rest_pr_state() {
 #   timeline = de-labeled now, but its timeline records having been labeled (the regression case)
 #   label    = still carries the label
 #   none     = neither — a pull request named by the marker that was never a member
-node() { # repo number state [mergedAt] [prov: timeline|label|none]
+node() { # repo number state [terminalAt] [prov: timeline|label|none]
+  # `terminalAt` is when the pull request reached its terminal state — it fills `mergedAt` for a MERGED
+  # one and `closedAt` otherwise, which is how GitHub reports them (a merged PR carries both, equal).
+  # `closedAt` is not in the action's search-node shape and it never reads it; it exists so the stub
+  # above can apply a `closed:>=` floor, which the real search applies server-side.
   jq -cn --arg r "$1" --argjson n "$2" --arg s "$3" --arg m "${4:-}" --arg p "${5:-timeline}" --arg e "epic:900" \
-    '{number:$n, headRefOid:("sha"+($n|tostring)), mergedAt:(if $m=="" then null else $m end),
+    '{number:$n, headRefOid:("sha"+($n|tostring)),
+      mergedAt:(if $m=="" or $s!="MERGED" then null else $m end),
+      closedAt:(if $m=="" or $s=="OPEN" then null else $m end),
       baseRefName:"master", isDraft:false, state:$s, repository:{nameWithOwner:$r},
       labels:{nodes:(if $p=="label" then [{name:$e}] else [] end)},
       timelineItems:{nodes:(if $p=="timeline" then [{label:{name:$e}}] else [] end)}}'
@@ -144,20 +163,30 @@ rehydrate() { # the aliased re-read response, one alias per member
 # parses the whole region as JSON chokes on it. A fixture that omits the note agrees with whatever the
 # reader happens to do and can never catch that, which is how a parser change once made the feature
 # silently inert end to end. Frozen payloads carry no `at`; only pending does.
-marker() { # status members-json
+marker() { # status members-json [since]
+  # `since` is the wave boundary. It is OPTIONAL on every status, because that is the shape the reader
+  # has to survive: it is absent on a first wave, present on a tombstone, and carried forward onto the
+  # pending / frozen markers that replace one.
   local payload note
-  if [ "$1" = frozen ]; then
-    payload=$(jq -cn --argjson m "$2" '{status:"frozen", members:$m}')
+  if [ "$1" = retired ]; then
+    payload=$(jq -cn --arg since "${3:-}" '{status:"retired"} + (if $since=="" then {} else {since:$since} end)')
+    note='_Epic membership, RETIRED — this wave has landed; the next ready set freezes its own. Do not edit._'
+  elif [ "$1" = frozen ]; then
+    payload=$(jq -cn --argjson m "$2" --arg since "${3:-}" \
+      '{status:"frozen", members:$m} + (if $since=="" then {} else {since:$since} end)')
     note='_Epic membership, FROZEN at activation by the merge-gate. The authoritative set for this landing — a later de-label, close, or relabel does not change it. Do not edit._'
   else
-    payload=$(jq -cn --arg s "$1" --argjson m "$2" '{status:$s, at:"2026-07-20T10:00:00Z", members:$m}')
+    payload=$(jq -cn --arg s "$1" --argjson m "$2" --arg since "${3:-}" \
+      '{status:$s, at:"2026-07-20T10:00:00Z", members:$m} + (if $since=="" then {} else {since:$since} end)')
     note='_Epic membership, PENDING — stabilizing before it freezes (the label index is eventually consistent). Do not edit._'
   fi
   printf '<!-- epic-membership:snapshot:start -->\n%s\n%s\n<!-- epic-membership:snapshot:end -->\n' "$note" "$payload"
 }
 
 AGO40=$(date -u -d '-40 minutes' +%Y-%m-%dT%H:%M:%SZ)
+AGO20=$(date -u -d '-20 minutes' +%Y-%m-%dT%H:%M:%SZ) # a wave boundary: after AGO40, before AGO5
 AGO5=$(date -u -d '-5 minutes' +%Y-%m-%dT%H:%M:%SZ)
+AHEAD=$(date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ)
 A=$(node a-novel-kit/repo-a 1 MERGED "$AGO40")
 B=$(node a-novel-kit/repo-b 2 CLOSED) # the abandoned member: closed unmerged, label removed
 C=$(node a-novel-kit/repo-c 3 OPEN)
@@ -431,9 +460,172 @@ check "an unparseable merge time never elapses grace" clear live 1/0/1
 reset_fixtures
 
 echo
+echo "the wave boundary: history is scoped to the wave, membership is not"
+# The regression that makes a second wave impossible. A merged pull request keeps its epic:<N> label, so
+# an unbounded is:merged search reports the PREVIOUS wave forever: merged>=1 stays true, grace runs from
+# the first merge EVER, and the first sibling of the next wave is a stray past grace on the very pass it
+# appears — frozen by a required check, re-frozen every sweep, with nothing the author can do about it.
+FX_QUEUE='[]'                                                   # the new sibling is labelled, not queued
+FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO40")]" # the previous wave: landed, past grace
+check "without a boundary, a new sibling is frozen on the last wave" frozen live 1/0/1
+FX_BODY=$(marker retired '[]' "$AGO20")
+check "the tombstone ends that history, and it is gated normally" clear live 0/0/1
+reset_fixtures
+
+echo
+echo "a partial landing INSIDE the wave still freezes"
+FX_BODY=$(marker retired '[]' "$AGO20")
+FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO5")]"
+FX_LIVE_CLOSED="[$(node a-novel-kit/repo-b 2 CLOSED "$AGO5")]"
+check "a member closed after the boundary is this wave's abandonment" frozen live 1/1/1
+[ "$EV_REASON" = "a member was closed without merging" ] \
+  && ok "and for the right reason" || ko "wrong reason: $EV_REASON"
+# The closed bucket carries the identical disease and is scoped identically: an abandonment a human has
+# already dealt with must not re-freeze every wave that follows it.
+FX_LIVE_CLOSED="[$(node a-novel-kit/repo-b 2 CLOSED "$AGO40")]"
+check "the same member closed before it belongs to the retired wave" clear live 1/0/1
+reset_fixtures
+
+echo
+echo "grace runs from THIS wave's first merge"
+FX_QUEUE='[]'
+FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/repo-d#4":"closed true"}')
+FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO40"),$(node a-novel-kit/repo-d 4 MERGED "$AGO5")]"
+check "unbounded, the oldest merge of all elapses grace" frozen live 2/0/1
+FX_BODY=$(marker retired '[]' "$AGO20")
+check "bounded, the clock starts at the merge inside the wave" clear live 1/0/1
+reset_fixtures
+
+echo
+echo "the boundary is read from every marker status, not only the tombstone"
+# merge-gate splices the whole region, so the tombstone is destroyed the moment the next wave captures a
+# marker of its own. A boundary that is not carried forward onto that marker dies with it, and the
+# permanent freeze returns one pass later — which is why the reader takes it from any status.
+FX_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=$(rehydrate "$B" "$C")
+check "a frozen marker with no boundary reads the whole history" frozen live+snapshot 1/1/1
+FX_BODY=$(marker frozen "$BC" "$AGO20")
+check "the same marker carrying one drops the retired wave" clear live+snapshot 0/1/1
+reset_fixtures
+FX_BODY=$(marker pending "$BC" "$AGO20")
+check "a pending marker carries it too, membership still live" clear live 0/0/1
+reset_fixtures
+
+echo
+echo "the boundary bounds HISTORY, never the frozen set"
+# The frozen set IS the current wave: retirement is what writes a boundary, and it removes the set it
+# retires. Time-filtering it here would let the boundary shrink MEMBERSHIP — the one thing the union
+# exists to prevent — and would drop exactly the abandoned member the snapshot is kept for.
+FX_LIVE_MERGED='[]'
+FX_BODY=$(marker frozen "$BC" "$AGO20")
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 MERGED "$AGO40")" "$C")
+check "a frozen member that merged before the boundary still counts" clear live+snapshot 1/0/1
+reset_fixtures
+
+echo
+echo "which searches the boundary reaches"
+FX_BODY=$(marker retired '[]' "$AGO20")
+: > "$WORK/searches"
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+[ "$(grep -cF "merged:>=$AGO20" "$WORK/searches")" = 1 ] \
+  && ok "the merged search is bounded" || ko "the merged search is not bounded by the boundary"
+[ "$(grep -cF "closed:>=$AGO20" "$WORK/searches")" = 1 ] \
+  && ok "the closed-unmerged search is bounded" || ko "the closed-unmerged search is not bounded"
+grep 'is:open' "$WORK/searches" | grep -q ':>=' \
+  && ko "the open search is bounded — but an open pull request is not history" \
+  || ok "and the open search is left unbounded"
+reset_fixtures
+
+echo
+echo "an unusable boundary is ignored, and never reaches a query"
+# The dangerous input is not an obviously broken one. GitHub answers a malformed time qualifier — and a
+# well-shaped impossible date — with ZERO rows and NO errors array, indistinguishable from a genuinely
+# empty bucket. That bucket gates every decision, and an empty one reads as "nothing has landed" →
+# `clear` → which POSTS success and lifts a standing freeze. Falling back to unbounded history is the
+# safe direction: it errs toward freezing. fd 6 keeps this loop's input clear of evaluate_epic's own.
+FX_QUEUE='[]'
+FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO40")]"
+while IFS='|' read -r why bad <&6; do
+  [ -n "$why" ] || continue
+  FX_BODY=$(marker retired '[]' "$bad")
+  : > "$WORK/searches"
+  check "$why" frozen live 1/0/1
+  grep -q ':>=' "$WORK/searches" \
+    && ko "  …but it reached a query anyway" || ok "  …with no floor in any query"
+done 6<<EOF
+not a timestamp at all|garbage
+a relative date the calendar happily accepts|yesterday
+a well-formed shape that is not a real date|2026-13-45T99:00:00Z
+a date with no time (one canonical form only)|2026-07-01
+an instant in the future|$AHEAD
+a trailing search qualifier|2026-07-01T00:00:00Z org:attacker
+a quote that would close the qualifier|2026-07-01T00:00:00Z"
+EOF
+# Not merely "no floor": the injected text must be nowhere in the grammar. `org:` is the scope that
+# bounds membership to this org, so a second one would widen the member set to a repository the marker's
+# author controls.
+FX_BODY=$(marker retired '[]' '2026-07-01T00:00:00Z org:attacker')
+: > "$WORK/searches"
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+grep -q 'attacker' "$WORK/searches" \
+  && ko "an injected qualifier reached the search grammar" \
+  || ok "an injected qualifier never reaches the search grammar"
+# Rejecting a value is not enough if REPORTING it is itself the vector. The marker lives in an issue
+# body, jq -r turns an embedded \n into a real newline, and GitHub reads workflow commands line by line
+# — so an unsanitized warning would let the boundary forge a command on the path that rejects it.
+# Captured in `$( )`, so EV_* never reach this shell: only the log is under test here.
+FX_BODY=$(marker retired '[]' "$(printf '2026-07-01T00:00:00Z\n::error::forged')")
+check "a boundary carrying a newline is rejected" frozen live 1/0/1
+out=$(evaluate_epic 900 2>&1)
+: > "$GITHUB_STEP_SUMMARY"
+printf '%s\n' "$out" | grep -q '^::error::forged' \
+  && ko "a newline in the boundary forged a workflow command" \
+  || ok "and reporting it cannot forge a workflow command"
+reset_fixtures
+
+echo
+echo "the boundary is compared against a clock that is already minutes old"
+# now_epoch is read when the STEP starts; a sweep is often minutes into it by the time it reaches an
+# Epic. Without a skew allowance a tombstone merge-gate wrote moments ago reads as "the future" and is
+# thrown away — costing a pass of unbounded history, which re-freezes the next wave until the sweep
+# after. The guard exists for a boundary far enough ahead to hide real history, not for that race.
+FX_QUEUE='[]'
+FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO40")]"
+FX_BODY=$(marker retired '[]' "$(date -u -d '+2 minutes' +%Y-%m-%dT%H:%M:%SZ)")
+check "a boundary inside the skew allowance is honoured" clear live 0/0/1
+FX_BODY=$(marker retired '[]' "$AHEAD")
+check "one an hour ahead is still refused" frozen live 1/0/1
+reset_fixtures
+
+echo
+echo "the boundary does not leak between Epics in one sweep process"
+FX_BODY=$(marker retired '[]' "$AGO20")
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+FX_BODY="" # the next Epic in the same sweep has no marker at all
+: > "$WORK/searches"
+evaluate_epic 901 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+[ -z "$SNAP_SINCE" ] && ok "the next Epic starts with no boundary" || ko "SNAP_SINCE leaked: $SNAP_SINCE"
+grep -q ':>=' "$WORK/searches" \
+  && ko "the previous Epic's boundary bounded this one's searches" \
+  || ok "and its searches are unbounded"
+reset_fixtures
+
+echo
 echo "a degraded marker falls back to the live floor — never a crash, never a freeze on garbage"
 FX_BODY=$(marker pending "$BC")
 check "a pending marker (the set has not settled)" clear live 1/0/1
+# A tombstone is the one marker whose whole purpose is the boundary; carrying none it says nothing, and
+# saying nothing must mean the Epic's whole history, not an empty one.
+FX_BODY=$(marker retired '[]')
+check "a tombstone carrying no boundary" clear live 1/0/1
+FX_BODY='<!-- epic-membership:snapshot:start -->
+[{"since":"2026-07-01T00:00:00Z"}]
+<!-- epic-membership:snapshot:end -->'
+check "a boundary on a marker that is an array, not an object" clear live 1/0/1
 FX_BODY='<!-- epic-membership:snapshot:start -->
 {"status":"frozen","members":"nope"}
 <!-- epic-membership:snapshot:end -->'
@@ -605,7 +797,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -lt 95 ]; then
-  echo "::error::only $ran assertion(s) ran (expected at least 95) — the suite did not execute fully"
+if [ "$ran" -lt 132 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 132) — the suite did not execute fully"
   exit 1
 fi


### PR DESCRIPTION
Closes #340. Blocks #328, and is why #339 was moved to draft.

## The gap

`evaluate_epic` derived its three buckets from live label searches spanning the Epic's **whole
history**. A merged pull request keeps its `epic:<N>` label, so `merged >= 1` — the precondition every
decision hangs on — is permanently true once anything lands, and `first_merged_at` is `min(mergedAt)`,
the first merge _ever_, so grace is permanently elapsed. A sibling labelled for a second wave is
therefore a stray past grace on the pass it appears: `epic-freeze=failure`, a required check, re-posted
every ~15 minutes, level-triggered. **A second wave under the same Epic could never land.**
`is:closed is:unmerged` carried the identical disease.

Retiring the snapshot (#328) does not help on its own — the detector never consulted the marker for
these numbers.

## The wave boundary

Only **time** separates one wave's history from the next. A set-based scope cannot work: a member that
merged _before_ the snapshot froze is absent from the frozen set (merge-gate captures it from OPEN pull
requests, while auto-merge is armed earlier), so it is visible only to the live search —
indistinguishable there from a previous wave's merges except by when it merged.

So the marker carries a boundary, `since`, read from **any** well-formed marker whatever its `status`:

```jsonc
{ "status": "retired", "since": "<iso>" }                     // the tombstone retirement writes
{ "status": "pending", "at": "<iso>", "since": "<iso>", ... } // carried forward
{ "status": "frozen",  "at": "<iso>", "since": "<iso>", ... } // carried forward
```

**It has to be carried forward, not merely written once** — the correction the earlier scoping missed.
`splice` replaces the whole fenced region, so the tombstone dies the moment the next wave's first
all-ready pass writes a fresh `pending`, and the freeze returns one pass later:

| pass         | marker           | live `is:merged`  | result                                |
| ------------ | ---------------- | ----------------- | ------------------------------------- |
| wave 1 lands | `frozen{A,B}`    | A, B              | —                                     |
| retirement   | `retired@T`      | —                 | boundary = T                          |
| E labelled   | `retired@T`      | A, B **excluded** | ✅ gated normally                     |
| E all-ready  | **`pending{E}`** | A, B **back**     | ❌ merged≥1, grace from A → E freezes |

## One scope, not three

Only the two **history** searches are bounded (` merged:>=` / ` closed:>=`). Everything else follows,
because it already derives from them: `first_merged_at` is a `min` over the merged bucket, so grace
starts at this wave's first merge, and strays are already gated on `merged >= 1`, so a sibling of a
wave that has not started landing is not a stray at all.

- The **open** search is deliberately unbounded — an open pull request is not history.
- The **frozen set** is never time-filtered. It IS the current wave (retirement is what writes a
  boundary, and it removes the set it retires), so the union widens membership without widening
  history — the #313 interaction. `snapshot_buckets` now resolves _before_ the searches it scopes, and
  `SNAP_SINCE` is pointedly **not** cleared in the `rc 2` branch beside the other `SNAP_*`: rc 2 is
  exactly the tombstone path, so clearing it there for symmetry would discard the only thing that path
  delivers.

## Validating the boundary is load-bearing, and its failure is silent

Verified against the live API:

| query                           | result                       |
| ------------------------------- | ---------------------------- |
| `merged:>=2026-07-21T12:00:00Z` | 39 (vs 47 for the date)      |
| `closed:>=2026-07-22T12:00:00Z` | 0 (vs 68 unscoped)           |
| `merged:>=garbage`              | **0 rows, no `errors` array** |
| `merged:>=2026-13-45T99:00:00Z` | **0 rows, no `errors` array** |

A malformed qualifier is answered with an empty set and no error — nothing the well-formed-page guard
can catch, and indistinguishable from a genuinely empty bucket. An empty `merged` bucket reads as
"nothing has landed" → `clear` → which POSTS success and lifts a standing freeze. `date` alone is not
the guard either: it accepts `yesterday`, which GitHub answers with zero rows.

So a value reaches a query only if it is the exact form merge-gate emits, a calendar accepts it, and it
is not ahead of this run. Anything else is dropped for unbounded history — the direction that errs
toward freezing — with a warning.

Two defects found in self-review, both fixed here and pinned by their own tests:

- **The future guard compared against a stale clock.** `now_epoch` is read when the step starts, and a
  sweep is often minutes into it by the time it reaches an Epic — so a tombstone written moments ago
  read as "the future" and was thrown away, costing a pass of unbounded history that re-freezes the
  next wave until the following sweep. It now allows the skew.
- **Reporting a rejected boundary was itself an injection vector.** The marker lives in an issue body,
  `jq -r` renders an embedded `\n` as a real newline, and GitHub reads workflow commands line by line —
  so the raw value echoed into a `::warning::` could forge its own `::error::` / `::stop-commands::`
  line on the very path that rejects it. The displayed value is now a single bounded line.

On trust generally: `since` grants no new capability. An actor who can edit the Epic body can already
label the Epic `automation:paused` and suppress detection outright. The corroboration machinery guards
the _other_ direction, where a marker naming arbitrary pull requests reaches repositories its author
has no rights in.

## Scope

This ships the **reader**. #328 ships the writer — retirement writing the tombstone, made reachable
before the not-in-set hold, and the carry-forward — and its body now carries that contract. Nothing
writes `since` yet, so this lands with **zero behaviour change**, and the detector tolerates the new
shape before anything can emit it.

## Tests: 95 → 132

The stub now applies the time qualifier the way **GitHub** does rather than asserting the action's
query contains a substring — a qualifier that was inert would pass that assertion just as well, and an
inert qualifier is precisely the failure mode. Every mutant below was run:

| Mutant                                         | Failed |
| ---------------------------------------------- | ------ |
| the merged search loses its floor              | 5      |
| the closed search loses its floor              | 2      |
| `SNAP_SINCE` cleared on the tombstone path     | 6      |
| boundary read only from a `frozen` marker      | 6      |
| the frozen set is time-filtered too            | 1      |
| the open search is bounded by history          | 2      |
| the shape guard removed                        | 3      |
| the calendar guard removed                     | 2      |
| the future guard removed                       | 2      |
| the skew allowance removed                     | 1      |
| the displayed value is not sanitized           | 1      |

Deterministic across runs, offline, no temp leakage. `merge-gate-snapshot-write` stays 76/76.
