### PR TITLE
docs(actions): trim and refocus code comments

### DIFF
--- a/.github/workflows/auto-approve-dependabot-run.yaml
+++ b/.github/workflows/auto-approve-dependabot-run.yaml
@@ -1,8 +1,8 @@
 name: auto-approve-dependabot (reusable)
 
-# The REUSABLE auto-approve-dependabot engine (workflow_call): every governed repo's thin
-# `auto-approve-dependabot.yaml` caller (repocfg-provisioned) calls this with its org creds. Runs in
-# the CALLER's context — it approves + queues the caller repo's trusted dependency-bot PRs.
+# The reusable auto-approve-dependabot engine (workflow_call). Every governed repo's thin
+# `auto-approve-dependabot.yaml` caller, provisioned by repocfg, calls this with its org creds. It
+# runs in the caller's context, approving and queueing that repo's trusted dependency-bot PRs.
 on:
   workflow_call:
     inputs:
@@ -29,27 +29,24 @@ jobs:
     if: >-
       github.event.pull_request.user.login == inputs.dependency_bot_login ||
       github.event.pull_request.user.login == inputs.dependabot_security_login
-    # Every step runs on the minted App token; the default token is unused.
+    # Every step runs on the minted App token, so the default token is unused.
     permissions: {}
     steps:
-      # Approve as the App — a distinct identity from the bot author, and one whose
-      # review reliably counts toward the required-approval rule (a workflow's own
-      # token does not).
+      # Approve as the App: an identity distinct from the bot author, and one whose review
+      # counts toward the required-approval rule, where a workflow's own token does not.
       - name: Mint approval token
         id: token
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ inputs.client_id }}
           private-key: ${{ secrets.bot_private_key }}
-          # No `owner`: approving + merging this one PR needs nothing org-wide, so
-          # the token stays scoped to the current repository (omitting `owner` +
-          # `repositories` scopes it there). Contrast the Projects-scoped actions.
+          # Omitting `owner` and `repositories` scopes the token to the current repository,
+          # which is all approving and merging this one PR needs.
           permission-contents: write
           permission-pull-requests: write
 
-      # A human push to the branch means the change needs real review, so approve
-      # only when every commit is the bot's own. Unknown authors count as non-bot,
-      # so the guard fails closed.
+      # A human push to the branch means the change needs real review, so this approves only when
+      # every commit is the bot's own. An unknown author counts as non-bot, failing closed.
       - name: Confirm every commit is the bot's
         id: guard
         env:
@@ -80,11 +77,10 @@ jobs:
           pull_request: ${{ github.event.pull_request.html_url }}
           github_token: ${{ steps.token.outputs.token }}
 
-      # Put the approved PR in the merge queue so it merges hands-off. The queue
-      # re-validates the required checks on the group and owns the merge method;
-      # pass `--squash` (the org's only allowed method) so the command is explicit
-      # for any repo without a queue too — where there is a queue it just logs that
-      # the strategy is queue-controlled.
+      # Put the approved PR in the merge queue so it merges hands-off. The queue re-validates the
+      # required checks on the group and owns the merge method; `--squash` is the org's only allowed
+      # method and makes the command explicit in a repo with no queue. Where there is one, gh just
+      # logs that the strategy is queue-controlled.
       - name: Enable auto-merge
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:

--- a/.github/workflows/epic-rollback-run.yaml
+++ b/.github/workflows/epic-rollback-run.yaml
@@ -2,9 +2,9 @@ name: epic-rollback (reusable)
 
 # The reusable epic-rollback engine (workflow_call). Every governed repo's thin `epic-rollback.yaml`
 # admin-dispatch caller, provisioned by repocfg, calls this with its org creds and the operator's
-# dispatch inputs. It runs in the caller's context, so nested actions are remote-pinned: a `./` path
-# would resolve against the caller. This is a destructive escape hatch, and the admin gate and typed
-# confirmation live in the job below.
+# dispatch inputs. It runs in the caller's context, where a `./` path resolves against the caller's
+# checkout, so nested actions are remote-pinned. This is a destructive escape hatch, and the admin
+# gate and typed confirmation live in the job below.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/epic-rollback-run.yaml
+++ b/.github/workflows/epic-rollback-run.yaml
@@ -1,9 +1,10 @@
 name: epic-rollback (reusable)
 
-# The REUSABLE epic-rollback engine (workflow_call): every governed repo's thin `epic-rollback.yaml`
-# admin-dispatch caller (repocfg-provisioned) calls this with its org creds + the operator's dispatch
-# inputs. Runs in the CALLER's context; nested actions are remote-pinned (`./` would resolve to the
-# caller, not here). Destructive escape hatch — the admin gate + typed confirmation live in the job.
+# The reusable epic-rollback engine (workflow_call). Every governed repo's thin `epic-rollback.yaml`
+# admin-dispatch caller, provisioned by repocfg, calls this with its org creds and the operator's
+# dispatch inputs. It runs in the caller's context, so nested actions are remote-pinned: a `./` path
+# would resolve against the caller. This is a destructive escape hatch, and the admin gate and typed
+# confirmation live in the job below.
 on:
   workflow_call:
     inputs:
@@ -50,14 +51,14 @@ on:
 jobs:
   rollback:
     runs-on: ubuntu-latest
-    # The default token is used only for the admin check (Metadata:read, always present); the
-    # rollback action mints its own least-privilege [Agent] tokens for every read and write.
+    # The default token serves only the admin check, which needs Metadata:read; the rollback action
+    # mints its own least-privilege [Agent] tokens for every read and write.
     permissions:
       contents: read
     steps:
-      # Fail closed unless the dispatcher is a repo admin, AND the epic number is numeric, AND
-      # the typed confirmation matches exactly. workflow_dispatch is open to any write user, so
-      # this gate is what keeps a destructive rollback admin-only + fat-finger-proof.
+      # Fail closed unless the dispatcher is a repo admin, the Epic number is numeric, and the typed
+      # confirmation matches exactly. workflow_dispatch is open to any write user, so this gate is
+      # what keeps a destructive rollback admin-only and deliberate.
       - name: Require admin + numeric epic + typed confirmation
         env:
           GH_TOKEN: ${{ github.token }}
@@ -68,9 +69,8 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          # Admin gate (copied from a-novel-kit/workflows' generic-actions/approve-pr/action.yaml):
-          # `|| echo ""` keeps a failed lookup from tripping `set -e` — an empty permission falls
-          # through and fails closed.
+          # Admin gate: `|| echo ""` keeps a failed lookup from tripping `set -e`, and an empty
+          # permission falls through and fails closed.
           perm=$(gh api "repos/${REPO_FULL}/collaborators/${ACTOR}/permission" -q '.permission' 2>/dev/null || echo "")
           if [ "$perm" != "admin" ]; then
             echo "::error::epic-rollback is admin-only; @${ACTOR} has permission '${perm:-none}'."
@@ -81,7 +81,7 @@ jobs:
             echo "::error::epic_number must be an integer, got \"${EPIC:-}\"."
             exit 1
           fi
-          # Typed confirmation — defeats a fat-finger on a destructive op.
+          # Typed confirmation, so a destructive operation cannot be triggered by a slip.
           if [ "${CONFIRM:-}" != "revert-epic-${EPIC}" ]; then
             echo "::error::confirmation mismatch — type \"revert-epic-${EPIC}\" exactly to proceed."
             exit 1
@@ -95,12 +95,12 @@ jobs:
           epic_number: ${{ inputs.epic_number }}
           reason: ${{ inputs.reason }}
           dry_run: ${{ inputs.dry_run }}
-          # BLAST-CAP: abort before any revert if the ledger spans more than this many repos.
+          # Blast cap: abort before any revert if the ledger spans more repos than this.
           max_rollback_repos: ${{ inputs.max_rollback_repos }}
-          # Org-level HALT (FAIL-SAFE — RUNNING only for an explicit off-token: empty/unset, 0, off,
-          # false, no, disabled; ANYTHING ELSE, incl. a fat-fingered value, engages) → the action
-          # aborts loud as its first step, before any mint. Threaded from the org variable (a
-          # composite action can't read `vars` itself).
+          # Org-level halt. Fail-safe: running only for an explicit off-token (empty/unset, 0, off,
+          # false, no, disabled); any other value engages it and the action aborts loudly as its first
+          # step, before any mint. Threaded from the org variable, which a composite action cannot
+          # read itself.
           kill_switch: ${{ inputs.kill_switch }}
-          # The org "Tasks" board id, inlined per-org the same way derive-status passes it.
+          # The org "Tasks" board id, inlined per org as derive-status passes it.
           project_id: ${{ inputs.project_id }}

--- a/.github/workflows/hotfix-run.yaml
+++ b/.github/workflows/hotfix-run.yaml
@@ -1,17 +1,18 @@
 name: hotfix (reusable)
 
-# The REUSABLE hotfix engine (workflow_call): every governed repo's thin `hotfix.yaml` dispatch caller
-# (repocfg-provisioned) calls this with its org creds. Runs in the CALLER's context — it patches the
-# caller repo. Nested actions are remote-pinned (`./` in a reusable resolves to the caller, not here).
+# The reusable hotfix engine (workflow_call). Every governed repo's thin `hotfix.yaml` dispatch
+# caller, provisioned by repocfg, calls this with its org creds. It runs in the caller's context and
+# patches that repo, so nested actions are remote-pinned: a `./` path in a reusable workflow resolves
+# against the caller.
 #
-# Patch an ALREADY-RELEASED line without touching the default branch. Dispatched from the UI (like
-# release.yaml — the protected `release` environment is the human "who may publish" gate), it cuts
-# an ephemeral branch from the latest live tag on the target X.Y line, applies the fix, and cuts a
-# vX.Y.(Z+1) tag via release-core-hotfix. The fix is then reconciled to master (added on this branch
-# next); this first layer is the cut path, drillable in dry-run.
+# It patches an already-released line without touching the default branch. Dispatched from the UI,
+# behind the protected `release` environment as the human "who may publish" gate, it cuts an ephemeral
+# branch from the latest live tag on the target X.Y line, applies the fix, cuts a vX.Y.(Z+1) tag
+# through release-core-hotfix, and reconciles the fix forward to master. The cut path is drillable in
+# dry-run.
 #
-# Kill-switch note: a hotfix is deliberately NOT gated on the org kill switch. The kill switch pauses
-# normal automation; the emergency PATCH path must stay open (it's human-gated by `release` + admin).
+# A hotfix is not gated on the org kill switch. The switch pauses normal automation, while the
+# emergency patch path stays open, human-gated by `release` and the admin check.
 on:
   workflow_call:
     inputs:
@@ -72,9 +73,9 @@ jobs:
       reconcile_pr: ${{ steps.reconcile.outputs.pr_url }}
       reconcile_conflicted: ${{ steps.reconcile.outputs.conflicted }}
     steps:
-      # Bot-authenticated full checkout: the baseline tag, the fix, and the ephemeral-branch push all
-      # need the bot's rights + complete history and tags. release-core-hotfix re-checks-out the
-      # ephemeral branch itself later with its own token.
+      # Bot-authenticated full checkout: the baseline tag, the fix and the ephemeral-branch push all
+      # need the bot's rights plus complete history and tags. release-core-hotfix later re-checks-out
+      # the ephemeral branch with its own token.
       - name: Mint git token
         id: token
         uses: actions/create-github-app-token@v3
@@ -91,10 +92,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      # Asymmetric lock: wait out any in-flight release before cutting a hotfix, so the two never
-      # interleave. Only the hotfix waits — release.yaml never locks, so release-vs-release keeps its
-      # collision-fail. Best-effort ordering (a hotfix and a release compute different tags, so they
-      # can't collide); a small post-wait race is acceptable.
+      # An asymmetric lock: wait out any in-flight release before cutting a hotfix, so the two never
+      # interleave. Only the hotfix waits, leaving release.yaml unlocked and two releases still
+      # colliding on the tag. The ordering is best-effort — a hotfix and a release compute different
+      # tags and cannot collide — so a small post-wait race is acceptable.
       - name: Acquire lock (wait for in-flight release)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -103,10 +104,10 @@ jobs:
           set -euo pipefail
           deadline=$((SECONDS + 1800)) # 30-minute cap → then abort (retry after the release lands)
           while :; do
-            # Only an ACTIVELY-RUNNING release blocks: in_progress or queued. A release parked in
-            # `waiting` (pending its environment approval) is deliberately IGNORED — it may never be
-            # approved, and the emergency hotfix must not spin on an unapproved dispatch. A gh error →
-            # "err", retry (don't abort the emergency path on a transient API blip).
+            # Only an actively-running release blocks, meaning in_progress or queued. A release
+            # parked in `waiting` for its environment approval is ignored: it may never be approved,
+            # and the emergency hotfix must not spin on an unapproved dispatch. A gh error yields
+            # "err" and retries rather than aborting the emergency path on a transient blip.
             active=$(gh run list --repo "$REPO" --workflow release.yaml --limit 30 \
               --json status --jq '[.[] | select(.status | IN("in_progress","queued"))] | length' 2>/dev/null || echo "err")
             if [ "$active" = "0" ]; then
@@ -124,10 +125,10 @@ jobs:
           done
           echo "✓ no release actively in flight — proceeding." | tee -a "$GITHUB_STEP_SUMMARY"
 
-      # Resolve the baseline (latest live tag on the line), cut the ephemeral branch from it, apply
-      # the fix, and capture fix-HEAD BEFORE the bump — that SHA range (baseline..fix_head) is what
-      # reconciles to master (the fix diff only, never the bump). Push the branch so release-core-
-      # hotfix can check it out.
+      # Resolve the baseline, the latest live tag on the line, cut the ephemeral branch from it,
+      # apply the fix, and capture fix-HEAD before the bump: the baseline..fix_head range is what
+      # reconciles to master, carrying the fix diff without the bump. The branch is pushed so
+      # release-core-hotfix can check it out.
       - name: Prepare ephemeral branch
         id: prepare
         env:
@@ -136,15 +137,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Validate the line (guards the glob/grep below against a malformed or injected value) and
-          # escape its dots so the grep can't match a stray character (e.g. line 1.4 vs a tag v1x4.0).
+          # Validate the line, which guards the glob and grep below against a malformed or injected
+          # value, and escape its dots so the grep cannot match a stray character: line 1.4 would
+          # otherwise match a tag v1x4.0.
           if ! printf '%s' "$LINE" | grep -qE '^[0-9]+\.[0-9]+$'; then
             echo "::error::line must be MAJOR.MINOR (e.g. 1.4), got \"$LINE\"."
             exit 1
           fi
           line_re=$(printf '%s' "$LINE" | sed 's/\./\\./g')
 
-          # Baseline = highest vLINE.PATCH release tag (exclude sub-module tags <dir>/v… and pre-releases).
+          # The baseline is the highest vLINE.PATCH release tag, excluding sub-module tags
+          # (<dir>/v…) and pre-releases.
           baseline=$(git tag -l "v${LINE}.*" | grep -E "^v${line_re}\.[0-9]+$" | sort -V | tail -1 || true)
           if [ -z "$baseline" ]; then
             echo "::error::no released tag on line v${LINE}.x — nothing to hotfix."
@@ -156,19 +159,19 @@ jobs:
           git config user.name "${{ steps.token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-          # A leftover ephemeral branch from an aborted run would block a fresh cut — remove it first.
+          # A leftover ephemeral branch from an aborted run would block a fresh cut, so remove it.
           git push origin --delete "$ephemeral" 2>/dev/null || true
           git checkout -b "$ephemeral" "$baseline"
 
-          # Apply the fix. A single SHA or an A..B range both work with cherry-pick -x (the -x trailer
+          # Apply the fix. cherry-pick -x takes a single SHA or an A..B range, and its trailer
           # records the origin SHA, one of the signals the reconcile uses to prove the fix reached
-          # master). Empty fix_ref = a drill that just re-cuts the baseline.
+          # master. An empty fix_ref makes this a drill that re-cuts the baseline.
           if [ -n "${FIX_REF:-}" ]; then
-            # Reject a value git could parse as an option (leading dash) — fix_ref flows into git fetch
-            # + cherry-pick as a revision.
+            # Reject a value git could parse as an option, since fix_ref flows into git fetch and
+            # cherry-pick as a revision.
             case "$FIX_REF" in -*) echo "::error::fix_ref must not begin with '-' (got \"$FIX_REF\")."; exit 1 ;; esac
-            # Make sure the fix commits are present (a fix pushed to another branch isn't fetched by
-            # the default checkout); harmless when FIX_REF is already reachable.
+            # Make sure the fix commits are present: the default checkout does not fetch a fix
+            # pushed to another branch. Harmless when FIX_REF is already reachable.
             git fetch origin "$FIX_REF" 2>/dev/null || true
             git cherry-pick -x "$FIX_REF"
             echo "Applied fix \`$FIX_REF\`." | tee -a "$GITHUB_STEP_SUMMARY"
@@ -179,9 +182,10 @@ jobs:
           fix_head=$(git rev-parse HEAD)
           git push origin "$ephemeral"
 
-          # Restore the main workspace to the triggering commit so the local `./` actions (the cut,
-          # reconcile, and escalate steps) resolve from the CURRENT ref — not the old baseline this
-          # step checked out. release-core-hotfix re-checks-out the ephemeral branch from the remote.
+          # Restore the main workspace to the triggering commit, so the local `./` actions in the
+          # cut, reconcile and escalate steps resolve from the current ref rather than the old
+          # baseline this step checked out. release-core-hotfix re-checks-out the ephemeral branch
+          # from the remote.
           git checkout --force "$GITHUB_SHA" >/dev/null 2>&1
 
           {
@@ -190,8 +194,8 @@ jobs:
             echo "fix_head=$fix_head"
           } >> "$GITHUB_OUTPUT"
 
-      # Cut the hotfix release from the ephemeral branch (patch bump, tag-only, --latest=false). In
-      # dry-run it bumps + reports without tagging/pushing.
+      # Cut the hotfix release from the ephemeral branch: a patch bump, tags only, --latest=false.
+      # In dry-run it bumps and reports without tagging or pushing.
       - name: Cut hotfix
         id: cut
         uses: a-novel-kit/workflows/publish-actions/release-core-hotfix@v1.20.2
@@ -201,10 +205,11 @@ jobs:
           app_private_key: ${{ secrets.app_private_key }}
           dry_run: ${{ inputs.dry_run }}
 
-      # The per-hotfix cleanup Task: a durable, escalatable marker that the fix MUST reach the default
-      # branch. The reconcile PR `Closes` it; if it lingers open the fix never reconciled and the
-      # watchdog escalates. Per-hotfix identity (the version in the title) so concurrent hotfixes don't
-      # collapse into one marker. Only opened once the cut succeeded (nothing to reconcile otherwise).
+      # The per-hotfix cleanup Task: a durable, escalatable marker that the fix has to reach the
+      # default branch. The reconcile PR `Closes` it, and a Task left open means the fix never
+      # reconciled, which the watchdog escalates. The version in the title gives each hotfix its own
+      # marker, so concurrent hotfixes do not collapse into one. It opens only once the cut
+      # succeeded, since a failed cut leaves nothing to reconcile.
       - name: Open cleanup Task
         id: cleanup_task
         if: ${{ success() && steps.cut.outcome == 'success' }}
@@ -231,9 +236,9 @@ jobs:
           echo "Opened cleanup Task #${num} (${url})." | tee -a "$GITHUB_STEP_SUMMARY"
           echo "number=$num" >> "$GITHUB_OUTPUT"
 
-      # Forward-port the fix diff (never the bump) to the default branch — a squash hotfix-reconcile/*
-      # PR that Closes the cleanup Task, degrading a conflict to a draft PR. Runs BEFORE the ephemeral
-      # branch is deleted (it fetches the fix commits from it).
+      # Forward-port the fix diff, without the bump, to the default branch as a squash
+      # hotfix-reconcile/* PR that Closes the cleanup Task, degrading a conflict to a draft PR. It
+      # runs before the ephemeral branch is deleted, since it fetches the fix commits from there.
       - name: Reconcile fix to the default branch
         id: reconcile
         if: ${{ success() && steps.cut.outcome == 'success' }}
@@ -248,9 +253,9 @@ jobs:
           cleanup_task: ${{ steps.cleanup_task.outputs.number }}
           dry_run: ${{ inputs.dry_run }}
 
-      # If the reconcile short-circuited (the fix was ALREADY on the default branch, patch-id match),
-      # no PR closes the cleanup Task — so close it here, or the watchdog would later escalate a hotfix
-      # that did reach master. reconcile has no issues:write; the git token (this job) does.
+      # When the reconcile short-circuits, the fix already being on the default branch by patch-id,
+      # no PR closes the cleanup Task, so close it here or the watchdog escalates a hotfix that did
+      # reach master. reconcile holds no issues:write; this job's git token does.
       - name: Close cleanup Task (already reconciled)
         if: ${{ success() && steps.reconcile.outputs.already_on_master == 'true' && steps.cleanup_task.outputs.number != '' && steps.cleanup_task.outputs.number != '0' }}
         env:
@@ -262,8 +267,8 @@ jobs:
             --comment "The fix was already on the default branch (patch-id match) — no reconcile PR was needed."
           echo "Closed cleanup Task #${NUM} (fix already on the default branch)." | tee -a "$GITHUB_STEP_SUMMARY"
 
-      # Any failure in the hotfix path pulls a human in — the emergency path must be loud, never silent.
-      # Passes the dispatch severity; a wired ESCALATE_PUSH_WEBHOOK pages SEV1. dry-run just logs it.
+      # Any failure in the hotfix path pulls a human in, so the emergency path is never silent. It
+      # passes the dispatch severity, a wired push webhook pages SEV1, and dry-run only logs it.
       - name: Escalate on failure
         if: ${{ failure() }}
         uses: a-novel-kit/workflows/generic-actions/escalate@v1.20.2
@@ -279,8 +284,8 @@ jobs:
           push_webhook: ${{ secrets.push_webhook }}
           dry_run: ${{ inputs.dry_run }}
 
-      # Clean up the ephemeral branch — AFTER the reconcile fetched its commits. The tag (if cut)
-      # preserves the fix commit. always() so an earlier failure still cleans up.
+      # Clean up the ephemeral branch, after the reconcile has fetched its commits. A tag that was
+      # cut preserves the fix commit. always() so an earlier failure still cleans up.
       - name: Clean up ephemeral branch
         if: ${{ always() && steps.prepare.outputs.ephemeral != '' }}
         env:

--- a/.github/workflows/hotfix-run.yaml
+++ b/.github/workflows/hotfix-run.yaml
@@ -107,7 +107,7 @@ jobs:
             # Only an actively-running release blocks, meaning in_progress or queued. A release
             # parked in `waiting` for its environment approval is ignored: it may never be approved,
             # and the emergency hotfix must not spin on an unapproved dispatch. A gh error yields
-            # "err" and retries rather than aborting the emergency path on a transient blip.
+            # "err" and retries, so a transient blip does not abort the emergency path.
             active=$(gh run list --repo "$REPO" --workflow release.yaml --limit 30 \
               --json status --jq '[.[] | select(.status | IN("in_progress","queued"))] | length' 2>/dev/null || echo "err")
             if [ "$active" = "0" ]; then
@@ -159,7 +159,7 @@ jobs:
           git config user.name "${{ steps.token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-          # A leftover ephemeral branch from an aborted run would block a fresh cut, so remove it.
+          # A leftover ephemeral branch from an aborted run blocks a fresh cut, so remove it.
           git push origin --delete "$ephemeral" 2>/dev/null || true
           git checkout -b "$ephemeral" "$baseline"
 
@@ -183,9 +183,8 @@ jobs:
           git push origin "$ephemeral"
 
           # Restore the main workspace to the triggering commit, so the local `./` actions in the
-          # cut, reconcile and escalate steps resolve from the current ref rather than the old
-          # baseline this step checked out. release-core-hotfix re-checks-out the ephemeral branch
-          # from the remote.
+          # cut, reconcile and escalate steps resolve from the current ref; this step left it on the
+          # baseline. release-core-hotfix re-checks-out the ephemeral branch from the remote.
           git checkout --force "$GITHUB_SHA" >/dev/null 2>&1
 
           {

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -1,13 +1,13 @@
 name: hotfix
 
-# repocfg-managed, org-wide. Thin dispatch caller — the whole hotfix engine lives in the reusable
-# a-novel-kit/workflows/.github/workflows/hotfix-run.yaml (@vX.Y.Z). Renovate bumps the pin. Do NOT
-# hand-edit on a target repo — `a-novel repo update` overwrites it.
+# repocfg-managed, org-wide. A thin dispatch caller: the hotfix engine lives in the reusable
+# a-novel-kit/workflows/.github/workflows/hotfix-run.yaml (@vX.Y.Z), and Renovate bumps the pin. A
+# hand-edit on a target repo is overwritten by `a-novel repo update`.
 #
-# Patch an ALREADY-RELEASED line without touching the default branch: cut vX.Y.(Z+1) from the line's
-# latest live tag, apply the fix, reconcile it forward to master. Admin + protected-`release`-env
-# gated (the human "who may publish" gate); deliberately kill-switch-EXEMPT (the emergency patch path
-# must stay open even when normal automation is halted).
+# It patches an already-released line without touching the default branch: cut vX.Y.(Z+1) from the
+# line's latest live tag, apply the fix, reconcile it forward to master. The admin check and the
+# protected `release` environment are the human "who may publish" gate. It is exempt from the kill
+# switch, so the emergency patch path stays open while normal automation is halted.
 on:
   workflow_dispatch:
     inputs:
@@ -36,8 +36,8 @@ on:
 
 run-name: "🚑 hotfix v${{ inputs.line }}.x${{ inputs.dry_run && ' (dry-run)' || '' }}"
 
-# hotfix-vs-hotfix: serialize on this repo (a second hotfix waits, never races). cancel-in-progress:false
-# = queue, don't cancel a hotfix mid-flight. (hotfix-vs-release is handled inside the reusable's lock.)
+# Serialize hotfixes on this repo, so a second one waits. cancel-in-progress:false queues rather
+# than cancelling a hotfix mid-flight. A hotfix racing a release is handled by the reusable's lock.
 concurrency:
   group: hotfix-${{ github.repository }}
   cancel-in-progress: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,13 +6,13 @@ on:
       - "**"
     branches:
       - "**"
-      # The transient ephemeral hotfix branches (pushed then deleted by hotfix.yaml, incl. dry-run
-      # drills) never become PRs, so there's nothing to lint — skip them to avoid churn runs.
+      # The ephemeral hotfix branches hotfix.yaml pushes and deletes, dry-run drills included, never
+      # become PRs, so there is nothing to lint on them.
       - "!hotfix/**"
 
-# Cancel an in-progress lint run when a newer commit lands on the same ref —
-# the superseded run's result is never useful. Safe here because this workflow
-# only lints (no release/deploy work that must run to completion).
+# Cancel an in-progress lint run when a newer commit lands on the same ref, since the superseded
+# run's result is worthless. This workflow only lints, with no release or deploy work that has to
+# run to completion.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -30,14 +30,12 @@ jobs:
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
 
-  # Guard against the v1.12.0 incident: a composite action's WHOLE manifest is
-  # expression-templated at load time — input descriptions and run: strings, bash
-  # comments included. The vars / secrets / needs / matrix / strategy contexts do not
-  # exist for composite actions, so a literal `vars.X` template expression anywhere in one — even
-  # as documentation — makes the action fail to LOAD, which took merge-gate offline
-  # org-wide until v1.12.1. Caller WORKFLOWS (.github/workflows/*) may use these; a
-  # composite action manifest may not. This job is a main.yaml job, so repocfg makes
-  # it a required check on this repo.
+  # A composite action's whole manifest is expression-templated at load time, input descriptions,
+  # `run:` strings and the bash comments inside them included. The vars, secrets, needs, matrix and
+  # strategy contexts do not exist for a composite action, so a literal `vars.X` template expression
+  # anywhere in one — documentation included — makes the action fail to load for every consumer.
+  # Caller workflows under .github/workflows may use those contexts; a composite manifest may not.
+  # This is a main.yaml job, so repocfg makes it a required check on this repo.
   lint-action-manifests:
     runs-on: ubuntu-latest
     permissions:
@@ -50,7 +48,7 @@ jobs:
           set -euo pipefail
           fail=0
           while IFS= read -r f; do
-            # Only composite actions are affected; reusable workflows are not composite.
+            # Only composite actions are affected; a reusable workflow is not one.
             grep -qE 'using:[[:space:]]*"?composite' "$f" || continue
             if grep -nE '\$\{\{[[:space:]]*(vars|secrets|needs|matrix|strategy)\.' "$f"; then
               echo "::error file=$f::references a context unavailable to composite actions (vars/secrets/needs/matrix/strategy) — deliteralize it: write the context as plain text (e.g. \`vars.X\`), never inside a template expression. See the v1.12.1 load-failure incident."
@@ -60,10 +58,9 @@ jobs:
           if [ "$fail" -ne 0 ]; then exit 1; fi
           echo "✓ no composite-illegal expression contexts in any action manifest."
 
-  # The landing-saga actions are bash, and their decisions (freeze / clear / hold) are too costly to
-  # get wrong to leave unexercised. Each test in tests/ extracts the functions it covers straight out
-  # of its action manifest and runs them against stubbed network leaves — offline, deterministic, and
-  # no fixture drift, since the shipped code is what executes.
+  # The landing-saga actions are bash, and their freeze, clear and hold decisions are too costly to
+  # get wrong to leave unexercised. Each suite in tests/ extracts the functions it covers straight out
+  # of its action manifest and runs them against stubbed network leaves, offline and deterministic.
   test-actions:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/merge-gate-run.yaml
+++ b/.github/workflows/merge-gate-run.yaml
@@ -1,21 +1,23 @@
 name: merge-gate (reusable)
 
-# The REUSABLE merge-gate engine (workflow_call): every governed repo's thin `merge-gate.yaml` caller
-# (repocfg-provisioned) calls this with its org creds. Runs in the CALLER's context — it gates the
-# caller repo's PRs. Nested actions are remote-pinned (`./` in a reusable resolves to the caller, not here).
+# The reusable merge-gate engine (workflow_call). Every governed repo's thin `merge-gate.yaml`
+# caller, provisioned by repocfg, calls this with its org creds. It runs in the caller's context and
+# gates that repo's PRs, so nested actions are remote-pinned: a `./` path in a reusable workflow
+# resolves against the caller.
 #
 # The required "may this PR merge?" gate, plus the landing coordinator for epic members. Two jobs:
 #
-#   evaluate   — posts the required `merge-gate` check on every PR and on the merge queue's group (the
-#                queue validates required checks on the group, so the gate must post there too or a
-#                queued PR waits out the timeout and drops). The check is posted by the [Agent] App via
-#                the Checks API (a stable integration id the ruleset requires), so the job is only the
-#                runner — its id is deliberately NOT `merge-gate`, to avoid a duplicate check name. A
-#                standalone PR passes; an epic member holds until every sibling is ready (epic-atomicity).
+#   evaluate   — posts the required `merge-gate` check on every PR and on the merge queue's group.
+#                The queue validates required checks on the group, so a gate that skipped it would
+#                leave a queued PR waiting out the timeout and dropping. The [Agent] App posts the
+#                check through the Checks API, giving the ruleset the stable integration id it
+#                requires, so this job is only the runner and its id is not `merge-gate`, which would
+#                duplicate the check name. A standalone PR passes; an Epic member holds until every
+#                sibling is ready.
 #
-#   auto-merge — enables native auto-merge on an epic member so the whole set lands together once the
-#                gate + approval go green. Enabling is safe while the gate is still red — GitHub parks it
-#                and merges when green. Live at `dry_run: "false"` — auto-merge is enabled for epic members.
+#   auto-merge — enables native auto-merge on an Epic member so the whole set lands together once the
+#                gate and the approval go green. Enabling while the gate is still red is safe: GitHub
+#                parks the request and merges when it goes green.
 on:
   workflow_call:
     inputs:
@@ -40,27 +42,27 @@ on:
 jobs:
   evaluate:
     runs-on: ubuntu-latest
-    # The gate mints its own [Agent] token (checks:write) and never uses the
-    # default token, so it needs no repository permissions of its own.
+    # The gate mints its own [Agent] token with checks:write and never uses the
+    # default token, so this job needs no repository permissions.
     permissions: {}
     steps:
       - uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.20.2
         with:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.app_private_key }}
-          # Org-level HALT (FAIL-SAFE — RUNNING only for an explicit off-token: empty/unset, 0, off,
-          # false, no, disabled; ANYTHING ELSE, incl. a fat-fingered value, engages) → the gate posts
-          # a `failure` HOLD on every PR, BEFORE any success path, so nothing merges org-wide.
-          # Threaded from the org variable (a composite action can't read `vars` itself). The variable
-          # need not exist to run — an unset value reads as empty, which is a running state.
+          # Org-level halt. Fail-safe: running only for an explicit off-token (empty/unset, 0, off,
+          # false, no, disabled); any other value engages it, and the gate then posts a `failure` hold
+          # on every PR ahead of any success path, so nothing merges org-wide. It is threaded from the
+          # org variable because a composite action cannot read `vars` itself, and the variable need
+          # not exist: an unset value reads as empty, which is a running state.
           kill_switch: ${{ inputs.kill_switch }}
 
   auto-merge:
     # Only where there is a PR to enable (pull_request events), and never on a draft.
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
-    # The member check reads the event payload (no API); enable-auto-merge mints its
-    # own [Agent] token — so no default-token permissions are needed.
+    # The member check reads the event payload with no API call, and enable-auto-merge
+    # mints its own [Agent] token, so no default-token permissions are needed.
     permissions: {}
     steps:
       - name: Is this an epic member?
@@ -79,10 +81,10 @@ jobs:
           pull_request_number: ${{ github.event.pull_request.number }}
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.app_private_key }}
-          # Live: auto-merge is enabled for epic members.
+          # Live, so auto-merge is enabled for Epic members.
           dry_run: "false"
-          # Org-level HALT (FAIL-SAFE — RUNNING only for an explicit off-token; ANYTHING ELSE engages)
-          # → do not arm auto-merge (merge-gate HOLDs anyway). NOTE: this does NOT disarm auto-merge
-          # ALREADY armed on an idle ready PR before the halt — merge-gate's red check still blocks it,
-          # with a brief latency window until the next event / reconcile sweep re-posts the hold.
+          # Org-level halt, fail-safe as above: when engaged, nothing is armed, and merge-gate holds
+          # anyway. A halt does not disarm auto-merge already armed on an idle ready PR; merge-gate's
+          # red check still blocks the merge, with a latency window until the next event or reconcile
+          # sweep re-posts the hold.
           kill_switch: ${{ inputs.kill_switch }}

--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -1,18 +1,18 @@
-# Reusable board reconcile sweep — the fail-safe that repairs board state the
-# event-driven automation can miss. Each org's `.github` repo calls this on a schedule
-# with a thin caller, so the sweep logic lives in ONE place. Five passes:
+# Reusable board reconcile sweep: the fail-safe that repairs board state the event-driven
+# automation can miss. Each org's `.github` repo calls this on a schedule through a thin caller, so
+# the sweep logic lives in one place. Five passes:
 #   - rollup:   roll each epic's Status + Start date up from its children (read-only by default).
 #   - rederive: re-derive every open Task PR's board Status, catching dropped derive events.
 #   - regate:   re-post merge-gate on every open epic-member PR, since a sibling changing
 #               in another repo emits no event to it.
-#   - detect:   re-derive every active Epic's partial-landing state org-wide and post epic-freeze
-#               (the SWEEP half of the detector) — the level-triggered floor + standalone backstop.
+#   - detect:   re-derive every active Epic's partial-landing state org-wide and post epic-freeze,
+#               the sweep half of the detector: a level-triggered floor and standalone backstop.
 #   - render:   rewrite each active Epic's display-only status read-model into its issue body,
-#               derived from live truth. Never authority — no board write, no check-run; a lost or
-#               hand-edited table is cosmetic.
-# The per-PR passes matrix over the org's open PRs (enumerated first, paginated) and call
-# the generic-actions cross-repo via their repo inputs. All board mutations still go through
-# the single-writer actions. The `when` (cron / concurrency) lives in the caller.
+#               derived from live truth. It is not authority: no board write, no check-run, and a
+#               lost or hand-edited table is cosmetic.
+# The per-PR passes matrix over the org's open PRs, enumerated and paginated first, and call the
+# generic-actions cross-repo through their repo inputs. Every board mutation still goes through the
+# single-writer actions. The schedule and concurrency live in the caller.
 name: reconcile-board
 
 on:
@@ -62,8 +62,8 @@ on:
 
 jobs:
   rollup:
-    # Run AFTER rederive so epics aggregate fresh Task statuses, not stale ones — but
-    # still run when rederive is skipped (no task PRs) or failed; only a cancel stops it.
+    # Run after rederive, so Epics aggregate fresh Task statuses, but still run when rederive was
+    # skipped for want of Task PRs or failed; only a cancel stops it.
     needs: rederive
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
@@ -75,18 +75,17 @@ jobs:
           app_private_key: ${{ secrets.private_key }}
           project_id: ${{ inputs.project_id }}
           dry_run: ${{ inputs.rollup_dry_run }}
-          # Org-level HALT: the org variable, read from the reusable workflow's `vars` context
-          # (org variables are available to reusable workflows) and threaded into every action here
-          # (a composite action can't read `vars` itself). FAIL-SAFE semantics live in the actions:
-          # each is RUNNING only for an explicit off-token (empty/unset, 0, off, false, no, disabled)
-          # and ENGAGES for anything else — so an unset variable runs, and a fat-fingered value halts.
-          # Engaged → this writer no-ops.
+          # Org-level halt. The org variable is read from this reusable workflow's `vars` context and
+          # threaded into every action here, since a composite action cannot read `vars` itself. The
+          # fail-safe semantics live in the actions: each runs only for an explicit off-token
+          # (empty/unset, 0, off, false, no, disabled) and halts on anything else, so an unset
+          # variable runs and a mistyped one stops the automation. When engaged this writer no-ops.
           kill_switch: ${{ vars.AGENT_KILL_SWITCH }}
 
-  # Clear terminal META work off the board: archive + close every org-wide "Applied" item (a resolved
-  # escalation ticket, a completed meta task). Per-repo "Awaiting release" archival happens on each
-  # repo's publish (release.yaml → archive-board-items); this sweep handles the Applied items that no
-  # release ever ships. Independent of the rollup pass, so it flips live on its own schedule.
+  # Clear terminal meta work off the board: archive and close every org-wide "Applied" item, such as
+  # a resolved escalation ticket. Per-repo "Awaiting release" archival happens on each repo's publish,
+  # through release.yaml and archive-board-items; this sweep handles the Applied items no release ever
+  # ships. It is independent of the rollup pass and goes live on its own schedule.
   archive:
     runs-on: ubuntu-latest
     permissions: {}
@@ -100,9 +99,9 @@ jobs:
           repo: "*"
           close: "true"
           dry_run: ${{ inputs.archive_dry_run }}
-      # Rule-4 complement: archive every board item whose ISSUE is CLOSED (org-wide) — done leaf
-      # planning issues in non-publishing .github never get archived by a publish otherwise, so this
-      # keeps closed ⟺ archived true on the board. Idempotent with the Applied pass above.
+      # Archive every board item whose issue is closed, org-wide. A done leaf planning issue in the
+      # non-publishing .github repo is never archived by a publish, so this keeps closed and archived
+      # equivalent on the board. Idempotent alongside the Applied pass above.
       - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.20.2
         with:
           client_id: ${{ inputs.client_id }}
@@ -112,7 +111,7 @@ jobs:
           repo: "*"
           dry_run: ${{ inputs.archive_dry_run }}
 
-  # Enumerate ALL the org's open PRs (paginated) → matrices for the two per-PR passes.
+  # Enumerate every open PR in the org, paginated, into matrices for the two per-PR passes.
   enumerate:
     runs-on: ubuntu-latest
     permissions: {}
@@ -140,7 +139,7 @@ jobs:
             pageInfo{ hasNextPage endCursor }
             nodes{ ... on PullRequest{ number headRefOid repository{ name }
               closingIssuesReferences(first:5){ nodes{ parent{ number } } } } } } }'
-          # Page every open PR — a fail-safe must not stop at the first 100.
+          # Page every open PR: a fail-safe cannot stop at the first 100.
           nodes='[]'
           cursor=""
           while :; do
@@ -151,8 +150,8 @@ jobs:
             [ "$(echo "$page" | jq -r '.data.search.pageInfo.hasNextPage')" = "true" ] || break
             cursor=$(echo "$page" | jq -r '.data.search.pageInfo.endCursor')
           done
-          # tasks    = open PRs that close an issue → re-derive their Status.
-          # epic_prs = those where ANY closing issue has a parent epic → re-post merge-gate.
+          # tasks holds the open PRs that close an issue, whose Status is re-derived.
+          # epic_prs holds those whose closing issue has a parent Epic, which get merge-gate re-posted.
           tasks=$(echo "$nodes" | jq -c '[.[]
             | select(.number and (.closingIssuesReferences.nodes | length > 0))
             | {repo: .repository.name, number, sha: .headRefOid}]')
@@ -164,7 +163,7 @@ jobs:
             echo "epic_prs=$epic_prs"
           } >> "$GITHUB_OUTPUT"
 
-  # Drift fail-safe: re-derive each open Task PR's Status (catches dropped derive events).
+  # Drift fail-safe: re-derive each open Task PR's Status, catching dropped derive events.
   rederive:
     needs: enumerate
     if: ${{ needs.enumerate.outputs.tasks != '[]' }}
@@ -182,7 +181,7 @@ jobs:
           client-id: ${{ inputs.client_id }}
           private-key: ${{ secrets.private_key }}
           owner: ${{ github.repository_owner }}
-          # This run only reads one PR — scope the token to that repo, not the org.
+          # This run reads one PR, so the token is scoped to that repo.
           repositories: ${{ matrix.pr.repo }}
           permission-contents: read
           permission-issues: read
@@ -195,12 +194,12 @@ jobs:
           repo: ${{ matrix.pr.repo }}
           pull_request_number: ${{ matrix.pr.number }}
           github_token: ${{ steps.token.outputs.token }}
-          # Org-level HALT: engaged → this writer no-ops (no re-derive, no board write).
+          # Org-level halt: when engaged this writer no-ops, with no re-derive and no board write.
           kill_switch: ${{ vars.AGENT_KILL_SWITCH }}
 
-  # Staleness fail-safe: re-post merge-gate on each open epic-member PR — a sibling
-  # changing in another repo emits no event to it. merge-gate mints its own org-wide
-  # token (it walks siblings across repos), so no token is scoped here.
+  # Staleness fail-safe: re-post merge-gate on each open Epic-member PR, since a sibling changing in
+  # another repo emits no event to it. merge-gate walks siblings across repos and mints its own
+  # org-wide token, so nothing is scoped here.
   regate:
     needs: enumerate
     if: ${{ needs.enumerate.outputs.epic_prs != '[]' }}
@@ -218,15 +217,16 @@ jobs:
           repo: ${{ matrix.pr.repo }}
           pull_request_number: ${{ matrix.pr.number }}
           head_sha: ${{ matrix.pr.sha }}
-          # Org-level HALT: engaged → merge-gate HOLDs (posts failure) this idle PR too, so a PR that
-          # emits no event while halted is still stopped. A gate must post failure, never skip.
+          # Org-level halt: when engaged merge-gate holds this idle PR too by posting failure, so a
+          # PR that emits no event while halted is still stopped. A gate posts failure; skipping would
+          # leave a neutral check that passes.
           kill_switch: ${{ vars.AGENT_KILL_SWITCH }}
 
-  # Partial-landing fail-safe: the SWEEP half of the epic-freeze detector. A single whole-org
-  # invocation — it self-enumerates every active Epic and every open head, so it needs no
-  # matrix and no `needs`. SWEEP mode (no pull_request_number; the event is schedule/dispatch).
-  # It mints its own org-wide tokens (read + checks +, sweep-only, a write token for grace-bounded
-  # roll-forward), so no token/permission is scoped here. dry_run threads from the caller.
+  # Partial-landing fail-safe: the sweep half of the epic-freeze detector. One whole-org invocation
+  # self-enumerates every active Epic and every open head, so it needs no matrix and no `needs`. It
+  # runs in sweep mode, with no pull_request_number, on a schedule or dispatch event. It mints its own
+  # org-wide read and checks tokens, plus a sweep-only write token for the grace-bounded
+  # roll-forward, so nothing is scoped here. dry_run threads from the caller.
   detect:
     runs-on: ubuntu-latest
     permissions: {}
@@ -236,16 +236,16 @@ jobs:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
           dry_run: ${{ inputs.detect_dry_run }}
-          # Org-level HALT (FAIL-SAFE, see the rollup job): engaged → the sweep skips all work
-          # (merge-gate HOLDs every PR via regate). The BLAST-CAP (max_freeze_repos) keeps its action
-          # default of 5 — an over-wide Epic is frozen ANYWAY (fail-safe) and merely flags the sweep RED.
+          # Org-level halt, fail-safe as in the rollup job: when engaged the sweep skips all work,
+          # while regate has merge-gate holding every PR. max_freeze_repos keeps its action default of
+          # 5; an over-wide Epic is frozen anyway and only flags the sweep red.
           kill_switch: ${{ vars.AGENT_KILL_SWITCH }}
 
-  # Display-only read-model: rewrite each active Epic's derived status table into its issue body. A
-  # single whole-org invocation — it self-enumerates active Epics and their siblings, so it needs no
-  # matrix and no `needs`. It is NOT authority (no board write, no check-run; a lost table is
-  # cosmetic), so it mints its own org-wide token and never fails the sweep. dry_run threads from the
-  # caller, independent of the other passes.
+  # Display-only read-model: rewrite each active Epic's derived status table into its issue body. One
+  # whole-org invocation self-enumerates active Epics and their siblings, so it needs no matrix and no
+  # `needs`. It is not authority — no board write, no check-run, and a lost table is cosmetic — so it
+  # mints its own org-wide token and never fails the sweep. dry_run threads from the caller,
+  # independent of the other passes.
   render:
     runs-on: ubuntu-latest
     permissions: {}
@@ -255,5 +255,5 @@ jobs:
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.private_key }}
           dry_run: ${{ inputs.render_dry_run }}
-          # Org-level HALT: engaged → this display-only writer no-ops (no Epic-body edits).
+          # Org-level halt: when engaged this display-only writer no-ops, editing no Epic body.
           kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/.github/workflows/release-train-run.yaml
+++ b/.github/workflows/release-train-run.yaml
@@ -1,8 +1,9 @@
 name: release-train (reusable)
 
-# The REUSABLE release-train engine (workflow_call): every governed repo's thin `release-train.yaml`
-# dispatch caller (repocfg-provisioned) calls this with its org creds + admin dispatch inputs. Runs in
-# the CALLER's context. Nested actions are remote-pinned (`./` in a reusable resolves to the caller, not here).
+# The reusable release-train engine (workflow_call). Every governed repo's thin `release-train.yaml`
+# dispatch caller, provisioned by repocfg, calls this with its org creds and admin dispatch inputs. It
+# runs in the caller's context, so nested actions are remote-pinned: a `./` path in a reusable
+# workflow resolves against the caller.
 on:
   workflow_call:
     inputs:
@@ -14,8 +15,8 @@ on:
         description: "true (default) = rehearse every repo, cut nothing; false = actually cut the releases."
         required: false
         default: "true"
-        # Former `choice` dispatch input. workflow_call has no choice type, so the thin caller keeps the
-        # choice-typed UI/API guard and passes a validated string through here.
+        # workflow_call has no choice type, so the thin caller keeps the choice-typed UI and API
+        # guard and passes a validated string through here.
         type: string
       client_id:
         description: The [Agent] bot App client id.
@@ -36,12 +37,12 @@ on:
 jobs:
   release-train:
     runs-on: ubuntu-latest
-    # The default token is used only for the admin check (Metadata:read, always present); the
-    # release-train action mints its own least-privilege [Agent] tokens (dispatch + reads).
+    # The default token serves only the admin check, which needs Metadata:read; the release-train
+    # action mints its own least-privilege [Agent] tokens for the dispatch and the reads.
     permissions:
       contents: read
     steps:
-      # Fail closed unless the dispatcher is a repo admin, AND the epic number is numeric.
+      # Fail closed unless the dispatcher is a repo admin and the Epic number is numeric.
       # workflow_dispatch is open to any write user, so this gate is what keeps the release train
       # admin-only.
       - name: Require admin + numeric epic
@@ -53,9 +54,8 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          # Admin gate (copied from a-novel-kit/workflows' generic-actions/approve-pr/action.yaml):
-          # `|| echo ""` keeps a failed lookup from tripping `set -e` — an empty permission falls
-          # through and fails closed.
+          # Admin gate: `|| echo ""` keeps a failed lookup from tripping `set -e`, and an empty
+          # permission falls through and fails closed.
           perm=$(gh api "repos/${REPO_FULL}/collaborators/${ACTOR}/permission" -q '.permission' 2>/dev/null || echo "")
           if [ "$perm" != "admin" ]; then
             echo "::error::release-train is admin-only; @${ACTOR} has permission '${perm:-none}'."
@@ -74,8 +74,8 @@ jobs:
           app_private_key: ${{ secrets.app_private_key }}
           epic_number: ${{ inputs.epic_number }}
           dry_run: ${{ inputs.dry_run }}
-          # Org-level HALT (FAIL-SAFE — RUNNING only for an explicit off-token: empty/unset, 0, off,
-          # false, no, disabled; ANYTHING else, incl. a fat-fingered value, engages) → the action
-          # aborts loud as its first step, before any mint. Threaded from the org variable (a composite
-          # action can't read `vars` itself).
+          # Org-level halt. Fail-safe: running only for an explicit off-token (empty/unset, 0, off,
+          # false, no, disabled); any other value engages it and the action aborts loudly as its first
+          # step, before any mint. Threaded from the org variable, which a composite action cannot
+          # read itself.
           kill_switch: ${{ inputs.kill_switch }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,8 @@
 name: release
 
-# Releases are cut from the GitHub UI (Actions ▸ release ▸ pick a type ▸ Run),
-# not from a developer's terminal. workflow_call exposes the same inputs so an
-# agent can drive an identical release headlessly later. The protected `release`
-# environment is the "who can publish" gate (configure its required reviewers).
+# Releases are cut from the GitHub UI: Actions ▸ release ▸ pick a type ▸ Run. workflow_call exposes
+# the same inputs, so an agent can drive an identical release headlessly. The protected `release`
+# environment is the "who can publish" gate, through its required reviewers.
 on:
   workflow_dispatch:
     inputs:
@@ -32,12 +31,11 @@ on:
 
 run-name: "🚀 release ${{ inputs.release_type }}${{ inputs.dry_run && ' (dry-run)' || '' }}"
 
-# No concurrency lock, on purpose. If two releases are triggered at once both
-# compute the same next tag; the first push wins and the second is rejected
-# (non-fast-forward / tag already exists) and fails in the release job below,
-# before any build job runs — so accidental double-triggers can't double-release.
-# A concurrency *queue* would instead serialize them and let the second cut a
-# second release. The protected `release` environment is the human gate on top.
+# There is no concurrency lock. Two releases triggered at once compute the same next tag: the first
+# push wins and the second is rejected as non-fast-forward, failing in the release job below before
+# any build job runs, so an accidental double-trigger cannot double-release. A concurrency queue
+# would serialize them instead and let the second cut a second release. The protected `release`
+# environment is the human gate on top.
 
 jobs:
   release:
@@ -49,8 +47,8 @@ jobs:
       version: ${{ steps.core.outputs.version }}
       tag: ${{ steps.core.outputs.tag }}
     steps:
-      # Initial checkout makes the local ./publish-actions/* actions available;
-      # release-core re-checks-out with the bot token to push.
+      # This checkout makes the local ./publish-actions/* actions available; release-core
+      # re-checks-out with the bot token to push.
       - uses: actions/checkout@v7
       - id: core
         uses: ./publish-actions/release-core
@@ -59,8 +57,8 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
-      # Everything on master just shipped — clear this repo's awaiting-release
-      # items off the board. Skipped on a dry run (nothing was released).
+      # Everything on master has now shipped, so clear this repo's awaiting-release items off the
+      # board. Skipped on a dry run, where nothing was released.
       - if: ${{ !inputs.dry_run }}
         uses: ./generic-actions/archive-board-items
         with:
@@ -68,7 +66,6 @@ jobs:
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
           project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
 
-      # Surface the cut version in the run summary so a release run is
-      # identifiable by version at a glance (run-name carries only the bump type).
+      # Surface the cut version in the run summary, since the run name carries only the bump type.
       - if: ${{ !inputs.dry_run }}
         run: echo "## 🚀 Released \`${{ steps.core.outputs.tag }}\` (${{ inputs.release_type }})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,7 @@ run-name: "🚀 release ${{ inputs.release_type }}${{ inputs.dry_run && ' (dry-r
 
 # There is no concurrency lock. Two releases triggered at once compute the same next tag: the first
 # push wins and the second is rejected as non-fast-forward, failing in the release job below before
-# any build job runs, so an accidental double-trigger cannot double-release. A concurrency queue
-# would serialize them instead and let the second cut a second release. The protected `release`
+# any build job runs, so an accidental double-trigger cannot double-release. The protected `release`
 # environment is the human gate on top.
 
 jobs:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -11,9 +11,9 @@ jobs:
       checks: write
       statuses: write
       contents: write
-      # generic-actions/renovate wires GITHUB_TOKEN as the npm.pkg.github.com
-      # token; an explicit permissions block drops packages to none, so grant
-      # read back or Renovate can't resolve private GitHub Packages deps.
+      # generic-actions/renovate wires GITHUB_TOKEN as the npm.pkg.github.com token, and an
+      # explicit permissions block drops packages to none, so read is granted back here or
+      # Renovate cannot resolve private GitHub Packages dependencies.
       packages: read
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/token-expiry.yaml
+++ b/.github/workflows/token-expiry.yaml
@@ -1,17 +1,16 @@
-# Reusable daily fine-grained-PAT expiry watcher for a WHOLE org. Runs every day, but only PINGS the
-# dedicated Discord channel (TOKEN_EXPIRY_WEBHOOK) when a token hits a milestone in the PING POLICY
-# below — so quiet days stay silent. Each ping @mentions a single configured admin (default_mention)
-# who triages; the token's OWNER login is shown in the message. Per-owner pinging is deferred to the
-# Bitwarden resolver (a-novel-kit/.github#101, resolver #104) — wire it where `did` is resolved below.
-# Per-org caller pattern, like watchdog: the caller owns schedule + concurrency; this owns
-# enumeration + the policy + the pings.
+# Reusable daily fine-grained-PAT expiry watcher for a whole org. It runs every day but pings the
+# dedicated Discord channel only when a token crosses a milestone in the ping policy below, so quiet
+# days stay silent. Each ping @mentions one configured admin, who triages, and shows the token owner's
+# login in the message. Per-owner pinging waits on the Bitwarden resolver; wire it where `did` is
+# resolved below. The caller owns the schedule and concurrency, as it does for watchdog, while this
+# owns the enumeration, the policy and the pings.
 #
-# TEST RUN: fire the caller from the UI with test_run=true to post for EVERY PAT regardless of the
-# policy (still admin-only, still for real) — a safe end-to-end drill of the channel + formatting.
+# Firing the caller from the UI with test_run=true posts for every PAT regardless of the policy,
+# still admin-only and still for real: an end-to-end drill of the channel and the formatting.
 #
-# It reads ONLY metadata via the org PAT endpoint (the App token carries
-# organization_personal_access_tokens: READ) — owner login, name, expiry, access-granted date. It
-# never holds a token value: unlike a header-based check it can't leak a credential.
+# It reads metadata alone through the org PAT endpoint, on an App token carrying
+# organization_personal_access_tokens read: owner login, name, expiry, access-granted date. It never
+# holds a token value, so unlike a header-based check it cannot leak a credential.
 name: token-expiry
 
 on:
@@ -75,17 +74,18 @@ jobs:
           set -euo pipefail
           now=$(date -u +%s)
 
-          # ── PING POLICY — edit here ─────────────────────────────────────────────────────────────
-          # Ping ONCE as %-of-lifetime-remaining crosses BELOW each milestone (stateless: fired iff
-          # yesterday's % was above and today's is at/below it), AND every day within
-          # FINAL_STRETCH_DAYS of expiry (an already-expired token counts as within the stretch).
-          # Lifetime is derived as (expires_at − access_granted_at): EXACT for the final-stretch rule,
-          # APPROXIMATE for the % milestones (a token re-approval resets access_granted_at). A token
-          # with no derivable lifetime still gets the final-stretch pings.
+          # ── Ping policy — edit here ─────────────────────────────────────────────────────────────
+          # Ping once as the percentage of lifetime remaining crosses below each milestone. The rule
+          # is stateless: it fires when yesterday's percentage was above the milestone and today's is
+          # at or below it. It also pings every day within FINAL_STRETCH_DAYS of expiry, counting an
+          # already-expired token as inside the stretch. Lifetime is derived as expires_at minus
+          # access_granted_at, which is exact for the final-stretch rule and approximate for the
+          # percentage milestones, since a token re-approval resets access_granted_at. A token with no
+          # derivable lifetime still gets the final-stretch pings.
           LIFETIME_MILESTONES="50 30 10"
           FINAL_STRETCH_DAYS=7
           # ────────────────────────────────────────────────────────────────────────────────────────
-          # Returns a human ping reason (→ ping) or nothing (→ stay silent). $1 days-left, $2 lifetime-days.
+          # Prints a human ping reason, or nothing to stay silent. $1 days-left, $2 lifetime-days.
           ping_reason() {
             local days="$1" life="$2" m pct pct_yst
             if [ "$days" -le "$FINAL_STRETCH_DAYS" ]; then
@@ -104,12 +104,12 @@ jobs:
             return 1
           }
 
-          # A test run posts for EVERY token, for real (overrides dry_run).
+          # A test run posts for every token, for real, overriding dry_run.
           TEST_RUN=$(printf '%s' "${TEST_RUN:-false}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
           [ "$TEST_RUN" = "true" ] || TEST_RUN=false
           [ "$TEST_RUN" = "true" ] && DRY_RUN=false
 
-          # Post one Discord payload with a small retry + timeouts. $1 = JSON payload.
+          # Post one Discord payload with a small retry and explicit timeouts. $1 = JSON payload.
           post_discord() {
             local payload="$1" max=3 code=000 attempt
             for attempt in $(seq 1 "$max"); do
@@ -123,8 +123,8 @@ jobs:
             return 1
           }
 
-          # Every fine-grained PAT with org access + its expiry/grant metadata. Fail LOUD (not to [])
-          # so a read error can't masquerade as "nothing to ping".
+          # Every fine-grained PAT with org access, plus its expiry and grant metadata. A read error
+          # fails loudly rather than yielding an empty list, which would read as nothing to ping.
           if ! pats=$(gh api "/orgs/${ORG}/personal-access-tokens" --paginate 2>"$RUNNER_TEMP/pat.err"); then
             echo "::error::could not list PATs for ${ORG} ($(tr '\n' ' ' < "$RUNNER_TEMP/pat.err")). A 404 means the App lacks organization_personal_access_tokens:read on this org."
             exit 1
@@ -151,7 +151,7 @@ jobs:
             [ -n "${name:-}" ] || continue
             total=$((total + 1))
 
-            # Days remaining (expired → -1; a parsed past date clamps to 0).
+            # Days remaining; an expired token gives -1, and a parsed past date clamps to 0.
             exp_ts=0
             if [ "$expired" = "true" ]; then
               days=-1
@@ -163,7 +163,7 @@ jobs:
               echo "  - ${name} (${login}): no expiry metadata — skipped" >> "$GITHUB_STEP_SUMMARY"; continue
             fi
 
-            # Lifetime (days) from access_granted_at → expires_at; 0 when not derivable.
+            # Lifetime in days, from access_granted_at to expires_at, or 0 when not derivable.
             life=0
             if [ "$expired" != "true" ] && [ -n "$granted" ] && [ "$exp_ts" -gt 0 ]; then
               g_ts=$(date -u -d "$granted" +%s 2>/dev/null || echo 0)
@@ -172,37 +172,37 @@ jobs:
 
             status=$([ "$expired" = "true" ] && echo "EXPIRED" || echo "${days}d left")
             reason=$(ping_reason "$days" "$life" || true)
-            # A test run pings EVERY token (bypasses the policy) so we can validate the REAL message
-            # rendering — so it still needs a reason when no milestone fired: fall back to the token's
-            # status. Everything below is otherwise IDENTICAL to a genuine ping (same content, embed,
-            # color, reason format); only the recipient differs (admin, since we can't ping owners in a
-            # drill). The 🧪 markers live in the run summary only, never in the delivered message.
+            # A test run pings every token, bypassing the policy, to validate the real message
+            # rendering, so it still needs a reason when no milestone fired and falls back to the
+            # token's status. Everything below is identical to a genuine ping — same content, embed,
+            # color and reason format — and only the recipient differs, being the admin rather than
+            # the owner. The 🧪 markers live in the run summary, never in the delivered message.
             if [ "$TEST_RUN" = "true" ] && [ -z "$reason" ]; then reason="$status"; fi
             if [ -z "$reason" ]; then
               echo "  - ${name} (${login}): ${status} — no ping today" >> "$GITHUB_STEP_SUMMARY"; continue
             fi
             echo "  - ${name} (${login}): ${status} — PING (${reason})" >> "$GITHUB_STEP_SUMMARY"
 
-            # ── "Our shape" — single source of truth is generic-actions/token-expiry-notify ────────
-            # The whole message is ONE embed description (no title field): a heading with days-left, a
-            # `-#` grey subtext, a blank line, then the masked regen link. Adapted for the org-wide
-            # sweep: the owner login is shown in the subtext (the owner isn't the runner), and a single
-            # admin is @mentioned via `content` — Discord only fires a notification on a content
-            # mention, never one inside an embed.
+            # ── Message shape, following generic-actions/token-expiry-notify ────────────────────
+            # The whole message is one embed description with no title field: a heading with the days
+            # left, a `-#` grey subtext, a blank line, then the masked regen link. The org-wide sweep
+            # adds the owner login to the subtext, since the owner is not the runner, and @mentions
+            # one admin through `content` — Discord fires a notification only on a content mention,
+            # never on one inside an embed.
             hdays=$([ "$days" -lt 0 ] && echo 0 || echo "$days")   # heading never shows a negative
             pctline=""
             if [ "$life" -gt 0 ]; then
               pct=$(( days * 100 / life )); [ "$pct" -gt 100 ] && pct=100; pctline=" | ${pct}% left"
             fi
-            # Color by absolute days remaining: green >30, yellow >14, orange >7, red ≤7 / expired.
+            # Color by absolute days remaining: green >30, yellow >14, orange >7, red ≤7 or expired.
             if [ "$expired" = "true" ] || [ "$days" -le 7 ]; then color=15158332
             elif [ "$days" -le 14 ]; then color=15105570
             elif [ "$days" -le 30 ]; then color=15844367
             else color=3066993; fi
-            # Scope + permissions come from the live per-token API data (not hardcoded), then the same
-            # regen recipe as the original notify-action message: masked link, owner/scope/permissions,
-            # and the `gh secret set` block. SECRET_NAME is a fill-in — the org PAT API exposes the
-            # token's own name, not the Actions-secret name it may be stored under.
+            # Scope and permissions come from the live per-token API data, followed by the same regen
+            # recipe the notify action's message uses: masked link, owner, scope, permissions and the
+            # `gh secret set` block. SECRET_NAME is a fill-in, since the org PAT API exposes the
+            # token's own name rather than the Actions-secret name it may be stored under.
             case "$repo_sel" in
               all)      scope="All repositories" ;;
               selected) scope="Selected repositories" ;;
@@ -220,9 +220,9 @@ jobs:
             desc=$(printf '%s' "$desc" | head -c 3900)
             desc=$(printf '%s' "$desc" | iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || printf '%s' "$desc")
 
-            # The admin @mention lives in `content` (fail-soft: no admin → post the embed WITHOUT a
-            # ping, which then matches the notify action's own payload exactly). users:[id] allows ONLY
-            # that one admin; parse:[] blocks @everyone/@here/roles.
+            # The admin @mention lives in `content`, fail-soft: with no admin configured the embed
+            # posts unpinged, matching the notify action's own payload. users:[id] allows that one
+            # admin alone, and parse:[] blocks @everyone, @here and roles.
             did="${DEFAULT_MENTION:-}"; target=admin
             if [ -n "$did" ]; then
               echo "::add-mask::$did"   # defensive: keep the admin id out of logs

--- a/.github/workflows/token-expiry.yaml
+++ b/.github/workflows/token-expiry.yaml
@@ -124,7 +124,7 @@ jobs:
           }
 
           # Every fine-grained PAT with org access, plus its expiry and grant metadata. A read error
-          # fails loudly rather than yielding an empty list, which would read as nothing to ping.
+          # fails loudly, since an empty list reads as nothing to ping.
           if ! pats=$(gh api "/orgs/${ORG}/personal-access-tokens" --paginate 2>"$RUNNER_TEMP/pat.err"); then
             echo "::error::could not list PATs for ${ORG} ($(tr '\n' ' ' < "$RUNNER_TEMP/pat.err")). A 404 means the App lacks organization_personal_access_tokens:read on this org."
             exit 1
@@ -175,8 +175,8 @@ jobs:
             # A test run pings every token, bypassing the policy, to validate the real message
             # rendering, so it still needs a reason when no milestone fired and falls back to the
             # token's status. Everything below is identical to a genuine ping — same content, embed,
-            # color and reason format — and only the recipient differs, being the admin rather than
-            # the owner. The 🧪 markers live in the run summary, never in the delivered message.
+            # color and reason format — and only the recipient differs: a test run delivers to the
+            # admin. The 🧪 markers live in the run summary, never in the delivered message.
             if [ "$TEST_RUN" = "true" ] && [ -z "$reason" ]; then reason="$status"; fi
             if [ -z "$reason" ]; then
               echo "  - ${name} (${login}): ${status} — no ping today" >> "$GITHUB_STEP_SUMMARY"; continue
@@ -201,8 +201,8 @@ jobs:
             else color=3066993; fi
             # Scope and permissions come from the live per-token API data, followed by the same regen
             # recipe the notify action's message uses: masked link, owner, scope, permissions and the
-            # `gh secret set` block. SECRET_NAME is a fill-in, since the org PAT API exposes the
-            # token's own name rather than the Actions-secret name it may be stored under.
+            # `gh secret set` block. SECRET_NAME is a fill-in: the org PAT API exposes the token's own
+            # name, and the Actions-secret name it is stored under is unavailable there.
             case "$repo_sel" in
               all)      scope="All repositories" ;;
               selected) scope="Selected repositories" ;;

--- a/.github/workflows/watchdog.yaml
+++ b/.github/workflows/watchdog.yaml
@@ -3,7 +3,7 @@
 # its own lock wait, but an App outage, a hung step or a dropped event can still leave a required
 # check with no conclusion — blocking a PR indefinitely, since a plain PR has no merge-queue timeout —
 # or a hotfix run hung holding its lock. This scheduled sweep notices those and escalates each, so a
-# stuck automation surfaces to a human instead of silently blocking work.
+# stuck automation surfaces to a human.
 #
 # Two detections, org-wide:
 #   - stale check: an open PR whose required merge-gate / epic-freeze check has had no terminal

--- a/.github/workflows/watchdog.yaml
+++ b/.github/workflows/watchdog.yaml
@@ -1,17 +1,17 @@
-# Reusable staleness watchdog — the fail-safe backstop for the exception path (a-novel-kit/.github#95).
-# The event-driven posters (merge-gate / epic-freeze) always TRY to post a terminal conclusion, and a
-# hotfix aborts its own lock wait — but an App outage, a hung step, or a dropped event can still leave a
-# required check stuck with no conclusion (a PR blocked forever, since a plain PR has no merge-queue
-# timeout) or a hotfix run hung holding its lock. This scheduled sweep NOTICES those and escalates each,
-# so a stuck automation always surfaces to a human instead of silently blocking work.
+# Reusable staleness watchdog: the fail-safe backstop for the exception path. The event-driven
+# posters, merge-gate and epic-freeze, always try to post a terminal conclusion, and a hotfix aborts
+# its own lock wait, but an App outage, a hung step or a dropped event can still leave a required
+# check with no conclusion — blocking a PR indefinitely, since a plain PR has no merge-queue timeout —
+# or a hotfix run hung holding its lock. This scheduled sweep notices those and escalates each, so a
+# stuck automation surfaces to a human instead of silently blocking work.
 #
 # Two detections, org-wide:
 #   - stale check: an open PR whose required merge-gate / epic-freeze check has had no terminal
 #     conclusion for longer than the threshold (the check never posted, or is stuck pending).
-#   - stuck hotfix: a hotfix.yaml run in_progress longer than the threshold (a hung step holding the
-#     per-repo hotfix lock, blocking further hotfixes there).
-# Each finding fans out to the escalate action (one deduped ticket per condition). The `when`
-# (cron / concurrency) lives in the thin per-org caller, exactly like reconcile-board.
+#   - stuck hotfix: a hotfix.yaml run in_progress longer than the threshold, a hung step holding the
+#     per-repo hotfix lock and blocking further hotfixes there.
+# Each finding fans out to the escalate action, one deduped ticket per condition. The schedule and
+# concurrency live in the thin per-org caller, as they do for reconcile-board.
 name: watchdog
 
 on:
@@ -67,8 +67,8 @@ on:
         description: Threaded to escalate as the SEV1 push webhook (empty = push channel off).
 
 jobs:
-  # Scan the org for stale required checks + stuck hotfix runs → a findings list the escalate job
-  # matrices over. Read-only; the App token is scoped to reads.
+  # Scan the org for stale required checks and stuck hotfix runs, producing the findings list the
+  # escalate job matrices over. Read-only, on a reads-scoped App token.
   detect:
     runs-on: ubuntu-latest
     permissions: {}
@@ -104,10 +104,10 @@ jobs:
               '$f + [{severity:$s, summary:$m, dedup_key:$d, repo:$r, body:$b}]')
           }
 
-          # ---- STALE CHECKS: open PRs whose required merge-gate/epic-freeze has no terminal conclusion.
-          # A check should complete within seconds of the event; if the PR head is older than the
-          # threshold and the check still isn't COMPLETED, the poster never finished (App outage / dropped
-          # event) and the PR is blocked with no self-heal (a plain PR has no merge-queue timeout).
+          # ---- Stale checks: open PRs whose required merge-gate or epic-freeze has no terminal
+          # conclusion. A check completes within seconds of the event, so a PR head older than the
+          # threshold with the check still incomplete means the poster never finished, through an App
+          # outage or a dropped event, and the PR is blocked with no self-heal.
           q='query($q:String!,$cursor:String){ search(query:$q, type:ISSUE, first:50, after:$cursor){
             pageInfo{ hasNextPage endCursor }
             nodes{ ... on PullRequest{ number url repository{ nameWithOwner }
@@ -131,8 +131,8 @@ jobs:
               for chk in merge-gate epic-freeze; do
                 status=$(printf '%s' "$pr" | jq -r --arg n "$chk" \
                   '[.commits.nodes[0].commit.statusCheckRollup.contexts.nodes[]? | select(.__typename=="CheckRun" and .name==$n)][0].status // "ABSENT"')
-                # COMPLETED = a terminal conclusion posted (success/failure/etc.) → healthy. Anything
-                # else (QUEUED / IN_PROGRESS / ABSENT) after the threshold = stale.
+                # COMPLETED means a terminal conclusion was posted, which is healthy. QUEUED,
+                # IN_PROGRESS or ABSENT past the threshold is stale.
                 if [ "$status" != "COMPLETED" ]; then
                   add sev2 "Stale required check '${chk}' on ${repo}#${num}" \
                     "stale-check:${chk}:${repo}:${num}" "$repo" \
@@ -144,12 +144,12 @@ jobs:
             cursor=$(printf '%s' "$page" | jq -r '.data.search.pageInfo.endCursor')
           done
 
-          # ---- STUCK HOTFIX RUNS: a hotfix.yaml run in_progress past the threshold — a hung step holding
-          # the per-repo hotfix lock (the run's own 30-min lock cap only covers WAITING, not a hang).
+          # ---- Stuck hotfix runs: a hotfix.yaml run in_progress past the threshold, a hung step
+          # holding the per-repo hotfix lock. The run's own 30-minute lock cap covers only the wait.
           repos=$(gh api "orgs/${ORG}/repos" --paginate --jq '.[].name' 2>/dev/null || true)
           while IFS= read -r repo; do
             [ -n "$repo" ] || continue
-            # Repos without a hotfix.yaml error here → skip quietly.
+            # A repo with no hotfix.yaml errors here, and is skipped quietly.
             runs=$(gh run list --repo "${ORG}/${repo}" --workflow hotfix.yaml --status in_progress \
               --json databaseId,createdAt,url --limit 10 2>/dev/null || echo '[]')
             while IFS= read -r run; do
@@ -166,11 +166,11 @@ jobs:
             done < <(printf '%s' "$runs" | jq -c '.[]?')
           done < <(printf '%s\n' "$repos")
 
-          # ---- HEARTBEAT / dead-man's-switch: the scheduled fail-safes (this sweep + reconcile-board)
-          # must keep RUNNING. If a caller workflow in THIS repo hasn't run within the window, its cron
-          # is broken/disabled and the org has silently lost that backstop — page it (SEV1: nothing is
-          # watching). This run catches a fail-safe that stopped-and-resumed or a SIBLING fail-safe
-          # that's down; a fail-safe that's still down is caught by its sibling's own heartbeat.
+          # ---- Heartbeat, a dead-man's switch over the scheduled fail-safes: this sweep and
+          # reconcile-board. A caller workflow in this repo that has not run within the window has a
+          # broken or disabled cron, and the org has silently lost that backstop, which pages as SEV1.
+          # This run catches a fail-safe that stopped and resumed, or a sibling that is down; a
+          # fail-safe still down is caught by its sibling's own heartbeat.
           if [ -n "${HEARTBEAT_WORKFLOWS:-}" ]; then
             IFS=',' read -ra hbwf <<< "$HEARTBEAT_WORKFLOWS"
             for wf in "${hbwf[@]}"; do
@@ -194,7 +194,7 @@ jobs:
           count=$(printf '%s' "$findings" | jq 'length')
           echo "Watchdog scan complete — ${count} stale/stuck finding(s)." | tee -a "$GITHUB_STEP_SUMMARY"
 
-  # One escalate per finding (deduped by its stable key, so a recurring condition updates one ticket).
+  # One escalate per finding, deduped by its stable key, so a recurring condition updates one ticket.
   escalate:
     needs: detect
     if: ${{ needs.detect.outputs.findings != '[]' && needs.detect.outputs.findings != '' }}

--- a/build-actions/docker-job/action.yaml
+++ b/build-actions/docker-job/action.yaml
@@ -65,8 +65,8 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v7
-    # Derive vX.Y / vX from an explicit version (the dispatched release passes one
-    # because the workflow runs on the default branch, where the ref isn't a tag).
+    # Derive vX.Y and vX from an explicit version. The dispatched release passes one
+    # because the workflow runs on the default branch, where the ref is not a tag.
     - id: ver
       if: ${{ inputs.version != '' }}
       shell: bash
@@ -79,7 +79,7 @@ runs:
       with:
         images: ghcr.io/${{ inputs.image_name }}
         tags: |
-          # Ref-derived tags (legacy tag-push flow) — off when a version is passed.
+          # Ref-derived tags for the tag-push flow, off when a version is passed.
           type=schedule,pattern=nightly,enable=${{ inputs.version == '' }}
           type=ref,event=branch,enable=${{ inputs.version == '' }}
           type=ref,event=tag,enable=${{ inputs.version == '' }}
@@ -101,13 +101,12 @@ runs:
     - uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
-        # Persist the module + go-build cache across runs so an image whose Go
-        # sources are unchanged (or only partly changed) reuses the previous
-        # run's compilation instead of building cold. mode=max caches the
-        # intermediate builder stage (where `go build` runs), not just the final
-        # layers. Scope is per-image: each service/job image builds in its own
-        # job, so a shared scope would let those parallel builds evict each
-        # other's cache — the image name keeps them isolated.
+        # Persist the module and go-build cache across runs, so an image whose Go
+        # sources are unchanged, or only partly changed, reuses the previous run's
+        # compilation. mode=max also caches the intermediate builder stage where
+        # `go build` runs. The scope is per image, since each image builds in its
+        # own job and a shared scope would let those parallel builds evict each
+        # other's cache.
         cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
         cache-to: ${{ inputs.cache == 'true' && format('type=gha,mode=max,scope={0}', inputs.image_name) || '' }}
         load: true
@@ -159,9 +158,8 @@ runs:
       id: build
       with:
         context: ${{ inputs.context }}
-        # Restore only: the push build shares this job's warm buildx cache from
-        # the load build above, so it re-tags/pushes the already-built layers
-        # rather than recompiling.
+        # Restore only: the push build shares this job's warm buildx cache from the
+        # load build above, so it re-tags and pushes the already-built layers.
         cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/build-actions/docker-job/action.yaml
+++ b/build-actions/docker-job/action.yaml
@@ -104,9 +104,8 @@ runs:
         # Persist the module and go-build cache across runs, so an image whose Go
         # sources are unchanged, or only partly changed, reuses the previous run's
         # compilation. mode=max also caches the intermediate builder stage where
-        # `go build` runs. The scope is per image, since each image builds in its
-        # own job and a shared scope would let those parallel builds evict each
-        # other's cache.
+        # `go build` runs. The scope is per image, so the parallel jobs building
+        # different images keep separate caches.
         cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
         cache-to: ${{ inputs.cache == 'true' && format('type=gha,mode=max,scope={0}', inputs.image_name) || '' }}
         load: true

--- a/build-actions/docker/action.yaml
+++ b/build-actions/docker/action.yaml
@@ -107,9 +107,8 @@ runs:
         # Persist the module and go-build cache across runs, so an image whose Go
         # sources are unchanged, or only partly changed, reuses the previous run's
         # compilation. mode=max also caches the intermediate builder stage where
-        # `go build` runs. The scope is per image, since each image builds in its
-        # own job and a shared scope would let those parallel builds evict each
-        # other's cache.
+        # `go build` runs. The scope is per image, so the parallel jobs building
+        # different images keep separate caches.
         cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
         cache-to: ${{ inputs.cache == 'true' && format('type=gha,mode=max,scope={0}', inputs.image_name) || '' }}
         load: true

--- a/build-actions/docker/action.yaml
+++ b/build-actions/docker/action.yaml
@@ -68,8 +68,8 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v7
-    # Derive vX.Y / vX from an explicit version (the dispatched release passes one
-    # because the workflow runs on the default branch, where the ref isn't a tag).
+    # Derive vX.Y and vX from an explicit version. The dispatched release passes one
+    # because the workflow runs on the default branch, where the ref is not a tag.
     - id: ver
       if: ${{ inputs.version != '' }}
       shell: bash
@@ -82,7 +82,7 @@ runs:
       with:
         images: ghcr.io/${{ inputs.image_name }}
         tags: |
-          # Ref-derived tags (legacy tag-push flow) — off when a version is passed.
+          # Ref-derived tags for the tag-push flow, off when a version is passed.
           type=ref,event=pr,enable=${{ inputs.version == '' }}
           type=ref,event=branch,enable=${{ inputs.version == '' }}
           type=ref,event=tag,enable=${{ inputs.version == '' }}
@@ -104,13 +104,12 @@ runs:
     - uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
-        # Persist the module + go-build cache across runs so an image whose Go
-        # sources are unchanged (or only partly changed) reuses the previous
-        # run's compilation instead of building cold. mode=max caches the
-        # intermediate builder stage (where `go build` runs), not just the final
-        # layers. Scope is per-image: each service/job image builds in its own
-        # job, so a shared scope would let those parallel builds evict each
-        # other's cache — the image name keeps them isolated.
+        # Persist the module and go-build cache across runs, so an image whose Go
+        # sources are unchanged, or only partly changed, reuses the previous run's
+        # compilation. mode=max also caches the intermediate builder stage where
+        # `go build` runs. The scope is per image, since each image builds in its
+        # own job and a shared scope would let those parallel builds evict each
+        # other's cache.
         cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
         cache-to: ${{ inputs.cache == 'true' && format('type=gha,mode=max,scope={0}', inputs.image_name) || '' }}
         load: true
@@ -151,9 +150,8 @@ runs:
       id: build
       with:
         context: ${{ inputs.context }}
-        # Restore only: the push build shares this job's warm buildx cache from
-        # the load build above, so it re-tags/pushes the already-built layers
-        # rather than recompiling.
+        # Restore only: the push build shares this job's warm buildx cache from the
+        # load build above, so it re-tags and pushes the already-built layers.
         cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.image_name) || '' }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/generic-actions/approve-pr/action.yaml
+++ b/generic-actions/approve-pr/action.yaml
@@ -31,18 +31,17 @@ inputs:
 runs:
   using: composite
   steps:
-    # Org-level HALT (read FIRST, before the admin check or any mint): AGENT_KILL_SWITCH engaged →
-    # refuse to record an approval. A human-triggered mutation aborts loud so the operator sees the
-    # halt and lifts it deliberately rather than silently doing nothing.
+    # Org-level halt, read before the admin check or any mint. A human-triggered mutation aborts
+    # loudly so the operator sees the halt and lifts it deliberately.
     - name: Halt guard (kill-switch)
       shell: bash
       env:
         KILL_SWITCH: ${{ inputs.kill_switch }}
       run: |
         set -euo pipefail
-        # FAIL-SAFE: RUNNING only for an explicit off-token (empty/unset, 0, off, false, no,
-        # disabled); ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. A failing step
-        # stops the composite, so the admin check, mint, and approval never run.
+        # Fail-safe: running only for an explicit off-token (empty/unset, 0, off, false, no,
+        # disabled); any other value engages the halt. A failing step stops the composite, so the
+        # admin check, the mint and the approval never run.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)
@@ -51,10 +50,9 @@ runs:
             ;;
         esac
 
-    # Fail closed unless the actor who dispatched this is a repo admin —
-    # workflow_dispatch is open to anyone with write access, so this check is what
-    # keeps it admin-only. The collaborator-permission endpoint needs only
-    # Metadata:read (always present), so the default token suffices.
+    # Fail closed unless the dispatching actor is a repo admin: workflow_dispatch is
+    # open to anyone with write access. The collaborator-permission endpoint needs
+    # only Metadata:read, so the default token suffices.
     - name: Require admin
       shell: bash
       env:
@@ -72,8 +70,8 @@ runs:
         fi
         echo "@${ACTOR} is a repo admin — recording an [Agent] approval." | tee -a "$GITHUB_STEP_SUMMARY"
 
-    # Mint a token scoped to ONLY what an approval needs: read the repo (so the
-    # nested approve-bot can `gh pr checkout`) plus write the PR review.
+    # Mint a token scoped to what an approval needs: read the repo, so the nested
+    # approve-bot can `gh pr checkout`, plus write the PR review.
     - name: Mint approval token
       id: token
       uses: actions/create-github-app-token@v3
@@ -84,10 +82,10 @@ runs:
         permission-contents: read
         permission-pull-requests: write
 
-    # approve-bot runs `gh pr checkout`, so a base checkout must exist first. Use
-    # the minted token so the action stays on its least-privilege token and never
-    # depends on the default token's contents permission; persist-credentials:false
-    # keeps it out of the git config (approve-bot passes it to gh explicitly).
+    # approve-bot runs `gh pr checkout`, so a base checkout must exist first. The
+    # minted token keeps this off the default token's contents permission, and
+    # persist-credentials:false keeps it out of the git config — approve-bot passes
+    # it to gh explicitly.
     - uses: actions/checkout@v7
       with:
         token: ${{ steps.token.outputs.token }}

--- a/generic-actions/archive-board-items/action.yaml
+++ b/generic-actions/archive-board-items/action.yaml
@@ -58,9 +58,8 @@ inputs:
 runs:
   using: composite
   steps:
-    # Mint a token that can write the org's Projects v2 — and nothing else.
-    # The [Agent] App can do more (issues/PRs), but we request only the org
-    # Projects scope, so a leak of this step's token is bounded to board edits.
+    # Mint a token scoped to the org's Projects v2 alone, so a leak of this
+    # step's token is bounded to board edits.
     - name: Mint org-Projects token
       id: token
       uses: actions/create-github-app-token@v3
@@ -84,7 +83,6 @@ runs:
       run: |
         set -euo pipefail
 
-        # The org "Tasks" board id is passed in directly — no title lookup.
         proj_id="$PROJECT_ID"
         if [ -z "$proj_id" ]; then
           echo "::error::project_id is required (the org \"Tasks\" board node id)"
@@ -95,8 +93,8 @@ runs:
         REPO_FULL="${REPO_IN:-$GITHUB_REPOSITORY}"
 
         # Page the board, keeping this repo's still-on-board items in $STATUS.
-        #    isArchived guards idempotency: an already-archived item is skipped,
-        #    so a re-run (or overlapping triggers) never double-archives.
+        #    isArchived guards idempotency: an already-archived item is skipped, so a
+        #    re-run or an overlapping trigger never double-archives.
         items_q='
           query($proj:ID!,$cursor:String){ node(id:$proj){ ... on ProjectV2{
             items(first:100, after:$cursor){
@@ -146,8 +144,8 @@ runs:
             echo "- [dry-run] would $verb #$num ($url)" | tee -a "$GITHUB_STEP_SUMMARY"
           else
             gh api graphql -f query="$archive_m" -F proj="$proj_id" -F item="$id" >/dev/null
-            # Close the tracker too — archiving a board item does NOT close the issue. Best-effort:
-            # a board item that is a PR/draft has no closable issue, so tolerate a failure.
+            # Archiving a board item leaves its issue open, so close the tracker too. Best-effort:
+            # a board item that is a PR or a draft has no closable issue.
             if [ "$CLOSE" = "true" ] && [ -n "$num" ] && [ "$num" != "null" ] && [ -n "$rp" ] && [ "$rp" != "null" ]; then
               gh issue close "$num" --repo "$rp" --reason completed >/dev/null 2>&1 || true
             fi

--- a/generic-actions/assign-bot/action.yaml
+++ b/generic-actions/assign-bot/action.yaml
@@ -21,18 +21,18 @@ runs:
         AUTHOR: ${{ github.event.pull_request.user.login }}
         AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
       run: |
-        # Pick the assignee. A human author owns their own PR. A bot/app author
-        # (Renovate, Dependabot) can't be assigned — GitHub rejects assigning an
-        # agent with an App installation token (HTTP 403) — so fall back to the
-        # repo's code owner, so dependency PRs still land in a human's queue.
-        # Assignees don't gate merge, so this never blocks the bot's auto-merge.
+        # Pick the assignee. A human author owns their own PR. A bot or app author
+        # such as Renovate cannot be assigned, since GitHub rejects assigning an
+        # agent with an App installation token (HTTP 403), so the repo's code owner
+        # takes it and dependency PRs still land in a human's queue. Assignees do
+        # not gate merge, so this never blocks the bot's auto-merge.
         if [ "$AUTHOR_TYPE" != "Bot" ]; then
           assignees="$AUTHOR"
         else
-          # Resolve the catch-all (*) owners from CODEOWNERS, read via the API
+          # Resolve the catch-all (*) owners from CODEOWNERS, read through the API
           # since this workflow has no checkout. GitHub's precedence is
           # .github/ > root > docs/, and the last matching rule wins. Only @user
-          # owners can be assignees (a @org/team can't), so keep those and drop @.
+          # owners can be assignees, so a @org/team entry is dropped.
           assignees=""
           for path in .github/CODEOWNERS CODEOWNERS docs/CODEOWNERS; do
             content=$(gh api "repos/$REPO/contents/$path" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null) || true

--- a/generic-actions/board-write/action.yaml
+++ b/generic-actions/board-write/action.yaml
@@ -76,9 +76,8 @@ outputs:
 runs:
   using: composite
   steps:
-    # Mint a token that can write the org's Projects v2 — and nothing else. The
-    # [Agent] App can do more (issues/PRs), but requesting only the org Projects scope
-    # bounds a leak of this step's token to board edits.
+    # Mint a token scoped to the org's Projects v2 alone, which bounds a leak of
+    # this step's token to board edits.
     - name: Mint org-Projects token
       id: token
       uses: actions/create-github-app-token@v3
@@ -104,15 +103,10 @@ runs:
       run: |
         set -euo pipefail
 
-        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
-        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
-        # engages. This is the single privileged board mutator, and its guard + the mutation live in
-        # THIS one step, so an `exit 0` here genuinely stops the write — every derived board write
-        # fails safe (no mutation, changed=false) while the org is halted.
-        # The org-Projects token is minted above, ahead of this guard, on purpose: nothing past the
-        # `exit 0` exercises it, so mint-vs-halt ordering is not blast radius here (token SCOPE, not
-        # mint timing, is the enforced bound) — and every action keeps one "mint per least-privilege,
-        # then halt-first" shape instead of duplicating this fail-safe parse pre-mint.
+        # Org-level halt, read before the write. Fail-safe: running only for an explicit off-token
+        # (empty/unset, 0, off, false, no, disabled); any other value engages the halt. This is the
+        # single privileged board mutator, and its guard and mutation share one step, so the `exit 0`
+        # here stops every derived board write (no mutation, changed=false) while the org is halted.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)
@@ -149,9 +143,9 @@ runs:
         fi
 
         # Build the GraphQL value fragment to write, and the sub-selection that reads
-        # the item's current value of this field (for the compare-before-write). Both
-        # inlined values are safe to interpolate: a single-select option id is a GitHub
-        # node id, and a date is format-checked below.
+        # the item's current value for the compare-before-write. Both inlined values are
+        # safe to interpolate: a single-select option id is a GitHub node id, and a date
+        # is format-checked below.
         case "$data_type" in
           SINGLE_SELECT)
             opt_id=$(echo "$fresp" | jq -r --arg v "$VALUE" \
@@ -168,9 +162,9 @@ runs:
               echo "::error::date field \"$FIELD\" needs a YYYY-MM-DD value, got \"$VALUE\""
               exit 1
             fi
-            # Reject a well-formed but impossible date (e.g. 2026-02-30) here, with a
-            # clear message, instead of letting the GraphQL mutation fail obscurely.
-            # A real date round-trips through `date -d`; a bad one errors or normalizes.
+            # Reject a well-formed but impossible date (2026-02-30, say) with a clear
+            # message. A real date round-trips through `date -d`; a bad one errors or
+            # normalizes to a different day.
             if [ "$(date -d "$VALUE" +%Y-%m-%d 2>/dev/null)" != "$VALUE" ]; then
               echo "::error::\"$VALUE\" is not a real calendar date"
               exit 1
@@ -184,10 +178,10 @@ runs:
             ;;
         esac
 
-        # 2. Resolve the content's item in this project; add it if missing (a derived
-        #    write on an un-boarded Task should board it, not vanish). Page through
-        #    projectItems so a content that sits on many projects still matches —
-        #    idempotence must not hinge on the first page holding the target board.
+        # 2. Resolve the content's item in this project, adding it if missing so a derived
+        #    write on an un-boarded Task boards it. Page through projectItems so a content
+        #    sitting on many projects still matches when the target board is not on the
+        #    first page.
         item_q='query($c:ID!,$cursor:String){ node(id:$c){
           ... on Issue{ projectItems(first:100, after:$cursor){
             pageInfo{ hasNextPage endCursor } nodes{ id project{ id } } } }
@@ -218,15 +212,15 @@ runs:
           echo "Added content to the board (item $item_id)." | tee -a "$GITHUB_STEP_SUMMARY"
         fi
 
-        # 3. Compare-before-write: read the item's current value for this field. Equal
-        #    means a re-run or overlapping trigger — no mutation, so no lost update.
+        # 3. Compare-before-write: read the item's current value for this field. An equal
+        #    value means a re-run or an overlapping trigger, so nothing is mutated.
         cur_q="query(\$item:ID!,\$field:String!){ node(id:\$item){ ... on ProjectV2Item{
           fieldValueByName(name:\$field){ $cur_frag } } } }"
         cur=$(gh api graphql -f query="$cur_q" -F item="$item_id" -F field="$FIELD" \
           | jq -r '.data.node.fieldValueByName.current // empty')
 
-        # A set-once field (Start date): if it already holds anything, leave it — don't
-        # let a re-run or the sweep overwrite the original stamp.
+        # A set-once field such as Start date keeps whatever it already holds, so a re-run
+        # or the sweep cannot overwrite the original stamp.
         if [ "$ONLY_IF_EMPTY" = "true" ] && [ -n "$cur" ]; then
           echo "No change — \"$FIELD\" already set (\"$cur\") and only_if_empty." | tee -a "$GITHUB_STEP_SUMMARY"
           {

--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -96,8 +96,8 @@ runs:
           pullRequest(number:$num){
             state isDraft reviewDecision
             closingIssuesReferences(first:5){ nodes{ id number labels(first:20){ nodes{ name } } } } } } }'
-        # A missing or inaccessible PR makes the GraphQL call error; catch it here for a
-        # clear message instead of gh's raw error mid-pipeline.
+        # A missing or inaccessible PR makes the GraphQL call error; catch it here so the failure
+        # surfaces as one clear message.
         if ! pr=$(gh api graphql -f query="$q" -F owner="$OWNER" -F repo="$REPO" -F num="$PR"); then
           echo "::error::could not query PR #$PR (not found, or the token lacks access)"
           exit 1
@@ -179,8 +179,8 @@ runs:
           | tee -a "$GITHUB_STEP_SUMMARY"
 
     # Write the derived Status. board-write mints the [Agent] token, resolves the item,
-    # adding it if absent, and compares before writing. The ref is pinned externally
-    # because a ./ path would resolve against the consumer repo's workspace.
+    # adding it if absent, and compares before writing. The ref is pinned externally, since a `./`
+    # path resolves against the consumer repo's workspace.
     - name: Write Status
       # A composite action has no early return, so the guard step's exit 0 does not stop this
       # mutating step; the `halted` gate does.

--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -55,10 +55,9 @@ inputs:
 runs:
   using: composite
   steps:
-    # Read the PR and compute the target Status. Reads only (PR state + the closing
-    # issue), so this runs on the caller's default token — the caller grants
-    # contents:read + pull-requests:read; the [Agent] token is minted only for the
-    # write, inside board-write.
+    # Read the PR and compute the target Status. This step only reads, so it runs on the
+    # caller's default token with contents:read and pull-requests:read; the [Agent] token
+    # is minted for the write, inside board-write.
     - name: Compute Status + resolve the Task
       id: derive
       shell: bash
@@ -71,12 +70,11 @@ runs:
       run: |
         set -euo pipefail
 
-        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
-        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
-        # engages. When engaged, skip the derivation entirely (no PR read, no board write). A
-        # composite action has NO early return — an `exit 0` here does NOT stop the two board-write
-        # steps — so emit an explicit `halted` output and `if:`-gate EVERY subsequent mutating step on
-        # it. has_issue=false also skips them, but `halted` is the explicit, load-bearing gate.
+        # Org-level halt, read before the derivation. Fail-safe: running only for an explicit
+        # off-token (empty/unset, 0, off, false, no, disabled); any other value engages the halt and
+        # skips the derivation entirely. A composite action has no early return, so an `exit 0` here
+        # does not stop the two board-write steps: this emits a `halted` output and every later
+        # mutating step carries an `if:` on it.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)
@@ -98,8 +96,8 @@ runs:
           pullRequest(number:$num){
             state isDraft reviewDecision
             closingIssuesReferences(first:5){ nodes{ id number labels(first:20){ nodes{ name } } } } } } }'
-        # A not-found / inaccessible PR makes the GraphQL call error; catch that here so
-        # it fails with a clear message rather than gh's raw error mid-pipeline.
+        # A missing or inaccessible PR makes the GraphQL call error; catch it here for a
+        # clear message instead of gh's raw error mid-pipeline.
         if ! pr=$(gh api graphql -f query="$q" -F owner="$OWNER" -F repo="$REPO" -F num="$PR"); then
           echo "::error::could not query PR #$PR (not found, or the token lacks access)"
           exit 1
@@ -108,33 +106,32 @@ runs:
         draft=$(echo "$pr" | jq -r '.data.repository.pullRequest.isDraft')
         review=$(echo "$pr" | jq -r '.data.repository.pullRequest.reviewDecision // ""')
 
-        # A missing/inaccessible PR resolves to null — fail with that, not a downstream
-        # "unexpected state 'null'".
+        # A PR the query could not resolve comes back null; fail here so the message names
+        # the real problem.
         if [ -z "$state" ] || [ "$state" = "null" ]; then
           echo "::error::PR #$PR not found or inaccessible (check the number and token access)"
           exit 1
         fi
 
-        # A Task pairs with exactly one PR, so normally one closing ref. If a PR closes
-        # several, pick the lowest-numbered deterministically (not arbitrary node order)
-        # and warn — the reconcile sweep derives the others from their own PRs anyway.
+        # A Task pairs with exactly one PR, so there is normally one closing ref. A PR that
+        # closes several resolves to the lowest-numbered one, which is deterministic across
+        # re-runs; the reconcile sweep derives the others from their own PRs.
         refs=$(echo "$pr" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes')
         ref_count=$(echo "$refs" | jq 'length')
         issue_id=$(echo "$refs" | jq -r 'sort_by(.number) | .[0].id // empty')
-        # Labels of the SELECTED closing issue — a hotfix cleanup Task carries `hotfix-reconcile`,
-        # which flips its terminal MERGED status from Awaiting-release to Done (see the MERGED case).
+        # Labels of the selected closing issue: a hotfix cleanup Task carries `hotfix-reconcile`,
+        # which makes Done its terminal MERGED status.
         issue_labels=$(echo "$refs" | jq -c 'sort_by(.number) | (.[0].labels.nodes // []) | map(.name)')
         if [ "$ref_count" -gt 1 ]; then
           echo "::warning::PR #$PR closes $ref_count issues; deriving the lowest-numbered. The reconcile sweep covers the rest."
         fi
 
-        # Pure function of the PR's current state — the reconcile sweep re-runs this
-        # identically, so it must not depend on which event fired.
+        # A pure function of the PR's current state: the reconcile sweep re-runs it and has
+        # to reach the same answer whatever event fired.
         case "$state" in
           MERGED)
-            # A hotfix-reconcile cleanup Task is TERMINAL on merge — the forward-port landed, so the
-            # Task is Done. It is NOT awaiting a release (a hotfix cuts its own tag off the reconcile's
-            # baseline, so nothing else ships it), so skip the default Awaiting-release for it.
+            # A hotfix-reconcile cleanup Task is terminal on merge: the forward-port landed and a
+            # hotfix cuts its own tag off the reconcile's baseline, so nothing else ships it.
             if printf '%s' "$issue_labels" | jq -e 'index("hotfix-reconcile")' >/dev/null 2>&1; then
               status="Done"
             else
@@ -163,9 +160,9 @@ runs:
           exit 0
         fi
 
-        # "activated" = the Task has genuinely started (any state past the pre-PR
-        # Backlog/Ready), which is when it earns a Start date. A reverted PR
-        # (closed-unmerged → Ready) is not activated, so it never back-stamps a date.
+        # A Task is "activated" once it moves past the pre-PR Backlog/Ready states, which is
+        # when it earns a Start date. A PR closed unmerged falls back to Ready and stamps
+        # nothing.
         activated=false
         case "$status" in
           "In progress" | "In review" | "Done" | "Awaiting release") activated=true ;;
@@ -181,12 +178,12 @@ runs:
         echo "PR #$PR ($state, draft=$draft, review=${review:-none}) → \"$status\" on issue $issue_id." \
           | tee -a "$GITHUB_STEP_SUMMARY"
 
-    # Write the derived Status. board-write mints the [Agent] token, resolves the item
-    # (adding it if absent), and compares before writing. This pins the external ref
-    # because a ./ path would resolve against the consumer repo's workspace, not this repo.
+    # Write the derived Status. board-write mints the [Agent] token, resolves the item,
+    # adding it if absent, and compares before writing. The ref is pinned externally
+    # because a ./ path would resolve against the consumer repo's workspace.
     - name: Write Status
-      # Gated on `halted` too: a composite action has no early return, so the guard step's exit 0
-      # does not stop this mutating step — it must be skipped explicitly when the org is halted.
+      # A composite action has no early return, so the guard step's exit 0 does not stop this
+      # mutating step; the `halted` gate does.
       if: ${{ steps.derive.outputs.has_issue == 'true' && steps.derive.outputs.halted != 'true' }}
       uses: a-novel-kit/workflows/generic-actions/board-write@v1.20.2
       with:
@@ -201,7 +198,7 @@ runs:
     # Stamp Start date once, on first activity. only_if_empty keeps a re-run or the
     # sweep from moving an already-set start date.
     - name: Stamp Start date (once)
-      # Gated on `halted` too (see Write Status) — the guard's exit 0 cannot stop this later step.
+      # The `halted` gate again: the guard's exit 0 cannot stop this later step.
       if: ${{ steps.derive.outputs.has_issue == 'true' && steps.derive.outputs.activated == 'true' && steps.derive.outputs.halted != 'true' }}
       uses: a-novel-kit/workflows/generic-actions/board-write@v1.20.2
       with:

--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -139,9 +139,8 @@ inputs:
 runs:
   using: composite
   steps:
-    # Mode, computed once before the tokens: per-PR if a pull_request_number was supplied or the event
-    # is a merge_group; else the sweep. Gating the write-token mint on this keeps per-PR to checks +
-    # reads.
+    # Mode, computed before the tokens: per-PR when a pull_request_number was supplied or the event is a
+    # merge_group, else the sweep. Gating the write-token mint on it keeps per-PR to checks + reads.
     - name: Select mode (per-PR vs sweep)
       id: mode
       shell: bash
@@ -158,15 +157,12 @@ runs:
           echo "detect-partial-landing: SWEEP mode."
         fi
 
-    # Least-privilege tokens: the sweep spans the whole org, so the single-repo GITHUB_TOKEN can't see
-    # sibling PRs. The READ and CHECKS tokens are org-wide (the enumeration + the freeze posts span every
-    # repo); the WRITE (enqueue) token is SCOPED to just the active-Epic repos (the scope step below),
-    # since a roll-forward only ever touches a repo with an open Epic PR. A composite action can't loop
-    # create-github-app-token per-repo, but it CAN scope one token to a discovered repo SET.
-    # These mints are deliberately NOT additionally gated on the kill-switch: a halted sweep no-ops
-    # without exercising them (token SCOPE, not mint timing, is the enforced bound), a mint-free halt
-    # is unachievable anyway (the per-PR HOLD below must mint checks:write to post `failure`), and
-    # gating each mint would duplicate the fail-safe off-token parse into a separate pre-mint step.
+    # Least-privilege tokens. The sweep spans the whole org, and the single-repo GITHUB_TOKEN cannot see
+    # sibling PRs. The read and checks tokens are org-wide (enumeration and the freeze posts span every
+    # repo); the enqueue token is scoped to the active-Epic repos discovered below, since a roll-forward
+    # only ever touches a repo with an open Epic PR.
+    # The mints are not gated on the kill-switch: token scope is the enforced bound, and a halted sweep
+    # no-ops without exercising them.
     - name: Mint read token
       id: read
       uses: actions/create-github-app-token@v3
@@ -186,17 +182,14 @@ runs:
         owner: ${{ inputs.org }}
         permission-checks: write
 
-    # Discover the repos with an OPEN epic:<N> PR — the bounded superset of this sweep's roll-forward
-    # targets (a reenqueue target is a landable stray, i.e. an open Epic member). The enqueue token
-    # below is scoped to exactly these, not org-wide, so a leak can't reach a repo that isn't mid-landing.
-    # Reads the same open-PR + label view the run step's enumeration does (labels first:100), so it is a
-    # superset of the reenqueue targets (a stray is an open Epic member). It stays a superset only because
-    # the roll-forward skips strays the label search no longer returns — the frozen activation snapshot
-    # widens MEMBERSHIP past this query, so a snapshot-only member's repo can be absent here; see
-    # sweep_post_clear, which is what keeps that member out of reenqueue's reach. Residual divergence is
-    # only a PR opening in the seconds between (self-heals — the reenqueue logs "next sweep retries") or an
-    # org with >1000 open PRs (not realistic here). A partial page failure abandons the token, never a
-    # partial scope.
+    # Discover the repos with an open epic:<N> PR — the bound on the enqueue token's scope, so a leak
+    # cannot reach a repo that is not mid-landing. It reads the same open-PR + label view the run step
+    # enumerates (labels first:100), which makes it a superset of the roll-forward targets (a stray is an
+    # open Epic member). It stays a superset because the roll-forward skips strays the label search no
+    # longer returns: the frozen activation snapshot widens membership past this query, so a snapshot-only
+    # member's repo can be absent here, and sweep_post_clear keeps that member out of reenqueue's reach.
+    # A PR opened in the seconds between self-heals on the next sweep. A partial page failure abandons
+    # the token, so the scope is never partial.
     - name: Discover active-Epic repos (scope for the enqueue token)
       id: scope
       if: ${{ steps.mode.outputs.mode == 'sweep' }}
@@ -216,8 +209,8 @@ runs:
         while :; do
           args=(-f query="$Q" -f q="org:${ORG} is:pr is:open")
           [ -n "$cursor" ] && args+=(-f cursor="$cursor")
-          # Require a well-formed page (data present, no errors) — same guard as the run step's
-          # search_prs — so a 200 carrying a partial data+errors payload abandons the token, not scopes it.
+          # Require a well-formed page (data present, no errors), the same guard search_prs uses, so a
+          # 200 carrying a partial data+errors payload abandons the token.
           if ! data=$(gh api graphql "${args[@]}" 2>/dev/null) \
             || ! printf '%s' "$data" | jq -e 'has("data") and (has("errors") | not)' >/dev/null 2>&1; then
             failed=1; break
@@ -229,22 +222,22 @@ runs:
           cursor=$(printf '%s' "$data" | jq -r '.data.search.pageInfo.endCursor')
         done
         if [ "$failed" = 1 ]; then
-          # A discovery blip must not yield a PARTIAL scope (a reenqueue in an uncovered repo would 403) —
-          # abandon the enqueue token this sweep. Freeze detection (checks token) is unaffected, and the
-          # next sweep re-discovers and rolls the stray forward then.
+          # A discovery blip abandons the enqueue token for this sweep: a partial scope 403s any
+          # reenqueue in an uncovered repo. Freeze detection (checks token) is unaffected, and the next
+          # sweep re-discovers and rolls the stray forward.
           echo "::warning::active-Epic repo discovery failed — not minting the enqueue token this sweep (roll-forward waits for the next); freeze detection is unaffected."
           echo "repos=" >> "$GITHUB_OUTPUT"
         else
-          # `sed '/^$/d'` (not `grep -v '^$'`): grep exits 1 when it drops EVERY line — the common
-          # no-active-Epic case — which under set -e/pipefail would abort the whole sweep. sed exits 0.
+          # sed drops the blank lines and still exits 0 when it drops every one, which is the common
+          # no-active-Epic case; under set -e/pipefail a non-zero exit here aborts the whole sweep.
           csv=$(printf '%s' "$names" | sed '/^$/d' | sort -u | paste -sd, -)
           echo "repos=${csv}" >> "$GITHUB_OUTPUT"
           echo "Enqueue-token scope (repos with an open Epic PR): ${csv:-<none>}"
         fi
 
-    # Sweep only, and SCOPED to the active-Epic repos (steps.scope) — not org-wide. Gating the mint on a
-    # non-empty scope means a sweep with no open Epic PRs (nothing to roll forward) never acquires write,
-    # and a per-PR run never even reaches this step.
+    # Sweep only, scoped to the active-Epic repos from steps.scope. Gating the mint on a non-empty scope
+    # keeps a sweep with no open Epic PRs from acquiring write at all, and a per-PR run never reaches
+    # this step.
     - name: Mint enqueue token
       id: write
       if: ${{ steps.mode.outputs.mode == 'sweep' && steps.scope.outputs.repos != '' }}
@@ -261,9 +254,9 @@ runs:
     - name: Detect + reconcile partial landings
       shell: bash
       env:
-        # Default GH_TOKEN is the read token (bare `gh` for every read helper); the checks and write
-        # tokens are applied inline at the two mutating call sites, so read helpers can't hold a write
-        # scope. WRITE_TOKEN is empty in per-PR mode (its mint step was skipped).
+        # The default GH_TOKEN is the read token, used by every read helper; the checks and write tokens
+        # are applied inline at the two mutating call sites, so a read helper never holds a write scope.
+        # WRITE_TOKEN is empty in per-PR mode, where the mint step is skipped.
         GH_TOKEN: ${{ steps.read.outputs.token }}
         CHECKS_TOKEN: ${{ steps.checks.outputs.token }}
         WRITE_TOKEN: ${{ steps.write.outputs.token }}
@@ -274,8 +267,8 @@ runs:
         MAX_FREEZE_REPOS: ${{ inputs.max_freeze_repos }}
         DRY_RUN: ${{ inputs.dry_run }}
         KILL_SWITCH: ${{ inputs.kill_switch }}
-        # Per-PR inputs + event payload (used only when MODE=per-pr). OWNER/REPO_FULL derive from `org`
-        # (the single source of truth matching the minted tokens), not github.repository_owner.
+        # Per-PR inputs + event payload, read only when MODE=per-pr. OWNER/REPO_FULL derive from `org`,
+        # the single source of truth that matches the minted tokens.
         OWNER: ${{ inputs.org }}
         REPO: ${{ inputs.repo }}
         REPO_FULL: ${{ inputs.org }}/${{ inputs.repo }}
@@ -284,15 +277,15 @@ runs:
         IN_QUEUE: ${{ github.event.merge_group.head_sha }}
         MG_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         # The triggering PR's own number + labels from the event payload (present on pull_request, empty
-        # on merge_group / sweep). Lets the standalone fast-path classify with no API call.
+        # on merge_group / sweep), which lets the standalone fast-path classify with no API call.
         EVENT_PR: ${{ github.event.pull_request.number }}
         EVENT_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
       run: |
         set -euo pipefail
 
         # ---- Validate the untrusted inputs before they reach a search grammar or arithmetic.
-        # org feeds `org:<ORG>` search qualifiers — require GitHub-login chars so a stray value
-        # (whitespace, an injected qualifier) can't broaden the scope or break the query. Empty fails too.
+        # org feeds `org:<ORG>` search qualifiers, so require GitHub-login characters: a stray value
+        # (whitespace, an injected qualifier) broadens the scope or breaks the query. Empty fails too.
         if ! [[ "${ORG:-}" =~ ^[A-Za-z0-9-]+$ ]]; then
           echo "::error::org must be a valid GitHub login (alphanumeric + hyphens), got \"${ORG:-}\""
           exit 1
@@ -307,26 +300,26 @@ runs:
           echo "::error::planning_repo must be a bare repository name (no owner/slash), got \"${PLANNING_REPO:-}\""
           exit 1
         fi
-        # max_freeze_repos (BLAST-CAP) feeds shell arithmetic + a `-gt` compare; require a positive int.
-        # Hard internal default 5 so an empty/unset value is safe rather than an error (mirrors the
-        # input default; the fallback covers a caller that threads an empty string through).
+        # max_freeze_repos (the blast cap) feeds shell arithmetic and a `-gt` compare, so require a
+        # positive integer. The internal default of 5 mirrors the input default and covers a caller that
+        # threads an empty string through.
         MAX_FREEZE_REPOS="${MAX_FREEZE_REPOS:-5}"
         if ! [[ "${MAX_FREEZE_REPOS}" =~ ^[0-9]+$ ]] || [ "${MAX_FREEZE_REPOS}" -lt 1 ]; then
           echo "::error::max_freeze_repos must be a positive integer, got \"${MAX_FREEZE_REPOS:-}\""
           exit 1
         fi
 
-        # Org-level HALT flag (read FIRST — resolved from an input, no token/API). FAIL-SAFE: RUNNING
-        # only for an explicit off-token (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE
-        # (a fat-fingered value or garbage) ENGAGES. Acted on at Dispatch below, after the helpers are
-        # defined so per-PR can reuse freeze_post (dry-run aware).
+        # Org-level halt flag, read first because it resolves from an input with no token or API call.
+        # Running requires an explicit off-token (empty/unset, 0, off, false, no, disabled); any other
+        # value engages the halt. Acted on at Dispatch below, once the helpers are defined, so per-PR can
+        # reuse the dry-run-aware freeze_post.
         kill_engaged=true
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) kill_engaged=false ;;
         esac
-        # Per-PR inputs become GraphQL args + API path components. Per-PR fails open on data
-        # uncertainty by design, but a misconfigured input (a slash/space in `repo`, a bad SHA) must
-        # fail loud, not silently post success — so validate them here. The sweep ignores these.
+        # Per-PR inputs become GraphQL arguments and API path components. Per-PR fails open on data
+        # uncertainty, but a misconfigured input (a slash or space in `repo`, a bad SHA) fails loud here.
+        # The sweep ignores these.
         if [ "${MODE:-}" = "per-pr" ]; then
           if ! [[ "${REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "::error::repo must be a bare repository name (no owner/slash), got \"${REPO:-}\""
@@ -342,8 +335,8 @@ runs:
           fi
         fi
 
-        # dry_run defaults on; only the literal "false" (any case) mutates. Lowercase via tr (portable),
-        # not ${VAR,,} (bash-4 only).
+        # dry_run defaults on; only the literal "false" (any case) mutates. tr keeps the lowercasing
+        # portable to Bash 3.x.
         dry=$(printf '%s' "${DRY_RUN:-true}" | tr '[:upper:]' '[:lower:]')
 
         now_epoch=$(date -u +%s)
@@ -361,8 +354,8 @@ runs:
               labels(first:100){ nodes{ name } } } } } }'
 
         # Live merge-queue read. `mergeQueue` is null when the branch has no queue configured (jq `// []`
-        # → empty set). headCommit.oid is the entry's live temp-merge head, which differs from the PR's
-        # head (MergeQueueEntry exposes the SHA via headCommit{oid}, not a headOid field).
+        # → empty set). headCommit.oid is the entry's live temp-merge head, distinct from the PR's own
+        # head; MergeQueueEntry exposes that SHA as headCommit{oid}.
         MQ_Q='query($owner:String!,$repo:String!,$base:String!){
           repository(owner:$owner,name:$repo){
             mergeQueue(branch:$base){
@@ -373,7 +366,7 @@ runs:
           repository(owner:$owner,name:$repo){
             pullRequest(number:$num){ labels(first:100){ nodes{ name } } } } }'
 
-        # ---- Read helpers (all use the default READ GH_TOKEN) ----------------------------
+        # ---- Read helpers (all use the default read GH_TOKEN) ----------------------------
 
         # Page an ISSUE search to completion, retrying transient GraphQL errors. Prints the aggregated
         # PR-node JSON array on success; returns 1 (logs to stderr) on failure so the caller fails closed.
@@ -455,45 +448,42 @@ runs:
           return 1
         }
 
-        # Is Epic N paused? Reads the `automation:paused` marker on the Epic issue in the planning
-        # repo — a >= triage label, so a permission-gated per-Epic hold. Returns 0 = paused,
-        # 1 = not paused, 2 = read error (the caller then proceeds with normal detection — fail-open
-        # on pause; a real partial landing still gets caught).
+        # Is Epic N paused? Reads the `automation:paused` marker on the Epic issue in the planning repo,
+        # a label needing at least triage, so the pause is permission-gated and per-Epic. Returns
+        # 0 = paused, 1 = not paused, 2 = read error, where the caller proceeds with normal detection so
+        # a real partial landing is still caught.
         epic_paused() { # $1 = epic number
           local out
           out=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" --jq '.labels[].name' 2>/dev/null) || return 2
           printf '%s\n' "$out" | grep -qx 'automation:paused'
         }
 
-        # Read an Epic's FROZEN activation-snapshot members and bucket them by their live state. Once
-        # landing stabilizes, merge-gate captures the member set into a marker in the Epic body. That
-        # set is what the live label search cannot reconstruct: GitHub indexes no "ever carried label
-        # X", so a member de-labeled mid-landing is gone from live truth for good. Only the SET is
-        # persisted; every member's STATE is re-read here on each pass.
+        # Read an Epic's frozen activation-snapshot members and bucket them by their live state. Once
+        # landing stabilizes, merge-gate captures the member set into a marker in the Epic body. That set
+        # is what the live label search cannot reconstruct: GitHub indexes no "ever carried label X", so
+        # a member de-labeled mid-landing is gone from live truth for good. Only the set is persisted;
+        # every member's state is re-read here on each pass.
         #
-        # These buckets are ADDED to the live ones by the caller, never substituted for them (see
-        # evaluate_epic). That is deliberate: the frozen set is NOT a superset of the live one. merge-gate
-        # builds it from OPEN pull requests and promotes it only after the set holds still, while
-        # auto-merge is armed earlier — so members routinely merge before the freeze and a frozen set
-        # commonly omits them. Substituting it would empty the `merged` bucket that gates all detection.
+        # The caller adds these buckets to the live ones (see evaluate_epic). The frozen set covers only
+        # part of the membership: merge-gate builds it from open pull requests once the set holds still,
+        # while auto-merge is armed earlier, so members routinely merge before the freeze and the frozen
+        # set omits them. The `merged` bucket gates all detection.
         #
         # Prints nothing; fills SNAP_MERGED / SNAP_CLOSED / SNAP_OPEN with the node shape search_prs
         # returns (repository.nameWithOwner, number, headRefOid, mergedAt, baseRefName, isDraft), plus
-        # SNAP_SINCE with the wave boundary. The boundary is read on EVERY rc, including the ones that
-        # report no usable frozen set: a `retired` tombstone names no members and exists only to carry it.
+        # SNAP_SINCE with the wave boundary. The boundary is read on every return code, including the
+        # ones reporting no usable frozen set: a `retired` tombstone names no members and only carries it.
         # Returns 0 = frozen set resolved, 2 = no usable snapshot (the live floor stands on its own),
-        # 1 = a frozen set exists but could NOT be resolved. On 1 the caller leaves EV_DECISION=error,
+        # 1 = a frozen set exists but could not be resolved. On 1 the caller leaves EV_DECISION=error,
         # which the sweep treats as "post nothing this pass" (a standing freeze survives) and per-PR as
-        # fail-open on the head — so 1 costs a pass, never a false clear in the sweep.
+        # fail-open on the head, so 1 costs a pass and never a false clear in the sweep.
         # The marker contract (fence names, `status`, `members`, `since`) is shared with epic-membership
-        # and merge-gate — a change to its shape has to land in all three. `since` is additive and both
-        # membership readers ignore it: they select on `status` and `members` alone, so a marker carrying
-        # it resolves there exactly as one without.
+        # and merge-gate; a change to its shape has to land in all three. `since` is additive: both
+        # membership readers select on `status` and `members` alone, so a marker carrying it resolves
+        # there exactly as one without.
         snapshot_buckets() { # $1 = epic number
-          # The fence strings, matched as WHOLE LINES. An unanchored match would let a pseudo-fence
-          # planted inside an HTML comment shadow the real region on every read while staying
-          # invisible to merge-gate's splice (which matches exact lines), so a tamper would survive
-          # every capture pass instead of self-healing.
+          # The fence strings, matched as whole lines — the same match merge-gate's splice uses, so a
+          # pseudo-fence planted inside an HTML comment cannot shadow the real region.
           local START_M='<!-- epic-membership:snapshot:start -->' END_M='<!-- epic-membership:snapshot:end -->'
           SNAP_MERGED='[]'
           SNAP_CLOSED='[]'
@@ -503,11 +493,10 @@ runs:
           local since="" since_epoch="" shown=""
           errf=$(mktemp)
           for attempt in 1 2 3; do
-            # Keep the streams apart: stdout is the payload, stderr is diagnosis. Folding them together
-            # would let a benign `gh` notice land inside the JSON and turn a healthy read into a parse
-            # failure — which now costs a whole pass, since an unreadable body no longer falls back.
-            # `.body` goes through jq rather than `--jq` so a non-issue response is rejected as a whole
-            # rather than silently yielding an empty body (which reads as "no snapshot").
+            # Keep the streams apart: stdout is the payload, stderr is diagnosis, so a benign `gh` notice
+            # cannot land inside the JSON and fail the parse. That costs a whole pass, because an
+            # unreadable body does not fall back. `.body` is parsed with jq, which rejects a non-issue
+            # response whole; an empty body reads as "no snapshot".
             if resp=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" 2>"$errf") \
               && printf '%s' "$resp" | jq -e 'type == "object" and has("body")' >/dev/null 2>&1; then
               # GitHub stores bodies with CRLF; strip \r so the marker fences match.
@@ -516,17 +505,16 @@ runs:
               break
             fi
             err=$(cat "$errf" 2>/dev/null || true)
-            # The Epic issue simply is not in the planning repo — nothing to retry.
+            # The Epic issue is not in the planning repo — nothing to retry.
             case "$err" in *"HTTP 404"*) break ;; esac
             [ "$attempt" -lt 3 ] && sleep 2
           done
           rm -f "$errf"
           if [ "$ok" != true ]; then
-            # A 404 is an ANSWER: the Epic issue is not there, so no snapshot can exist and the live
-            # floor is the whole truth. Any other failure leaves us not knowing whether a frozen set
-            # exists — and deciding on the live floor while ignorant is not neutral, because a `clear`
-            # POSTS success and would lift a freeze an earlier pass had correctly set. Treat ignorance
-            # the same way the re-read failure below does: decide nothing, re-derive next pass.
+            # A 404 is an answer: the Epic issue is not there, so no snapshot can exist and the live
+            # floor is the whole truth. Any other failure leaves it unknown whether a frozen set exists.
+            # A `clear` posts success and lifts a standing freeze, so an unknown decides nothing and
+            # re-derives next pass, exactly as the re-read failure below does.
             case "$err" in
               *"HTTP 404"*)
                 echo "::warning::epic #$1: ${ORG}/${PLANNING_REPO}#$1 not found — no snapshot possible, live label set only."
@@ -538,46 +526,44 @@ runs:
           fi
 
           # The fenced region holds a human-readable note and then the JSON, so skip to the first line
-          # that opens a value before parsing. Requiring the JSON to be one compact line at column 0
-          # (what a `grep '^{'` does) silently kills a pretty-printed marker; parsing the note as JSON
-          # kills every marker the writer actually emits. `-s .[0]` takes the first value if a hand-edit
-          # left several — though trailing prose inside the region still voids the whole marker, which fails safe. All three participants extract identically — see the contract note above.
+          # that opens a value before parsing: the note is not JSON, and the JSON may be pretty-printed
+          # across several lines. `-s .[0]` takes the first value if a hand-edit left several; trailing
+          # prose inside the region voids the whole marker, which fails safe. All three participants
+          # extract identically — see the contract note above.
           marker=$(printf '%s\n' "$body" \
             | awk -v s="$START_M" -v e="$END_M" '$0 == s {f=1;next} $0 == e {f=0} f' \
             | sed -n '/^[[:space:]]*[{[]/,$p' \
             | jq -s -c '.[0] // empty' 2>/dev/null || true)
 
-          # The WAVE BOUNDARY, read from ANY well-formed marker whatever its `status`, and read HERE —
-          # ahead of the frozen-only returns below — because the paths that report no frozen set need it
-          # most. A `retired` tombstone names no members and exists ONLY to carry this instant; a
-          # pending/frozen marker carries it forward from the tombstone it replaced, since merge-gate
-          # splices the whole region and a boundary not carried forward dies with the next capture.
-          # Canonicalized once, right here: the caller appends it to a search query and never re-parses it.
+          # The wave boundary, read from any well-formed marker whatever its `status`, and read ahead of
+          # the frozen-only returns below because the paths that report no frozen set need it most. A
+          # `retired` tombstone names no members and exists only to carry this instant; a pending or
+          # frozen marker carries it forward from the tombstone it replaced, because merge-gate splices
+          # the whole region and a boundary dies with the next capture unless it is carried forward.
+          # Canonicalized once here: the caller appends it to a search query and never re-parses it.
           since=$(printf '%s' "$marker" | jq -r 'if type == "object" then (.since // empty) else empty end' 2>/dev/null || true)
           if [ -n "$since" ]; then
-            # A malformed time qualifier is the dangerous input, not an obviously broken one: GitHub
-            # answers `merged:>=garbage` — and `merged:>=2026-13-45T99:00:00Z`, which passes any
-            # shape-only check — with ZERO results and NO `errors` array, so nothing in search_prs can
-            # tell it from a genuinely empty bucket. That bucket is what every decision hangs on, and an
-            # empty one reads as "nothing has landed" → `clear`, which POSTS success and lifts a standing
-            # freeze. A future instant does the same while looking well-formed. So only a value in the
-            # exact form merge-gate emits, that a calendar accepts, and that is not ahead of this run
-            # reaches a query; anything else is dropped for unbounded history, which errs toward freezing.
-            # Everything shown below is attacker-controlled — the marker lives in an issue body. jq -r
-            # renders an embedded \n as a REAL newline and GitHub reads workflow commands line by line,
-            # so echoing the raw value would let a crafted boundary forge its own `::error::` or
-            # `::stop-commands::` line on the very path that REJECTS it. Show one bounded line instead.
+            # GitHub answers a malformed time qualifier — `merged:>=garbage`, and
+            # `merged:>=2026-13-45T99:00:00Z`, which passes any shape-only check — with zero rows and no
+            # `errors` array, indistinguishable from a genuinely empty bucket. Every decision hangs on
+            # that bucket, and an empty one reads as "nothing has landed" → `clear`, which posts success
+            # and lifts a standing freeze. A future instant does the same while looking well-formed. So a
+            # value reaches a query only in the exact form merge-gate emits, accepted by a calendar, and
+            # not ahead of this run; anything else is dropped for unbounded history, which errs toward
+            # freezing.
+            # The marker lives in an issue body, so everything shown below is attacker-controlled. jq -r
+            # renders an embedded \n as a real newline and GitHub reads workflow commands line by line,
+            # so a raw value carrying one forges its own `::error::` or `::stop-commands::` line on the
+            # very path that rejects it. Show one bounded line instead.
             shown=$(printf '%s' "$since" | tr -d '\r\n' | cut -c1-64)
             if ! [[ "$since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
               echo "::warning::epic #$1: the snapshot's wave boundary \"${shown}\" is not an ISO-8601 UTC instant (YYYY-MM-DDTHH:MM:SSZ) — ignoring it and scoping to the Epic's whole history."
             elif ! since_epoch=$(date -u -d "$since" +%s 2>/dev/null); then
               echo "::warning::epic #$1: the snapshot's wave boundary \"${shown}\" is not a real date — ignoring it and scoping to the Epic's whole history."
-            # Compared against the clock this STEP started on, plus a skew allowance: a sweep can be
-            # minutes into the step by the time it reaches an Epic, so a tombstone merge-gate wrote
-            # moments ago would otherwise read as "the future" and be discarded for no reason — costing
-            # a pass of unbounded history, which re-freezes the next wave until the following sweep.
-            # What this check is actually for is a boundary far enough ahead to hide REAL history, and
-            # a few minutes hides a few minutes of merges, well inside the grace window either way.
+            # Compared against the clock this step started on, plus a skew allowance: a sweep can be
+            # minutes into the step by the time it reaches an Epic, and a tombstone merge-gate wrote
+            # moments ago must still read as past. The check catches a boundary far enough ahead to hide
+            # real history; a few minutes hides a few minutes of merges, well inside the grace window.
             elif [ "$since_epoch" -gt "$(( now_epoch + 300 ))" ]; then
               echo "::warning::epic #$1: the snapshot's wave boundary \"${shown}\" is in the FUTURE — ignoring it (it would hide every merge this Epic has) and scoping to the Epic's whole history."
             else
@@ -586,15 +572,15 @@ runs:
           fi
 
           [ -n "$marker" ] || return 2
-          # Only a well-formed FROZEN marker counts. A pending marker (the set has not settled yet), a
-          # hand-edited one, or the wrong shape falls back to the live floor rather than crashing.
-          # The guards are strict because `.repo` and `.number` are interpolated into a GraphQL document
-          # below and the Epic body is writable by anyone with write access to the planning repo:
-          # `[^/]` would admit quotes and newlines (enough to inject fields), and `type == "number"`
-          # alone would admit 1.5, which is a document-level validation error rather than a skippable
-          # one. The dedup key is case-folded because GitHub resolves repository names case-insensitively,
-          # so `org/Repo` and `org/repo` are one member and would otherwise both be queried and both be
-          # counted. The cap bounds the single aliased query below.
+          # Only a well-formed frozen marker counts. A pending marker (the set has not settled yet), a
+          # hand-edited one, or the wrong shape falls back to the live floor.
+          # The guards are strict because `.repo` and `.number` are interpolated into the GraphQL
+          # document below and the Epic body is writable by anyone with write access to the planning
+          # repo. The repo pattern excludes quotes and newlines, which are enough to inject fields, and
+          # the number must be a whole integer, since 1.5 is a document-level validation error rather
+          # than a skippable one. The dedup key is case-folded because GitHub resolves repository names
+          # case-insensitively, so `org/Repo` and `org/repo` are one member. The cap bounds the single
+          # aliased query below.
           frozen=$(printf '%s' "$marker" | jq -c --arg org "$ORG" '
             select(type == "object" and .status == "frozen" and (.members | type == "array"))
             | .members
@@ -607,16 +593,15 @@ runs:
           { [ -n "$frozen" ] && [ "$frozen" != "null" ]; } || return 2
           want=$(printf '%s' "$frozen" | jq 'length')
 
-          # One aliased GraphQL call re-reads every member's live state. It is all-or-nothing on
-          # purpose. GitHub answers a multi-alias query with partial data plus an `errors` array,
-          # nulling what failed — and in a DETECTOR a dropped member does not shrink a ready set (as it
-          # would in epic-membership, where the consumer then HOLDs), it erases the evidence of
-          # abandonment and reads as "nothing wrong". Accepting a short answer here would silently
-          # decide `clear` and post success on the very case this exists to catch.
-          # `|floor` renders the number as a canonical integer literal. The guard above already rejects
-          # a fractional value, but jq preserves the literal a body was written with, so 1.0 and 1e2
-          # would reach the query verbatim — and a non-Int literal is a document-level validation error
-          # that rejects the whole query rather than one alias, wedging the Epic on every retry.
+          # One aliased GraphQL call re-reads every member's live state, and it is all-or-nothing.
+          # GitHub answers a multi-alias query with partial data plus an `errors` array, nulling what
+          # failed; a dropped member erases the evidence of abandonment and reads as "nothing wrong", so
+          # a short answer accepted here decides `clear` and posts success on the very case this exists
+          # to catch.
+          # `|floor` renders the number as a canonical integer literal. The guard above rejects a
+          # fractional value, but jq preserves the literal a body was written with, so 1.0 and 1e2 reach
+          # the query verbatim. A non-Int literal is a document-level validation error: it rejects the
+          # whole query, so every retry wedges the Epic.
           alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
               + "{pullRequest(number:\(.value.number|floor)){number headRefOid mergedAt baseRefName isDraft state repository{nameWithOwner}"
@@ -636,28 +621,25 @@ runs:
             [ "$attempt" -lt 3 ] && sleep 2
           done
           if [ -z "$rh" ]; then
-            # Runs in the caller's shell but the decision is silent (EV_DECISION stays error), so echo
-            # the underlying failure here or the fail-closed pass is undiagnosable.
+            # The decision is silent (EV_DECISION stays error), so the underlying failure is echoed here
+            # to keep the fail-closed pass diagnosable.
             printf 'snapshot_buckets: could not re-read all %s frozen member(s) of epic #%s after 3 attempts: %s\n' \
               "$want" "$1" "$out" >&2
             return 1
           fi
 
-          # CORROBORATE membership before trusting the marker. The marker lives in an issue body, so its
-          # author is whoever can edit that issue — and every member it names becomes a freeze target
-          # posted with an org-wide checks:write token. Without this, naming arbitrary pull requests
-          # would let one issue edit block merges across the whole org.
-          # The label is the permission-gated assertion (applying it needs >= triage on that repo), so a
-          # member must show it: either it still carries `epic:<N>`, or its timeline records having been
-          # labeled with it. That is exactly the "was a member" claim the snapshot exists to remember —
-          # unavailable by SEARCH, which is why the set is persisted, but verifiable per pull request.
-          # A member that cannot show it means the marker is not trustworthy. Dropping just that member
-          # would be worse than useless — the marker is attacker-controlled, so the surviving subset is
-          # attacker-chosen — and falling back to the live floor is worse still: the floor is the blind
-          # spot the snapshot exists to cover, and a `clear` POSTS success, so a single appended object
-          # would LIFT a standing freeze and let the partial landing finish. The only honest answer to
-          # "the authoritative record is untrustworthy" is to decide nothing (rc 1), which leaves any
-          # prior freeze in place and re-derives next pass.
+          # Corroborate membership before trusting the marker. The marker lives in an issue body, so its
+          # author is whoever can edit that issue, and every member it names becomes a freeze target
+          # posted with an org-wide checks:write token: one issue edit reaches merges across the org.
+          # The label is the permission-gated assertion (applying it needs at least triage on that repo),
+          # so a member must show it — either it still carries `epic:<N>`, or its timeline records having
+          # been labeled with it. That is the "was a member" claim the snapshot exists to remember: no
+          # search reaches it, which is why the set is persisted, and it is verifiable per pull request.
+          # A member that cannot show it makes the whole marker untrustworthy, and an untrustworthy
+          # marker decides nothing (rc 1), leaving any prior freeze in place to re-derive next pass.
+          # Dropping the failing member alone leaves an attacker-chosen subset, and the live floor is the
+          # blind spot the snapshot exists to cover; a `clear` from either posts success, lifting a
+          # standing freeze and letting the partial landing finish.
           local unverified
           unverified=$(printf '%s' "$rh" | jq -r --arg lbl "epic:$1" '
             [ (.data // {}) | to_entries[] | .value.pullRequest | select(. != null)
@@ -670,12 +652,11 @@ runs:
           fi
 
           # Reconcile each node against the member it was asked for, so a response cannot smuggle in a
-          # pull request nobody asked about — such a node would flow into EV_OPEN and become a freeze
-          # target under an org-wide checks:write token. Identity is the ALIAS INDEX plus the pull
-          # request number, deliberately not the repository name: GraphQL follows a rename silently and
-          # answers with the NEW nameWithOwner, and since a frozen marker is never rewritten, matching
-          # on the name would wedge a renamed member's Epic at `error` forever. The number is stable
-          # under a rename, and the alias index is ours, so together they still pin identity.
+          # pull request nobody asked about: such a node reaches EV_OPEN and becomes a freeze target
+          # under an org-wide checks:write token. Identity is the alias index plus the pull request
+          # number. GraphQL follows a rename silently and answers with the new nameWithOwner, while a
+          # frozen marker is never rewritten, so the repository name stays out of the match. The number
+          # is stable under a rename and the alias index is ours, so together they pin identity.
           nodes=$(printf '%s' "$rh" | jq -c --argjson members "$frozen" '
             [ (.data // {}) | to_entries[]
               | (.key | ltrimstr("m") | tonumber) as $i
@@ -687,8 +668,8 @@ runs:
             return 1
           fi
 
-          # MERGED / CLOSED / OPEN are exclusive on a PullRequest — a merged PR reports MERGED, never
-          # CLOSED — so CLOSED is exactly the closed-without-merge bucket the live search widens for.
+          # MERGED, CLOSED and OPEN are exclusive on a PullRequest (a merged one reports MERGED), so
+          # CLOSED is exactly the closed-without-merge bucket the live search widens for.
           SNAP_MERGED=$(printf '%s' "$nodes" | jq -c '[.[] | select(.state == "MERGED")]')
           SNAP_CLOSED=$(printf '%s' "$nodes" | jq -c '[.[] | select(.state == "CLOSED")]')
           SNAP_OPEN=$(printf '%s' "$nodes" | jq -c '[.[] | select(.state == "OPEN")]')
@@ -698,19 +679,19 @@ runs:
         # Combine the live label buckets with the frozen snapshot's into one membership view, printed as
         # {merged, closed, open}. Prints nothing and returns non-zero if the merge fails.
         #
-        # A pull request present in the snapshot is taken FROM the snapshot, bucket and all. Both
-        # sources describe the same pull request, but the snapshot node is a direct read issued this
-        # pass while the live node comes from GitHub's eventually-consistent search index, so the
-        # snapshot carries the fresher state and head SHA — and posting a check on a stale head is the
-        # "stranded on Expected" failure this action exists to avoid. It also keeps each pull request in
-        # exactly ONE bucket: two sources disagreeing about a member (the index still calling a merged
-        # pull request open) would otherwise count it twice and post success on a merged head.
-        # This cannot weaken detection: MERGED is terminal, so a fresher read never demotes a member the
-        # index already reports as merged, and `merged >= 1` is the precondition every decision needs.
+        # A pull request present in the snapshot is taken from the snapshot, bucket and all. Both sources
+        # describe the same pull request, but the snapshot node is a direct read issued this pass while
+        # the live node comes from GitHub's eventually-consistent search index, so the snapshot carries
+        # the fresher state and head SHA; a check posted on a stale head is the "stranded on Expected"
+        # failure this action exists to avoid. It also keeps each pull request in exactly one bucket, so
+        # two sources disagreeing about a member — the index still calling a merged pull request open —
+        # count it once. Detection stays as strong: MERGED is terminal, so a fresher read never demotes a
+        # member the index already reports as merged, and `merged >= 1` is the precondition every
+        # decision needs.
         #
         # Every node is tagged `liveMember`, recording whether the live `epic:<N>` label search still
-        # returns it. Detection ignores the tag — a de-labeled member is a member. Mutations must not:
-        # see the roll-forward in sweep_post_clear.
+        # returns it. Detection ignores the tag, since a de-labeled member is a member; mutations honor
+        # it, in the roll-forward in sweep_post_clear.
         union_buckets() { # $1..$3 = live merged/closed/open, $4..$6 = snapshot merged/closed/open
           jq -cn --argjson lm "$1" --argjson lc "$2" --argjson lo "$3" \
             --argjson sm "$4" --argjson sc "$5" --argjson so "$6" '
@@ -728,10 +709,10 @@ runs:
 
         # ---- Post helpers (dry-run aware; the checks token posts) -------------------------
 
-        # Post an epic-freeze check-run (jq builds the payload so quotes / newlines can't break the JSON).
-        # Guard the post explicitly — `set -e` is disabled inside a function called under `||`: in the
-        # sweep a failed post is a per-target `::warning::` and we continue; in per-PR (single head) we
-        # surface it as a failed run (better red-and-retryable than a silent abort).
+        # Post an epic-freeze check-run (jq builds the payload so quotes and newlines cannot break the
+        # JSON). The post is guarded explicitly because `set -e` is disabled inside a function called
+        # under `||`: the sweep logs a per-target `::warning::` and continues, while per-PR (a single
+        # head) surfaces it as a failed run, red and retryable.
         post_check() { # $1=owner/repo $2=sha $3=conclusion $4=summary
           local payload
           payload=$(jq -n --arg sha "$2" --arg concl "$3" --arg summary "$4" \
@@ -761,14 +742,12 @@ runs:
 
         # Re-enqueue a stray by enabling native auto-merge, idempotently (query first, enable only if
         # off). Uses the write token (sweep only); a failure is a warning and the next sweep retries.
-        # `--squash` matches the org-wide squash-only merge method; a repo on merge/rebase would need it
-        # to follow that method.
+        # `--squash` matches the org-wide squash-only merge method.
         reenqueue() { # $1=owner/repo $2=number
           local target="$1#$2" already
-          # Checked before the dry-run return, so a rehearsal reports what would REALLY happen: the
-          # enqueue token is deliberately absent when repo discovery failed (the scope step warns and
-          # mints nothing), and claiming "would re-enqueue" there is a rehearsal that lies. It also
-          # keeps a live sweep from reporting the deliberate skip as a GitHub outage.
+          # Checked before the dry-run return, so a rehearsal reports the real outcome: when repo
+          # discovery fails the scope step mints no enqueue token, and the roll-forward is skipped rather
+          # than attempted. It also keeps a live sweep from reporting that skip as a GitHub outage.
           if [ -z "${WRITE_TOKEN:-}" ]; then
             echo "::warning::no enqueue token this sweep (repo discovery failed) — not rolling $target forward; the next sweep retries." \
               | tee -a "$GITHUB_STEP_SUMMARY"
@@ -792,10 +771,10 @@ runs:
         }
 
         # ---- evaluate_epic — the pure, shared decision (no posting, no mutation) ----------
-        # Sets EV_DECISION ∈ {clear, frozen, error} (+ EV_REASON when frozen) and the EV_* data both
-        # wrappers post from. Never returns non-zero — any resolve/queue/REST error leaves
-        # EV_DECISION=error (robust whether or not `set -e` is active). Shared by both writers, so the
-        # predicate structurally cannot drift between them.
+        # Sets EV_DECISION ∈ {clear, frozen, error} (plus EV_REASON when frozen) and the EV_* data both
+        # wrappers post from. Never returns non-zero: any resolve, queue or REST error leaves
+        # EV_DECISION=error, whether or not `set -e` is active. Both writers share it, so the predicate
+        # cannot drift between them.
         evaluate_epic() { # $1 = Epic number (already validated numeric)
           EV_DECISION=error; EV_REASON=""
           EV_OPEN='[]'; EV_QUEUE='[]'; EV_STRAYS='[]'
@@ -803,47 +782,39 @@ runs:
           local EPIC="$1"
           local base_q="label:\"epic:${EPIC}\" org:${ORG}"
 
-          # The snapshot is resolved FIRST because it carries the wave boundary the searches below are
-          # scoped by. It is otherwise added ON TOP of the live floor, never swapped for it: it
-          # contributes the members live truth has forgotten — a de-labeled one stays a member — and
-          # nothing else. The union is what makes MEMBERSHIP monotone: no snapshot, however degraded or
-          # incomplete, can shrink the member set the detector already saw, so the worst case is the
-          # behaviour that predates it. A straight substitution would not be safe, because a frozen set
-          # is not a superset of the live one: merge-gate captures it from OPEN pull requests after the
-          # set holds still, while auto-merge is armed earlier, so already-merged members are commonly
-          # absent from it — and `merged >= 1` is the precondition every decision below hangs on.
+          # The snapshot is resolved first because it carries the wave boundary the searches below are
+          # scoped by. It is otherwise added on top of the live floor: it contributes the members live
+          # truth has forgotten, since a de-labeled one stays a member, and nothing else. The union keeps
+          # membership monotone, so no snapshot, however degraded, shrinks the member set the detector
+          # already saw.
           local merged closed_unmerged open membership=live snap_rc=0
           snapshot_buckets "$EPIC" || snap_rc=$?
           case "$snap_rc" in
             0) membership=live+snapshot ;;
             # Pre-activation, or no usable marker: the live floor stands alone. It still goes through
-            # union_buckets, against an empty snapshot — every membership view is built the same way, so
-            # `liveMember` is present on every node no matter which path produced it. Tagging only on the
-            # snapshot path once left these nodes untagged, and since jq reads a missing key as null, the
-            # roll-forward silently selected nothing while its skip-warning selected everything.
-            # SNAP_SINCE is deliberately NOT reset alongside these: rc 2 is exactly the tombstone case —
-            # a `retired` marker has no members to bucket and exists only to carry the boundary — so
-            # clearing it here for symmetry would discard the one thing that path is there to deliver.
+            # union_buckets against an empty snapshot, so every membership view is built the same way and
+            # `liveMember` is present on every node whichever path produced it. jq reads a missing key as
+            # null, so an untagged node drops out of the roll-forward and into its skip-warning.
+            # SNAP_SINCE is not reset alongside these. Return code 2 is the tombstone case: a `retired`
+            # marker has no members to bucket and exists only to carry the boundary.
             2) SNAP_MERGED='[]'; SNAP_CLOSED='[]'; SNAP_OPEN='[]' ;;
             *)
-              # A frozen set exists (or might) and could not be resolved. Deciding on the live floor
-              # alone would mean answering "is a member missing?" with the one source that cannot see a
-              # missing member — and a `clear` is not passive here, it POSTS success and would lift a
-              # freeze an earlier pass set. Leave EV_DECISION=error: the sweep posts nothing (a standing
-              # freeze survives) and re-derives next pass.
+              # A frozen set exists (or might) and could not be resolved. The live floor alone cannot see
+              # a missing member, and a `clear` posts success and lifts a freeze an earlier pass set, so
+              # EV_DECISION stays error: the sweep posts nothing and re-derives next pass.
               return 0
               ;;
           esac
 
-          # The live label set is the FLOOR. Widened resolve, three passes: is:closed is:unmerged
-          # catches the closed-without-merge blind spot; is:merged and is:open complete the picture.
-          # Any failure → EV_DECISION stays error.
-          # The two TERMINAL passes are bounded by the wave boundary, so a previous wave's merges and
-          # abandonments are not read as this wave's. Everything else follows from that one scope:
-          # `first_merged_at` is already a `min` over the merged bucket, so grace starts at THIS wave's
-          # first merge, and strays are already gated on `merged >= 1`, so a sibling of a wave that has
-          # not started landing is not a stray at all. The open pass is deliberately unbounded — an open
-          # pull request is not history, and a member can have been opened long before its wave began.
+          # The live label set is the floor, resolved in three passes: is:closed is:unmerged catches the
+          # closed-without-merge blind spot, is:merged and is:open complete the picture. Any failure
+          # leaves EV_DECISION at error.
+          # The two terminal passes are bounded by the wave boundary, so a previous wave's merges and
+          # abandonments stay with that wave. Everything else follows from that one scope:
+          # `first_merged_at` is a `min` over the merged bucket, so grace starts at this wave's first
+          # merge, and strays are gated on `merged >= 1`, so a sibling of a wave that has not started
+          # landing is not a stray. The open pass is unbounded, since an open pull request is not history
+          # and a member can have been opened long before its wave began.
           local merged_floor="" closed_floor=""
           if [ -n "${SNAP_SINCE:-}" ]; then
             merged_floor=" merged:>=${SNAP_SINCE}"
@@ -852,11 +823,10 @@ runs:
           if ! merged=$(search_prs "is:pr is:merged $base_q$merged_floor"); then return 0; fi
           if ! closed_unmerged=$(search_prs "is:pr is:closed is:unmerged $base_q$closed_floor"); then return 0; fi
           if ! open=$(search_prs "is:pr is:open $base_q"); then return 0; fi
-          # The snapshot's own buckets enter UNFILTERED by the boundary, and must: a frozen set is the
-          # current wave by construction (retirement is what writes a boundary, and it removes the set it
-          # retires), so every member it names belongs here whenever it merged. Filtering them would let
-          # the boundary shrink MEMBERSHIP — the one thing the union exists to prevent — and would drop
-          # exactly the abandoned member the snapshot is kept for.
+          # The snapshot's own buckets enter unfiltered by the boundary. A frozen set is the current wave
+          # by construction — retirement is what writes a boundary, and it removes the set it retires —
+          # so every member it names belongs here whenever it merged, and the boundary never shrinks
+          # membership.
           local buckets
           if ! buckets=$(union_buckets "$merged" "$closed_unmerged" "$open" \
             "$SNAP_MERGED" "$SNAP_CLOSED" "$SNAP_OPEN"); then
@@ -872,9 +842,9 @@ runs:
           EV_CLOSED_COUNT=$(printf '%s' "$closed_unmerged" | jq 'length')
           EV_OPEN_COUNT=$(printf '%s' "$open" | jq 'length')
 
-          # Live queue membership for every distinct (repo, base) among the open siblings. Ref names can't
-          # contain spaces (git forbids them), so a space-joined pair splits safely; fd 4 keeps this
-          # loop's input clear of the gh calls inside it.
+          # Live queue membership for every distinct (repo, base) among the open siblings. Git forbids
+          # spaces in ref names, so a space-joined pair splits safely; fd 4 keeps this loop's input clear
+          # of the gh calls inside it.
           local queue='[]' repos_bases rb_repo rb_base owner_only repo_only entries
           repos_bases=$(printf '%s' "$open" | jq -r '[.[] | "\(.repository.nameWithOwner) \(.baseRefName)"] | unique | .[]')
           while read -r rb_repo rb_base <&4; do
@@ -886,8 +856,8 @@ runs:
             queue=$(jq -s '.[0] + .[1]' <(printf '%s' "$queue") <(printf '%s' "$entries"))
           done 4< <(printf '%s\n' "$repos_bases")
 
-          # The org queue holds unrelated PRs too — keep only entries that are open siblings, so we never
-          # dequeue a non-member.
+          # The org queue holds unrelated PRs too, so keep only entries that are open siblings: a
+          # non-member must never be dequeued.
           queue=$(printf '%s' "$queue" | jq -c --argjson open "$open" '
             [ .[] | . as $e
               | select( ($open | map(select(.repository.nameWithOwner == $e.repo and .number == $e.number)) | length) > 0 ) ]')
@@ -900,9 +870,9 @@ runs:
               | select( ($q | map(select(.repo == $pr.repository.nameWithOwner and .number == $pr.number)) | length) == 0 ) ]')
 
           # REST-confirm each candidate stray is genuinely "open false" before it counts (parity with the
-          # closed-unmerged path), so a lagging index can't invent a stray; a REST error → EV_DECISION
-          # stays error. Keep the full node (with isDraft) so roll-forward can skip drafts. A stray only
-          # matters once landing is in progress (>=1 merged); when merged=0, skip the per-sibling REST.
+          # closed-unmerged path), so a lagging index cannot invent a stray; a REST error leaves
+          # EV_DECISION at error. Keep the full node (with isDraft) so roll-forward can skip drafts. A
+          # stray only matters once landing is in progress (>=1 merged), so merged=0 skips the REST pass.
           local confirmed_keys='[]' rs_repo rs_num st
           if [ "$EV_MERGED_COUNT" -ge 1 ]; then
             while read -r rs_repo rs_num <&4; do
@@ -921,8 +891,8 @@ runs:
           EV_STRAY_COUNT=$(printf '%s' "$EV_STRAYS" | jq 'length')
 
           # Grace window measured from the first sibling merge (ISO-8601 UTC sorts chronologically, so
-          # `min` is earliest). Unparseable → be conservative: treat grace as not elapsed, so a stray
-          # never trips on an unknown age.
+          # `min` is earliest). An unparseable timestamp counts as grace not elapsed, so a stray never
+          # trips on an unknown age.
           local first_merged_at first_epoch grace_elapsed=false
           first_merged_at=$(printf '%s' "$merged" | jq -r '[.[].mergedAt] | map(select(. != null)) | min // empty')
           if [ -n "$first_merged_at" ]; then
@@ -932,10 +902,9 @@ runs:
             fi
           fi
 
-          # wave_since is logged separately from `membership`, not folded into it: a tombstone yields a
-          # boundary and NO frozen set, so `membership=live` alongside a boundary is the normal shape
-          # between waves, and a pass that read the marker would otherwise be indistinguishable from one
-          # that found nothing.
+          # wave_since is logged as its own field: a tombstone yields a boundary and no frozen set, so
+          # `membership=live` alongside a boundary is the normal shape between waves, and the separate
+          # field is what tells a pass that read the marker from one that found none.
           echo "epic #$EPIC: membership=$membership wave_since=${SNAP_SINCE:-none} merged=$EV_MERGED_COUNT closed_unmerged=$EV_CLOSED_COUNT open=$EV_OPEN_COUNT stray=$EV_STRAY_COUNT grace_elapsed=$grace_elapsed" \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
@@ -994,23 +963,22 @@ runs:
 
         # ---- Sweep wrappers ---------------------------------------------------------------
 
-        # Clear: roll landable strays forward while within grace (merged>=1 = a set actively landing; the
-        # clear decision guarantees grace has not elapsed for any stray), then post epic-freeze=success on
-        # every open sibling head. That success is both the default state of the required check and the
-        # unfreeze: re-derived each sweep, it re-posts success on the same open-head set a prior freeze
-        # touched, clearing a stale freeze the instant the Epic is whole (latest check of a name wins).
-        # Queue heads self-expire, so they need no success.
+        # Clear: roll landable strays forward while within grace (merged>=1 marks a set actively landing,
+        # and the clear decision guarantees grace has not elapsed for any stray), then post
+        # epic-freeze=success on every open sibling head. That success is both the default state of the
+        # required check and the unfreeze: re-derived each sweep, it re-posts success on the same
+        # open-head set a prior freeze touched, clearing a stale freeze the instant the Epic is whole
+        # (latest check of a name wins). Queue heads self-expire, so they need no success.
         sweep_post_clear() { # $1 = epic
           local epic="$1"
           if [ "$EV_MERGED_COUNT" -ge 1 ] && [ "$EV_STRAY_COUNT" -ge 1 ]; then
             echo "epic #$epic: $EV_STRAY_COUNT stray sibling(s) within grace — rolling forward (re-arms auto-merge; \`automation:paused\` stops it)." | tee -a "$GITHUB_STEP_SUMMARY"
             # Roll forward only strays the live `epic:<N>` label search still returns. A snapshot-only
-            # member is one a human de-labeled, and re-arming auto-merge on it would do three wrong
-            # things at once: resume a landing a human stepped out of (the one thing epic-freeze must
-            # never do), arm a pull request that merge-gate and per-PR both now classify as standalone
-            # and therefore no longer gate, and reach for a repository outside the enqueue token's
-            # scope, which is derived from that same label search and would 403 on every sweep forever.
-            # Detection still counts it: it stays in EV_STRAYS and can still trip the freeze at grace.
+            # member is one a human de-labeled: re-arming auto-merge on it resumes a landing a human
+            # stepped out of, arms a pull request merge-gate and per-PR both classify as standalone and
+            # no longer gate, and reaches for a repository outside the enqueue token's scope, which is
+            # derived from that same label search and 403s on every sweep. Detection still counts it: it
+            # stays in EV_STRAYS and can trip the freeze at grace.
             local s_repo s_num skipped drafts
             while read -r s_repo s_num <&5; do
               [ -n "$s_repo" ] || continue
@@ -1021,9 +989,9 @@ runs:
               echo "::warning::epic #$epic: $skipped stray sibling(s) are frozen-set members the \`epic:$epic\` label no longer returns — NOT rolled forward (a de-labeled member is not auto-merged back into a landing). They still count toward the freeze." \
                 | tee -a "$GITHUB_STEP_SUMMARY"
             fi
-            # Drafts are skipped too, and silently until now: a draft stray cannot be auto-merged, so it
-            # sits out every roll-forward and is guaranteed to reach the freeze at grace. Say so while
-            # there is still time to mark it ready.
+            # Drafts are skipped too: a draft stray cannot be auto-merged, so it sits out every
+            # roll-forward and reaches the freeze at grace. Warn while there is still time to mark it
+            # ready.
             drafts=$(printf '%s' "$EV_STRAYS" | jq -r '[.[] | select(.isDraft)] | length')
             if [ "$drafts" -gt 0 ]; then
               echo "::warning::epic #$epic: $drafts stray sibling(s) are DRAFTS — not rolled forward (a draft cannot auto-merge). Mark them ready before the ${GRACE_MINUTES}-minute grace elapses or they trip the freeze." \
@@ -1043,9 +1011,9 @@ runs:
         }
 
         # Frozen: post epic-freeze=failure once per (repo, sha) over the deduplicated union of every open
-        # sibling's current head (blocks it entering the queue / merging) and every live queue entry's
-        # head (fails a required check there → dequeues the in-flight group). Re-derived each sweep, so
-        # the freeze follows new commits and clears once whole.
+        # sibling's current head (blocking it from the queue and from merging) and every live queue
+        # entry's head (failing a required check there dequeues the in-flight group). Re-derived each
+        # sweep, so the freeze follows new commits and clears once the Epic is whole.
         sweep_post_freeze() { # $1 = epic
           local epic="$1"
           echo "epic #$epic: PARTIAL LANDING confirmed ($EV_REASON) — freezing $EV_OPEN_COUNT open sibling(s) + queue heads." | tee -a "$GITHUB_STEP_SUMMARY"
@@ -1058,12 +1026,12 @@ runs:
             | map(select(.sha != null))
             | unique_by(.repo + " " + .sha)')
 
-          # BLAST-CAP: a freeze spanning more than max_freeze_repos DISTINCT repos is almost certainly
-          # a runaway / mis-scoped Epic — but SKIPPING the post would leave a REST-confirmed partial
-          # landing un-frozen (fail-UNSAFE). So STILL post the freeze on every target (fail toward
-          # freezing), and only set the tripwire flag + raise a LOUD ::error so the sweep ends RED and
-          # a human investigates. This is a flag-and-continue tripwire: sweep_main exits non-zero AFTER
-          # the whole loop; it never aborts the sweep mid-epic, and other Epics are unaffected.
+          # Blast cap: a freeze spanning more than max_freeze_repos distinct repos is almost certainly a
+          # runaway or mis-scoped Epic. The freeze is still posted on every target, since a
+          # REST-confirmed partial landing must never be left un-frozen; the cap only sets the tripwire
+          # flag and raises an ::error so the sweep ends red and a human investigates. sweep_main exits
+          # non-zero after the whole loop, so the sweep never aborts mid-epic and other Epics are
+          # unaffected.
           local distinct_repos
           distinct_repos=$(printf '%s' "$targets" | jq -r '[.[].repo] | unique | length')
           if [ "$distinct_repos" -gt "$MAX_FREEZE_REPOS" ]; then
@@ -1079,8 +1047,8 @@ runs:
         }
 
         sweep_epic() { # $1 = epic
-          # Per-Epic pause: `automation:paused` on the Epic issue → leave this Epic entirely alone (no
-          # freeze, no roll-forward), so its landing is under manual control while OTHER Epics move. A
+          # Per-Epic pause: `automation:paused` on the Epic issue leaves this Epic entirely alone (no
+          # freeze, no roll-forward), putting its landing under manual control while other Epics move. A
           # read error (2) falls through to normal detection so a real partial landing is still caught.
           if epic_paused "$1"; then
             echo "epic #$1: automation:paused — skipping (no freeze / roll-forward this sweep)." | tee -a "$GITHUB_STEP_SUMMARY"
@@ -1094,9 +1062,10 @@ runs:
           esac
         }
 
-        # Standalone backstop (universal satisfiability floor): after the epic loop, post
-        # epic-freeze=success on every open PR head that carries no epic:<N> label — so a standalone PR
-        # whose `opened` webhook never fired is still covered and never strands on "Expected". Idempotent.
+        # Standalone backstop (the universal satisfiability floor): post epic-freeze=success on every
+        # open PR head carrying no epic:<N> label, so a standalone PR whose `opened` webhook never fired
+        # is still covered and never strands on "Expected". Idempotent, and it runs ahead of the epic
+        # loop — see sweep_main.
         standalone_sweep() {
           local standalone count s_repo s_sha
           standalone=$(printf '%s' "$all_open" | jq -c '
@@ -1116,8 +1085,8 @@ runs:
         }
 
         sweep_main() {
-          # BLAST-CAP tripwire: set true by sweep_post_freeze when an Epic's freeze exceeds
-          # max_freeze_repos. Checked at the end so the whole sweep run ends RED — a loud alert.
+          # Blast-cap tripwire: set true by sweep_post_freeze when an Epic's freeze exceeds
+          # max_freeze_repos. Checked at the end, so the whole sweep run ends red.
           blast_cap_tripped=false
           echo "Enumerating active Epics (distinct epic:<N> labels on open PRs, org=${ORG})…" | tee -a "$GITHUB_STEP_SUMMARY"
           if ! all_open=$(search_prs "org:${ORG} is:pr is:open"); then
@@ -1132,17 +1101,15 @@ runs:
             [ .[] | (.labels.nodes // [])[].name | select(test("^epic:[0-9]+$")) | ltrimstr("epic:") ]
             | unique | .[]')
 
-          # Backstop first: running it before the epic loop means any epic-pass success/failure posts last
-          # and wins on a head both could touch — flipping a contested head to fail-closed. Two things
-          # contest a head: a lagging label index, and a snapshot member whose label was removed while it
-          # stayed open (the backstop reads labels, so it sees a non-member; the epic pass reads the frozen
-          # set, so it sees a member).
-          # This ordering only settles the contest WITHIN one sweep, and only on the branches that post: a
-          # paused Epic returns before evaluate_epic, and an error decision posts nothing, so on those the
-          # backstop's success stands. It settles nothing against per-PR mode, which classifies by label
-          # alone and will green a de-labeled member's head on its next event —
-          # https://github.com/a-novel-kit/workflows/issues/325. Treat the sweep as a floor, not a gate.
-          # Always runs, even with no active Epics.
+          # Backstop first, so the epic pass posts last and wins on a head both touch, flipping a
+          # contested head to fail-closed. Two things contest a head: a lagging label index, and a
+          # snapshot member whose label was removed while it stayed open (the backstop reads labels and
+          # sees a non-member; the epic pass reads the frozen set and sees a member).
+          # The ordering settles the contest within one sweep, on the branches that post: a paused Epic
+          # returns before evaluate_epic and an error decision posts nothing, so the backstop's success
+          # stands there. Per-PR mode classifies by label alone and greens a de-labeled member's head on
+          # its next event; tracked in https://github.com/a-novel-kit/workflows/issues/325. The sweep is
+          # a floor. It always runs, even with no active Epics.
           standalone_sweep
 
           if [ -n "$epics" ]; then
@@ -1164,9 +1131,9 @@ runs:
 
           echo "Partial-landing sweep complete." | tee -a "$GITHUB_STEP_SUMMARY"
 
-          # A tripped BLAST-CAP fails the sweep run RED — the loud alert — but only AFTER the whole
-          # loop, never mid-epic. The over-wide Epic WAS still frozen (fail-safe — a partial landing is
-          # never left open); its width is merely flagged for a human to investigate.
+          # A tripped blast cap fails the sweep run red once the whole loop has finished. The over-wide
+          # Epic was still frozen, so no partial landing is left open; its width is flagged for a human
+          # to investigate.
           if [ "$blast_cap_tripped" = true ]; then
             echo "::error::BLAST-CAP tripped this sweep — one or more Epics exceeded max_freeze_repos=${MAX_FREEZE_REPOS} (details above). They were frozen anyway (fail-safe); investigate a runaway / mis-scoped Epic."
             exit 1
@@ -1174,11 +1141,10 @@ runs:
         }
 
         # ---- Per-PR wrapper ---------------------------------------------------------------
-        # Classify the triggering PR (mirror of merge-gate's classify step) and post epic-freeze on its
-        # head only. Fails open (success on standalone and any uncertainty) — the satisfiability guarantor
-        # for a fresh head with no prior check; a wrongly-open PR is double-backstopped by merge-gate
-        # (independently required + fail-closed) and the next sweep. Only a REST-confirmed frozen Epic
-        # posts failure.
+        # Classify the triggering PR (mirroring merge-gate's classify step) and post epic-freeze on its
+        # head only. Fails open — success on standalone and on any uncertainty — which is what keeps a
+        # fresh head with no prior check satisfiable; merge-gate (independently required and fail-closed)
+        # and the next sweep backstop a wrongly-open PR. Only a REST-confirmed frozen Epic posts failure.
         per_pr_main() {
           # Anchor the check to the head the ruleset evaluates. No head SHA = misconfigured caller.
           if [ -z "${HEAD_SHA:-}" ]; then
@@ -1192,8 +1158,8 @@ runs:
           if [ -n "${IN_QUEUE:-}" ]; then
             classify_pr=$(printf '%s' "${MG_HEAD_REF:-}" | grep -oE 'pr-[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
             if [ -z "$classify_pr" ]; then
-              # Can't identify the queued PR — post failure on the group head (dequeues). merge-gate
-              # already dequeues an unidentifiable group; the sweep re-checks the PR head.
+              # The queued PR is unidentifiable, so post failure on the group head, which dequeues it.
+              # merge-gate already dequeues an unidentifiable group; the sweep re-checks the PR head.
               freeze_post "$REPO_FULL" "$HEAD_SHA" "failure" \
                 "merge_group head_ref \"${MG_HEAD_REF:-}\" — couldn't identify the queued PR to check its Epic; posting failure (dequeues) rather than passing blind. The sweep re-checks the PR head."
               return 0
@@ -1201,17 +1167,17 @@ runs:
           elif [ -n "${PR_NUMBER:-}" ]; then
             classify_pr="$PR_NUMBER"
           else
-            # A head SHA but neither a PR nor a merge_group is a misconfigured caller — refuse to satisfy
+            # A head SHA with neither a PR nor a merge_group is a misconfigured caller. Refuse to satisfy
             # a required check on a real SHA with nothing evaluated.
             freeze_post "$REPO_FULL" "$HEAD_SHA" "failure" \
               "No pull_request_number for ${HEAD_SHA:0:12} and not a merge_group event — refusing to pass a required check without evaluating a PR."
             return 0
           fi
 
-          # This PR's labels (the membership authority). On the native pull_request event they are in the
-          # payload → classify with no API call (the standalone fast-path can't be frozen by a GraphQL
-          # outage). merge_group / repost paths have no payload, so read via GraphQL; a read failure fails
-          # open (post success) — merge-gate holds independently and the sweep re-derives.
+          # This PR's labels, the membership authority. The native pull_request event carries them in the
+          # payload, so that path classifies with no API call and a GraphQL outage cannot freeze the
+          # standalone fast-path. The merge_group and repost paths have no payload and read via GraphQL;
+          # a read failure posts success, since merge-gate holds independently and the sweep re-derives.
           local labels=""
           if [ -n "${EVENT_PR:-}" ] && [ "$classify_pr" = "${EVENT_PR}" ]; then
             labels=$(printf '%s' "${EVENT_LABELS:-[]}")
@@ -1234,9 +1200,9 @@ runs:
             return 0
           fi
 
-          # Per-Epic pause: `automation:paused` on the Epic issue → don't evaluate partial-landing for
-          # it. merge-gate HOLDs a paused Epic's members independently, so fail open here (post success)
-          # to avoid stranding this head on "Expected". A read error (2) proceeds with normal detection.
+          # Per-Epic pause: `automation:paused` on the Epic issue leaves partial-landing unevaluated.
+          # merge-gate holds a paused Epic's members independently, so this posts success and the head
+          # never strands on "Expected". A read error (2) proceeds with normal detection.
           if epic_paused "$epic"; then
             freeze_post "$REPO_FULL" "$HEAD_SHA" "success" \
               "Epic #${epic} is automation:paused — merge-gate holds it; epic-freeze not evaluating partial-landing while paused. epic-freeze clear."
@@ -1254,19 +1220,19 @@ runs:
               freeze_post "$REPO_FULL" "$HEAD_SHA" "failure" \
                 "Epic #${epic} PARTIALLY LANDED (merged=${EV_MERGED_COUNT}, closed-unmerged=${EV_CLOSED_COUNT}, stray=${EV_STRAY_COUNT}): ${EV_REASON}. Holding this sibling to prevent further partial landing. Does NOT roll back merged PRs — human rollback is a-novel-kit/workflows#235." ;;
             *)
-              # Uncertainty (resolve/queue/REST) → fail open. Double-backstopped by merge-gate + the next
-              # sweep, which re-derives from scratch and freezes the true heads if it is real.
+              # Uncertainty (resolve, queue or REST) fails open. merge-gate and the next sweep back it
+              # up: the sweep re-derives from scratch and freezes the true heads if it is real.
               freeze_post "$REPO_FULL" "$HEAD_SHA" "success" \
                 "Epic #${epic}: couldn't confirm partial-landing state (resolve/queue/REST uncertainty) — failing open (success). merge-gate holds independently and the reconcile sweep re-derives." ;;
           esac
         }
 
-        # ---- Org-level HALT (AGENT_KILL_SWITCH) — acted on FIRST at dispatch ---------------
-        # Per-PR is a required-check poster → HOLD (post failure), never skip (a skipped/neutral
-        # required check passes OPEN). Sweep is a recovery writer → skip all work: no freeze posts, no
-        # roll-forward. The halt is still complete because merge-gate independently HOLDs every PR
-        # org-wide (the regate sweep pass re-posts it on idle PRs). freeze_post is dry-run aware, so a
-        # halted per-PR run under dry_run only logs the intended HOLD.
+        # ---- Org-level halt (AGENT_KILL_SWITCH), acted on first at dispatch ----------------
+        # Per-PR is a required-check poster, so it holds by posting failure; a skipped or neutral
+        # required check passes open. The sweep is a recovery writer, so it skips all work: no freeze
+        # posts, no roll-forward. The halt is still complete because merge-gate independently holds every
+        # PR org-wide, its regate sweep pass re-posting on idle PRs. freeze_post is dry-run aware, so a
+        # halted per-PR run under dry_run only logs the intended hold.
         if [ "$kill_engaged" = true ]; then
           if [ "${MODE:-sweep}" = "per-pr" ]; then
             freeze_post "$REPO_FULL" "$HEAD_SHA" "failure" \

--- a/generic-actions/enable-auto-merge/action.yaml
+++ b/generic-actions/enable-auto-merge/action.yaml
@@ -52,9 +52,8 @@ inputs:
 runs:
   using: composite
   steps:
-    # Scope the token to just the target repo (least privilege). The [Agent] App is
-    # installed org-wide, so a cross-repo caller can enable on any sibling's repo by
-    # passing its name here.
+    # Scope the token to the target repo. The [Agent] App is installed org-wide, so a
+    # cross-repo caller reaches any sibling by passing its name here.
     - name: Mint token
       id: token
       uses: actions/create-github-app-token@v3
@@ -64,8 +63,7 @@ runs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ inputs.repo }}
         permission-pull-requests: write
-        # contents:write is granted alongside pull-requests:write because the proven
-        # `gh pr merge --auto` enqueue pattern mints both.
+        # `gh pr merge --auto` needs contents:write alongside pull-requests:write.
         permission-contents: write
 
     - name: Enable auto-merge
@@ -85,18 +83,11 @@ runs:
         fi
         target="${REPO_FULL}#${PR}"
 
-        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
-        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
-        # engages. When engaged, do NOT arm auto-merge (no-op + exit 0; guard and the enable share one
-        # step, so the exit is sufficient). merge-gate independently HOLDs while halted, so an armed
-        # request could not merge anyway; not arming keeps the [Agent] from mutating during a halt.
-        # NOTE: this does NOT disarm auto-merge ALREADY armed on an idle ready PR before the halt —
-        # merge-gate's red check still blocks it, but there is a brief latency window until the next
-        # event / reconcile sweep re-posts that hold.
-        # The repo-scoped pr+contents:write token is minted above, ahead of this guard, on purpose:
-        # nothing past the `exit 0` exercises it, so mint-vs-halt ordering is not blast radius here
-        # (token SCOPE, not mint timing, is the enforced bound) — and every action keeps one "mint per
-        # least-privilege, then halt-first" shape instead of duplicating this fail-safe parse pre-mint.
+        # Org-level halt, read before anything is armed. Fail-safe: running only for an explicit
+        # off-token (empty/unset, 0, off, false, no, disabled); any other value engages the halt and
+        # this step exits 0 having armed nothing. A halt does not disarm auto-merge already armed on
+        # an idle ready PR — merge-gate's red check still blocks the merge, with a latency window
+        # until the next event or reconcile sweep re-posts that hold.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)
@@ -105,13 +96,12 @@ runs:
             ;;
         esac
 
-        # Idempotency by query, not by parsing an error string: is auto-merge already on?
+        # Idempotency is decided by querying the PR: is auto-merge already on?
         already=$(gh pr view "$PR" --repo "$REPO_FULL" --json autoMergeRequest \
           -q '.autoMergeRequest != null')
 
-        # DRY_RUN defaults on; only the literal "false" (any case) actually enables.
-        # Lowercase with tr, not ${VAR,,} — the latter is a Bash 4+ expansion that fails
-        # on Bash 3.x (e.g. macOS runners).
+        # DRY_RUN defaults on; only the literal "false" (any case) enables. `tr` lowercases
+        # because ${VAR,,} is a Bash 4+ expansion and macOS runners ship Bash 3.x.
         dry=$(printf '%s' "${DRY_RUN:-true}" | tr '[:upper:]' '[:lower:]')
         if [ "$dry" != "false" ]; then
           if [ "$already" = "true" ]; then

--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -61,10 +61,9 @@ runs:
   using: composite
   steps:
     # Mint an org-wide [Agent] token: the search spans every repo in the org, and the
-    # default GITHUB_TOKEN is single-repo, so it can't see sibling PRs in other repos.
-    # Set `owner` and omit `repositories` to install org-wide; request only the two read
-    # scopes the search needs (issues + pull-requests) and nothing else — this action
-    # never writes.
+    # default GITHUB_TOKEN is single-repo, so it cannot see sibling PRs. Setting `owner`
+    # with no `repositories` installs it org-wide; the two read scopes are all the search
+    # needs, and this action never writes.
     - name: Mint token
       id: token
       uses: actions/create-github-app-token@v3
@@ -90,50 +89,51 @@ runs:
           echo "::error::epic_number is required"
           exit 1
         fi
-        # Coerce to an integer before it reaches the search grammar. `epic_number` builds
+        # Check for an integer before it reaches the search grammar: `epic_number` builds
         # the `label:"epic:${EPIC}"` qualifier, so a non-numeric value could close the
-        # quoted qualifier and inject further search terms — silently broadening the set.
-        # The label convention is numeric, so reject anything else outright.
+        # quoted qualifier and inject further search terms, broadening the set.
         if ! [[ "$EPIC" =~ ^[0-9]+$ ]]; then
           echo "::error::epic_number must be an integer, got \"$EPIC\""
           exit 1
         fi
 
         # --- Activation snapshot -----------------------------------------------------------------
-        # Once landing has stabilized, merge-gate freezes the member set into a marker in the Epic body
-        # (a two-phase pending→frozen capture, so an index-lagging member is never frozen out). A
-        # FROZEN marker IS the set — a later de-label, close, or relabel never changes it; per-member
-        # STATE is still read live below. A `pending` marker, a malformed one, or none → the live label
-        # search further down (the safe, self-healing default).
+        # Once landing has stabilized, merge-gate freezes the member set into a marker in the Epic
+        # body, capturing in two phases (pending then frozen) so an index-lagging member is never
+        # frozen out. A frozen marker is the set: a later de-label, close or relabel does not change
+        # it, while each member's state is still read live below. A pending marker, a malformed one,
+        # or none falls through to the live label search further down.
         #
-        # Guard planning_repo before it becomes an API path component (as the sibling actions do).
+        # Guard planning_repo before it becomes an API path component.
         if ! [[ "${PLANNING_REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
           echo "::error::planning_repo must be a bare repository name (no owner/slash), got \"${PLANNING_REPO:-}\""
           exit 1
         fi
         frozen=""
-        # The fence strings, matched as WHOLE LINES — see the note in detect-partial-landing: an
-        # unanchored match lets a pseudo-fence planted in an HTML comment shadow the real region.
+        # The fence strings, matched as whole lines: under an unanchored match a pseudo-fence planted
+        # in an HTML comment would shadow the real region.
         START_M='<!-- epic-membership:snapshot:start -->'
         END_M='<!-- epic-membership:snapshot:end -->'
         # GitHub stores bodies with CRLF; strip \r so the marker lines match.
         if body=$(gh api "repos/${OWNER}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
           # The fenced region holds a human-readable note and then the JSON, so skip to the first line
-          # that opens a value before parsing. Requiring the JSON to be one compact line at column 0
-          # (what a `grep '^{'` does) silently kills a pretty-printed marker; parsing the note as JSON
-          # kills every marker merge-gate actually emits. `-s .[0]` takes the first value if a hand-edit
-          # left several — though trailing prose inside the region still voids the whole marker, which fails safe. All three participants extract identically.
+          # that opens a value before parsing: parsing the note as JSON would kill every marker
+          # merge-gate emits, and requiring one compact line at column 0 would kill a pretty-printed
+          # one. `-s .[0]` takes the first value if a hand-edit left several; trailing prose inside
+          # the region voids the whole marker, which fails safe. All three participants extract
+          # this way.
           marker=$(printf '%s\n' "$body" \
             | awk -v s="$START_M" -v e="$END_M" '$0 == s {f=1;next} $0 == e {f=0} f' \
             | sed -n '/^[[:space:]]*[{[]/,$p' \
             | jq -s -c '.[0] // empty' 2>/dev/null || true)
-          # Only a well-formed FROZEN marker with a valid member list counts; anything else (pending,
-          # hand-edited garbage, wrong shape) yields an empty `frozen` and falls through to the live
-          # search — never a crash or a permanent HOLD.
+          # Only a well-formed frozen marker with a valid member list counts. A pending marker,
+          # hand-edited garbage or the wrong shape yields an empty `frozen` and falls through to the
+          # live search, never a crash or a permanent hold.
           # The guards are strict because `.repo` and `.number` are interpolated into the GraphQL
           # document below, and the Epic body is writable by anyone with write access to this repo:
-          # `[^/]` would admit quotes and newlines (enough to inject fields), and `type == "number"`
-          # alone would admit 1.5, a document-level validation error rather than a skippable one.
+          # `[^/]` would admit quotes and newlines, enough to inject fields, and a bare
+          # `type == "number"` would admit 1.5, a document-level validation error rather than a
+          # skippable one.
           [ -n "$marker" ] && frozen=$(printf '%s' "$marker" | jq -c '
             select(type == "object" and .status == "frozen" and (.members | type == "array"))
             | .members
@@ -145,16 +145,15 @@ runs:
         fi
         if [ -n "$frozen" ] && [ "$frozen" != "null" ]; then
           # Re-read each frozen member's current state (OPEN / MERGED / CLOSED), one GraphQL alias per
-          # member in a single call. The response must account for EVERY member: GitHub answers a
-          # multi-alias query with partial data plus an `errors` array, nulling what failed, and a
-          # dropped member here does not merely shrink a report — this set is what merge-gate gates on,
-          # so a member that silently vanishes is a member never evaluated, and the gate posts success
-          # on a wave that was never whole. That is the premature partial landing the gate exists to
-          # prevent. An incomplete answer therefore yields [], which merge-gate reads as a HOLD: a held
-          # pull request only waits, while a wrongly-passed set has already merged.
-          # Identity is the alias index plus the number, not the repository name: GraphQL follows a
-          # rename silently and answers with the new nameWithOwner, and a frozen marker is never
-          # rewritten, so name-matching would strand a renamed member's Epic permanently.
+          # member in a single call. The response has to account for every member: GitHub answers a
+          # multi-alias query with partial data plus an `errors` array, nulling what failed, and this
+          # set is what merge-gate gates on, so a member that vanishes is a member never evaluated and
+          # the gate posts success on a wave that was never whole. An incomplete answer therefore
+          # yields [], which merge-gate reads as a hold; a held pull request only waits, while a
+          # wrongly-passed set has already merged.
+          # Identity is the alias index plus the number. GraphQL follows a rename silently and answers
+          # with the new nameWithOwner, and a frozen marker is never rewritten, so matching on the
+          # repository name would strand a renamed member's Epic permanently.
           alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
               + "{pullRequest(number:\(.value.number|floor)){number isDraft reviewDecision headRefOid state repository{nameWithOwner}}}"
@@ -192,20 +191,18 @@ runs:
           exit 0
         fi
 
-        # The authority: open PRs carrying the permission-gated `epic:<N>` label,
-        # org-wide. `is:pr is:open` bounds the search to open PRs; the quoted label name
-        # matches the `epic:<N>` convention exactly (the colon needs the quotes);
-        # `org:${OWNER}` scopes the walk to the workflow's org (the owner is an
-        # Organization — a user account would need the `user:` qualifier instead).
-        # GitHub's search index is eventually consistent, so a PR labeled or opened
-        # seconds ago may be missing from an otherwise-successful response (and a
-        # just-closed one briefly present); the caller must tolerate a transiently short
-        # set. The timeline-fold follow-up above closes this window by reading the Epic
-        # timeline live instead of the lagging index.
+        # Membership authority: open PRs carrying the permission-gated `epic:<N>` label,
+        # org-wide. The label name is quoted because of its colon, and `org:${OWNER}`
+        # scopes the walk to the workflow's org, which is an Organization; a user account
+        # would need the `user:` qualifier. GitHub's search index is eventually consistent,
+        # so a PR labeled or opened seconds ago may be missing from an otherwise-successful
+        # response, and a just-closed one briefly present, which the caller tolerates as a
+        # transiently short set. The timeline-fold follow-up above closes that window by
+        # reading the Epic timeline live.
         search="is:pr is:open label:\"epic:${EPIC}\" org:${OWNER}"
 
-        # Search returns the ISSUE union; PRs come through the PullRequest inline
-        # fragment. headRefOid is the current ready SHA the readiness gate anchors to.
+        # Search returns the ISSUE union, so PRs come through the PullRequest inline
+        # fragment. headRefOid is the ready SHA the readiness gate anchors to.
         q='query($q:String!,$cursor:String){
           search(query:$q, type:ISSUE, first:100, after:$cursor){
             pageInfo{ hasNextPage endCursor }
@@ -213,10 +210,9 @@ runs:
               number isDraft reviewDecision headRefOid
               repository{ nameWithOwner } } } } }'
 
-        # Retry transient GraphQL failures a few times. Unlike merge-gate (which posts a
-        # required check and so must fail open to avoid deadlocking the queue), this is a
-        # read helper with no side effect: if the set can't be resolved we fail with a
-        # clear message and let the caller choose hold-vs-fail-open with full context.
+        # Retry transient GraphQL failures a few times. This is a read helper with no side
+        # effect, so an unresolvable set fails with a clear message and the caller chooses
+        # between holding and failing open with full context.
         fetch() { # $1=cursor  → prints the response JSON on success, nothing on failure
           # -f (raw string) for every variable: all three are GraphQL String, and -f
           # skips the typed coercion -F applies (bare true/false/numeric, leading @=file).
@@ -224,9 +220,9 @@ runs:
           [ -n "${1:-}" ] && args+=(-f cursor="$1")
           local data
           for attempt in 1 2 3; do
-            # Capture stdout+stderr together so a transport / auth / rate-limit / query
-            # error (gh writes those to stderr) survives to be echoed on final failure;
-            # on success gh prints only the response JSON, which the jq check validates.
+            # Capture stdout and stderr together so a transport, auth, rate-limit or query
+            # error survives to be echoed on final failure; on success gh prints only the
+            # response JSON, which the jq check validates.
             if data=$(gh api graphql "${args[@]}" 2>&1) \
               && echo "$data" | jq -e 'has("data") and (has("errors") | not)' >/dev/null 2>&1; then
               printf '%s' "$data"
@@ -234,18 +230,17 @@ runs:
             fi
             [ "$attempt" -lt 3 ] && sleep 2
           done
-          # This runs in a command-substitution subshell, so the caller's ::error:: can't
-          # see $data — echo the underlying error to the run log here so the fail-closed
-          # exit is diagnosable (auth, rate limit, query validation, …).
+          # This runs in a command-substitution subshell, where the caller's ::error:: has
+          # no access to $data, so echo the underlying error here to make the fail-closed
+          # exit diagnosable.
           printf 'epic-membership: GraphQL fetch failed after 3 attempts: %s\n' "$data" >&2
           return 1
         }
 
-        # Accumulate PR nodes across pages (an Epic can span more than 100 PRs) in a
-        # plain JSON string — no temp file, matching the pure-jq style of the sibling
-        # actions. `(.data.search.nodes // [])[]` tolerates a null `nodes` (so jq can't
-        # abort the graceful error path), and `.number != null` drops any non-PR row the
-        # ISSUE-union search might surface rather than emitting an empty object.
+        # Accumulate PR nodes across pages, since an Epic can span more than 100 PRs.
+        # `(.data.search.nodes // [])[]` tolerates a null `nodes`, keeping jq from aborting
+        # the graceful error path, and `.number != null` drops any non-PR row the
+        # ISSUE-union search surfaces.
         agg='[]'
         cursor=""
         while :; do
@@ -259,11 +254,11 @@ runs:
           cursor=$(printf '%s' "$resp" | jq -r '.data.search.pageInfo.endCursor')
         done
 
-        # Compact (jq -c) so the output is a single line — GITHUB_OUTPUT is line-based.
-        # Sorted by repo then number: GitHub's search order isn't stable, so an unsorted
-        # set churns downstream diffs/comparisons across runs. reviewDecision stays null
-        # when GitHub reports no decision yet; the caller reads head SHA + review live
-        # anyway, this is the discovery view.
+        # `jq -c` keeps the output on one line, because GITHUB_OUTPUT is line-based.
+        # Sorting by repo then number stabilizes the set: GitHub's search order is not
+        # stable, so an unsorted set churns downstream comparisons across runs.
+        # reviewDecision stays null while GitHub reports no decision; this is the discovery
+        # view, and the caller reads head SHA and review live.
         members=$(printf '%s' "$agg" | jq -c '[.[] | {
           repo: .repository.nameWithOwner,
           number,

--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -110,18 +110,17 @@ runs:
           exit 1
         fi
         frozen=""
-        # The fence strings, matched as whole lines: under an unanchored match a pseudo-fence planted
-        # in an HTML comment would shadow the real region.
+        # The fence strings, matched as whole lines — the same match merge-gate's splice uses, so a
+        # pseudo-fence planted in an HTML comment cannot shadow the real region.
         START_M='<!-- epic-membership:snapshot:start -->'
         END_M='<!-- epic-membership:snapshot:end -->'
         # GitHub stores bodies with CRLF; strip \r so the marker lines match.
         if body=$(gh api "repos/${OWNER}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
           # The fenced region holds a human-readable note and then the JSON, so skip to the first line
-          # that opens a value before parsing: parsing the note as JSON would kill every marker
-          # merge-gate emits, and requiring one compact line at column 0 would kill a pretty-printed
-          # one. `-s .[0]` takes the first value if a hand-edit left several; trailing prose inside
-          # the region voids the whole marker, which fails safe. All three participants extract
-          # this way.
+          # that opens a value before parsing: the note is not JSON, and the JSON may be pretty-printed
+          # across several lines. `-s .[0]` takes the first value if a hand-edit left several; trailing
+          # prose inside the region voids the whole marker, which fails safe. All three participants
+          # extract this way.
           marker=$(printf '%s\n' "$body" \
             | awk -v s="$START_M" -v e="$END_M" '$0 == s {f=1;next} $0 == e {f=0} f' \
             | sed -n '/^[[:space:]]*[{[]/,$p' \
@@ -130,10 +129,10 @@ runs:
           # hand-edited garbage or the wrong shape yields an empty `frozen` and falls through to the
           # live search, never a crash or a permanent hold.
           # The guards are strict because `.repo` and `.number` are interpolated into the GraphQL
-          # document below, and the Epic body is writable by anyone with write access to this repo:
-          # `[^/]` would admit quotes and newlines, enough to inject fields, and a bare
-          # `type == "number"` would admit 1.5, a document-level validation error rather than a
-          # skippable one.
+          # document below, and the Epic body is writable by anyone with write access to this repo.
+          # The repo pattern excludes quotes and newlines, which are enough to inject fields, and the
+          # number must be a whole integer, since 1.5 is a document-level validation error that
+          # rejects the whole query.
           [ -n "$marker" ] && frozen=$(printf '%s' "$marker" | jq -c '
             select(type == "object" and .status == "frozen" and (.members | type == "array"))
             | .members
@@ -152,8 +151,8 @@ runs:
           # yields [], which merge-gate reads as a hold; a held pull request only waits, while a
           # wrongly-passed set has already merged.
           # Identity is the alias index plus the number. GraphQL follows a rename silently and answers
-          # with the new nameWithOwner, and a frozen marker is never rewritten, so matching on the
-          # repository name would strand a renamed member's Epic permanently.
+          # with the new nameWithOwner, while a frozen marker is never rewritten, so the repository
+          # name stays out of the match.
           alias_q=$(printf '%s' "$frozen" | jq -r 'to_entries | map(
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
               + "{pullRequest(number:\(.value.number|floor)){number isDraft reviewDecision headRefOid state repository{nameWithOwner}}}"
@@ -193,8 +192,8 @@ runs:
 
         # Membership authority: open PRs carrying the permission-gated `epic:<N>` label,
         # org-wide. The label name is quoted because of its colon, and `org:${OWNER}`
-        # scopes the walk to the workflow's org, which is an Organization; a user account
-        # would need the `user:` qualifier. GitHub's search index is eventually consistent,
+        # scopes the walk to the workflow's org, which is an Organization; the `user:`
+        # qualifier covers a user account. GitHub's search index is eventually consistent,
         # so a PR labeled or opened seconds ago may be missing from an otherwise-successful
         # response, and a just-closed one briefly present, which the caller tolerates as a
         # transiently short set. The timeline-fold follow-up above closes that window by

--- a/generic-actions/epic-rollback/action.yaml
+++ b/generic-actions/epic-rollback/action.yaml
@@ -118,18 +118,17 @@ inputs:
 runs:
   using: composite
   steps:
-    # Org-level HALT (read FIRST, before the admin check or any token mint): AGENT_KILL_SWITCH
-    # engaged → refuse to run. A destructive rollback must be an explicit, un-halted decision, so
-    # this aborts loud rather than silently no-opping.
+    # Org-level halt, read before the admin check or any token mint. A destructive rollback is an
+    # explicit, un-halted decision, so an engaged switch aborts loudly.
     - name: Halt guard (kill-switch)
       shell: bash
       env:
         KILL_SWITCH: ${{ inputs.kill_switch }}
       run: |
         set -euo pipefail
-        # FAIL-SAFE: RUNNING only for an explicit off-token (empty/unset, 0, off, false, no,
-        # disabled); ANYTHING ELSE (a fat-fingered value or garbage) engages the halt. A failing step
-        # stops the composite, so no later step (admin check, mints, revert) runs.
+        # Fail-safe: running only for an explicit off-token (empty/unset, 0, off, false, no,
+        # disabled); any other value engages the halt. A failing step stops the composite, so the
+        # admin check, the mints and the revert never run.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)
@@ -138,12 +137,11 @@ runs:
             ;;
         esac
 
-    # Defense in depth: re-check the dispatcher is a repo admin HERE, as the action's first step —
-    # the gate must not live ONLY in the caller's dispatch shell (a hand-written or drifted copy could
-    # drop it). Copied from approve-pr/action.yaml: the collaborator-permission endpoint needs only
-    # Metadata:read (the default token always has it), and `|| echo ""` keeps a failed lookup from
-    # tripping `set -e` — an empty permission falls through and fails closed. github.repository /
-    # github.actor are the dispatching repo + user.
+    # Re-check the dispatcher is a repo admin here as well as in the caller's dispatch shell, which a
+    # hand-written or drifted copy could drop. The collaborator-permission endpoint needs only
+    # Metadata:read, which the default token always has, and `|| echo ""` keeps a failed lookup from
+    # tripping `set -e`: an empty permission falls through and fails closed. github.repository and
+    # github.actor are the dispatching repo and user.
     - name: Require admin (defense in depth)
       shell: bash
       env:
@@ -159,8 +157,8 @@ runs:
         fi
         echo "@${ACTOR} is a repo admin (action-level re-check passed)." | tee -a "$GITHUB_STEP_SUMMARY"
 
-    # Read token: the ledger search + REST reads span every repo in the org, and the single-repo
-    # GITHUB_TOKEN can't see sibling PRs / commits in other repos. Least privilege: read only.
+    # Read token: the ledger search and REST reads span every repo in the org, and the single-repo
+    # GITHUB_TOKEN cannot see sibling PRs or commits.
     - name: Mint read token
       id: read
       uses: actions/create-github-app-token@v3
@@ -172,11 +170,11 @@ runs:
         permission-pull-requests: read
         permission-contents: read
 
-    # Reconstruct the epic:<N> ledger (READ-only) and derive the epic-scoped repo set. Emits `proceed`
-    # (true only for a live run that cleared every gate), `ledger` (the reconstructed JSON — the single
-    # source of truth the mutation step consumes), and `repos` (the ledger's repos + the planning repo,
-    # the scope the write token is then minted for). Splitting reconstruct from mutate is what lets the
-    # write token be scoped to exactly the epic's repos — and not minted at all on a dry run.
+    # Reconstruct the epic:<N> ledger read-only and derive the epic-scoped repo set. Emits `proceed`,
+    # true only for a live run that cleared every gate; `ledger`, the reconstructed JSON the mutation
+    # step consumes; and `repos`, the ledger's repos plus the planning repo, which is the scope the
+    # write token is minted for. Splitting reconstruct from mutate is what lets that token be scoped
+    # to exactly the Epic's repos, and not minted at all on a dry run.
     - name: Reconstruct ledger + plan (read-only)
       id: plan
       shell: bash
@@ -194,13 +192,13 @@ runs:
         set -euo pipefail
 
         # ---- Validate untrusted inputs before they reach a search grammar --------------------
-        # epic_number builds `label:"epic:<N>"`; a non-numeric value could close the quoted
-        # qualifier and inject terms. The label convention is numeric — reject anything else.
+        # epic_number builds `label:"epic:<N>"`, so a non-numeric value could close the quoted
+        # qualifier and inject terms.
         if ! [[ "${EPIC:-}" =~ ^[0-9]+$ ]]; then
           echo "::error::epic_number must be an integer, got \"${EPIC:-}\""
           exit 1
         fi
-        # org feeds `org:<ORG>` — require GitHub-login chars so a stray value can't broaden scope.
+        # org feeds `org:<ORG>`, so require GitHub-login characters: a stray value would broaden scope.
         if ! [[ "${ORG:-}" =~ ^[A-Za-z0-9-]+$ ]]; then
           echo "::error::org must be a valid GitHub login (alphanumeric + hyphens), got \"${ORG:-}\""
           exit 1
@@ -209,31 +207,30 @@ runs:
           echo "::error::reason is required (it is the audit trail for the rollback)"
           exit 1
         fi
-        # planning_repo now feeds TWO sinks: the write token's `repositories:` scope (via the repos
-        # output) and the rollback-Epic issue's API path. Require a bare repo name so a stray value
-        # can't widen the token scope (a comma would add a repo) or break the `repos=` output (a
-        # newline). Mirrors the merge-gate / detect-partial-landing guard.
+        # planning_repo feeds two sinks: the write token's `repositories:` scope, through the repos
+        # output, and the rollback-Epic issue's API path. A bare repo name keeps a comma from widening
+        # the token scope and a newline from breaking the `repos=` output.
         if ! [[ "${PLANNING_REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
           echo "::error::planning_repo must be a bare repository name (no owner/slash), got \"${PLANNING_REPO:-}\""
           exit 1
         fi
-        # BLAST-CAP bound feeds shell arithmetic + a `-gt` compare; require a positive integer.
-        # Hard internal default 5 so an empty/unset value is safe rather than an error.
+        # The blast-cap bound feeds shell arithmetic and a `-gt` compare, so require a positive
+        # integer. The internal default of 5 makes an empty or unset value safe.
         MAX_ROLLBACK_REPOS="${MAX_ROLLBACK_REPOS:-5}"
         if ! [[ "${MAX_ROLLBACK_REPOS}" =~ ^[0-9]+$ ]] || [ "${MAX_ROLLBACK_REPOS}" -lt 1 ]; then
           echo "::error::max_rollback_repos must be a positive integer, got \"${MAX_ROLLBACK_REPOS:-}\""
           exit 1
         fi
 
-        # dry_run defaults on; only the literal "false" (any case) mutates. Lowercase via tr
-        # (portable), not ${VAR,,} (bash-4 only).
+        # dry_run defaults on; only the literal "false" (any case) mutates. `tr` lowercases because
+        # ${VAR,,} is a Bash 4+ expansion.
         dry=$(printf '%s' "${DRY_RUN:-true}" | tr '[:upper:]' '[:lower:]')
 
         # ---- Per-Epic pause -------------------------------------------------------------------
-        # `automation:paused` on the Epic issue holds ALL [Agent] automation for that Epic. A
-        # destructive rollback must be an explicit, un-paused decision, so refuse to run while the
-        # Epic is paused. Read the Epic issue's labels (issues:read); a read error does NOT block
-        # (fail-open — the admin + typed-confirmation gate already fenced this dispatch).
+        # `automation:paused` on the Epic issue holds all [Agent] automation for that Epic, and a
+        # destructive rollback is an explicit, un-paused decision, so refuse to run while it is set.
+        # A failed label read does not block, since the admin and typed-confirmation gates already
+        # fenced this dispatch.
         paused_labels=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.labels[].name' 2>/dev/null || echo "")
         if printf '%s\n' "$paused_labels" | grep -qx 'automation:paused'; then
           echo "::error::epic:#${EPIC} is automation:paused — remove the \`automation:paused\` label from the Epic issue before rolling it back."
@@ -243,11 +240,11 @@ runs:
         # Marker file for the conflict-placeholder fallback (a ruleset may reject an empty commit).
         MARKER="ROLLBACK-HELD.md"
 
-        # ---- Shared GraphQL + read helpers (the detect-partial-landing search pattern) --------
+        # ---- Shared GraphQL + read helpers ----------------------------------------------------
 
-        # PR search node — extended from detect-partial-landing's SEARCH_Q with mergeCommit{oid}
-        # (a cross-check of the squash SHA) and closingIssuesReferences (the Task ids the board reset
-        # walks). REST remains the authority for the squash SHA; these are the read-only plan inputs.
+        # PR search node. mergeCommit{oid} cross-checks the squash SHA and closingIssuesReferences
+        # carries the Task ids the board reset walks. REST is the authority for the squash SHA; these
+        # are the read-only plan inputs.
         SEARCH_Q='query($q:String!,$cursor:String){
           search(query:$q, type:ISSUE, first:100, after:$cursor){
             pageInfo{ hasNextPage endCursor }
@@ -285,9 +282,8 @@ runs:
           printf '%s' "$agg"
         }
 
-        # REST authority for one PR (the search index lags): prints "<merged> <merge_commit_sha>"
-        # (e.g. "true a1b2c3…"). Extends detect-partial-landing's rest_pr_state to also return the
-        # squash SHA. Returns 1 on error so the caller fails closed.
+        # REST authority for one PR, which the search index lags: prints "<merged> <merge_commit_sha>"
+        # (e.g. "true a1b2c3…"). Returns 1 on error so the caller fails closed.
         rest_pr_merge() { # $1=owner/repo $2=number
           local data
           for attempt in 1 2 3; do
@@ -325,16 +321,16 @@ runs:
           exit 1
         fi
         cand_count=$(printf '%s' "$candidates" | jq 'length')
-        # Precondition: there must be something merged, or there is nothing to roll back. The
-        # INV-1-violation JUDGMENT stays with the human; this only refuses the nonsensical case.
+        # Something has to be merged, or there is nothing to roll back. Judging whether the landing
+        # was legitimate stays with the human; this only refuses the nonsensical case.
         if [ "$cand_count" -eq 0 ]; then
           echo "::error::no merged PRs carry epic:${EPIC} in org ${ORG} — nothing to roll back."
           exit 1
         fi
 
         # Per candidate: REST-confirm merged==true, take the authoritative squash SHA, assert a single
-        # parent, record the pre-merge parent + the Task ids. A row that REST says is NOT merged is
-        # excluded (authoritatively not landed); a two-parent commit means the ledger is wrong → abort.
+        # parent, and record the pre-merge parent and the Task ids. A row REST reports as unmerged is
+        # excluded; a two-parent commit means the ledger is wrong and aborts the run.
         ledger='[]'
         for i in $(seq 0 $((cand_count - 1))); do
           row=$(printf '%s' "$candidates" | jq -c ".[$i]")
@@ -408,20 +404,19 @@ runs:
         task_n=$(printf '%s' "$task_ids" | grep -c . || true)
         echo "### Board reset plan: ${task_n} rolled-back Task(s) → Status \"Ready\"" | tee -a "$GITHUB_STEP_SUMMARY"
 
-        # ---- BLAST-CAP (before ANY mutation, for both dry + real runs) --------------------------
-        # A rollback fans a DESTRUCTIVE revert across every repo in the ledger. Cap the distinct-repo
-        # target set: over the cap → ABORT LOUD rather than proceed, a guard against a runaway or
-        # mis-scoped rollback. The plan above is already in the summary, so the operator sees WHAT it
-        # would have touched; they raise max_rollback_repos deliberately if the width is genuine.
+        # ---- Blast cap, before any mutation, on both dry and live runs -------------------------
+        # A rollback fans a destructive revert across every repo in the ledger, so a distinct-repo
+        # count over the cap aborts. The plan above is already in the summary, so the operator sees
+        # what it would have touched and raises max_rollback_repos if the width is genuine.
         repo_n=$(printf '%s' "$repos" | grep -c . || true)
         if [ "$repo_n" -gt "$MAX_ROLLBACK_REPOS" ]; then
           echo "::error::BLAST-CAP: rollback of epic:#${EPIC} would touch ${repo_n} repos (> max_rollback_repos=${MAX_ROLLBACK_REPOS}) — aborting before any revert. A rollback this wide is almost certainly a mis-scoped Epic; investigate, or re-dispatch with a higher max_rollback_repos if it is genuinely intended." | tee -a "$GITHUB_STEP_SUMMARY"
           exit 1
         fi
 
-        # ---- Multi-base assert (before ANY mutation, for both dry + real runs) -----------------
-        # A repo's siblings must all target ONE base branch. Reverting an older-base sibling onto the
-        # newest base would revert a change that isn't on that base — abort loud rather than corrupt.
+        # ---- Multi-base assert, before any mutation, on both dry and live runs -----------------
+        # A repo's siblings all target one base branch. Reverting an older-base sibling onto the
+        # newest base would revert a change that is not on that base, so abort instead.
         multibase=$(printf '%s' "$ledger" | jq -r '
           group_by(.repo)[] | select((map(.base) | unique | length) > 1)
           | "\(.[0].repo): \((map(.base) | unique) | join(", "))"')
@@ -435,11 +430,11 @@ runs:
         fi
 
         # ---- Emit the ledger + the epic-scoped repo set for the gated, scoped write-token mint -----
-        # repos = the ledger's repo NAMES (the owner comes from the token's `owner:`) plus the planning
-        # repo, where the rollback-Epic issue + labels are written. create-github-app-token then scopes
-        # the write token to EXACTLY these repos, so a leaked token cannot reach a repo outside this
-        # rollback. The ledger is passed verbatim so the mutation reverts precisely what was scoped —
-        # one reconstruction, no time-of-check/time-of-use drift against a re-search.
+        # repos holds the ledger's repo names — the owner comes from the token's `owner:` — plus the
+        # planning repo, where the rollback-Epic issue and labels are written. create-github-app-token
+        # scopes the write token to exactly these, so a leaked token cannot reach a repo outside this
+        # rollback. The ledger is passed verbatim, so the mutation reverts what was scoped from one
+        # reconstruction and nothing drifts against a re-search.
         repos_csv=$(printf '%s' "$ledger" | jq -r --arg pr "$PLANNING_REPO" '([.[].repo | split("/")[1]] + [$pr]) | unique | join(",")')
         {
           echo "repos=${repos_csv}"
@@ -454,14 +449,14 @@ runs:
           echo "proceed=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        # Live run, every gate cleared → authorize the scoped write-token mint + the mutation step.
+        # A live run with every gate cleared authorizes the scoped write-token mint and the mutation.
         echo "proceed=true" >> "$GITHUB_OUTPUT"
 
-    # Write token — minted ONLY on a live, gate-cleared run (steps.plan.outputs.proceed) and SCOPED
-    # via repositories: to just the epic's repos + the planning repo, not org-wide. Branch push + revert
-    # commit (contents), open + label + auto-merge the revert PRs (pull-requests), and open the
-    # rollback-Epic issue + edit its body + apply epic:<M> (issues). It never APPROVES — the App authors
-    # these reverts and GitHub 422s a self-approval, so a human approves the wave.
+    # Write token, minted only on a live, gate-cleared run and scoped through `repositories:` to the
+    # Epic's repos plus the planning repo. contents covers the branch push and revert commit,
+    # pull-requests covers opening, labeling and arming the revert PRs, and issues covers the
+    # rollback-Epic issue, its body and the epic:<M> label. It never approves: the App authors these
+    # reverts and GitHub 422s a self-approval, so a human approves the wave.
     - name: Mint scoped write token
       id: write
       if: ${{ steps.plan.outputs.proceed == 'true' }}
@@ -475,10 +470,10 @@ runs:
         permission-pull-requests: write
         permission-issues: write
 
-    # Board token: org-Projects write only — bounds a leak of this token to board edits. Also minted
-    # only on a live, gate-cleared run. organization-projects:write is org-scoped (repositories: does
-    # not apply), so it cannot be epic-scoped; gating the mint is the only blast-radius lever, and it
-    # suffices — no board token exists on a dry run.
+    # Board token, scoped to org-Projects write, which bounds a leak to board edits. Minted only on a
+    # live, gate-cleared run: organization-projects:write is org-scoped, `repositories:` does not
+    # apply to it, so gating the mint is the only blast-radius lever and no board token exists on a
+    # dry run.
     - name: Mint board token
       id: board
       if: ${{ steps.plan.outputs.proceed == 'true' }}
@@ -489,16 +484,17 @@ runs:
         owner: ${{ inputs.org }}
         permission-organization-projects: write
 
-    # Generate the reverts, land the wave, reset the board — the MUTATIONS, gated on the live-run flag
-    # and running with the SCOPED write token. Rehydrates the reconstructed ledger from the plan step
-    # (the single source of truth the scoped token was minted for).
+    # Generate the reverts, land the wave and reset the board. Every mutation lives here, gated on the
+    # live-run flag and running with the scoped write token, on the ledger rehydrated from the plan
+    # step that the token was minted for.
     - name: Generate reverts, land + reset
       id: mutate
       if: ${{ steps.plan.outputs.proceed == 'true' }}
       shell: bash
       env:
-        # Default GH_TOKEN is the READ token (bare `gh` for any read); the write + board tokens are
-        # applied inline at the mutating call sites so a read can't hold a write scope.
+        # The default GH_TOKEN is the read token, which every bare-`gh` read picks up; the write and
+        # board tokens are applied inline at the mutating call sites, so a read never holds a write
+        # scope.
         GH_TOKEN: ${{ steps.read.outputs.token }}
         WRITE_TOKEN: ${{ steps.write.outputs.token }}
         BOARD_TOKEN: ${{ steps.board.outputs.token }}
@@ -513,12 +509,12 @@ runs:
       run: |
         set -euo pipefail
 
-        # Rehydrate the reconstructed ledger from the plan step — the single source of truth, and
-        # exactly the repos the scoped write token was minted for. Recompute the derived sets the
-        # mutation uses (repos = owner/name for the per-repo loop; task_n = the total Task count).
-        # INVARIANT (no-partial-rollback scope guarantee): the mutation MUST derive its repo set only
-        # from THIS ledger — never re-search the epic:<N> set here. The write token was scoped to
-        # exactly these repos (+ planning), so a repo from a fresh query would 403 mid-wave.
+        # Rehydrate the reconstructed ledger from the plan step: it names exactly the repos the scoped
+        # write token was minted for. The derived sets the mutation uses are recomputed from it —
+        # repos as owner/name for the per-repo loop, task_n as the total Task count.
+        # The mutation derives its repo set from this ledger alone and never re-searches the epic:<N>
+        # set, since the write token covers only these repos plus planning and a repo from a fresh
+        # query would 403 mid-wave.
         ledger="$LEDGER"
         repos=$(printf '%s' "$ledger" | jq -r '[.[].repo] | unique | .[]')
         task_n=$(printf '%s' "$ledger" | jq -r '[.[].tasks[]] | unique | length')
@@ -546,10 +542,11 @@ runs:
         produced='[]'
         had_failure=false
 
-        # Emit a cleanup summary of the revert PRs already opened under #M — printed on any mid-loop
-        # abort (clone / push / label failure) so we never exit silently leaving orphaned reverts. Every
-        # listed PR is already a labeled epic:${M} member with NO auto-merge armed and NO approval, so
-        # the merge-gate holds them — nothing lands. The human closes them (+ #M) or finishes by hand.
+        # Emit a cleanup summary of the revert PRs already opened under #M, printed on any mid-loop
+        # abort (clone, push or label failure) so the run never exits silently leaving orphaned
+        # reverts. Every listed PR is a labeled epic:${M} member with no auto-merge armed and no
+        # approval, so the merge-gate holds them and nothing lands. The human closes them and #M, or
+        # finishes the rollback by hand.
         orphan_summary() {
           local n
           n=$(printf '%s' "$produced" | jq 'length')
@@ -564,11 +561,10 @@ runs:
           echo "- Rollback-Epic: ${ORG}/${PLANNING_REPO}#${M}" | tee -a "$GITHUB_STEP_SUMMARY"
         }
 
-        # ---- PASS 1a: per repo — clone base, integrity-assert, revert newest-first, push, open PR,
-        # then apply epic:<M> INLINE (fatal). Applying the label as we go means a mid-loop abort still
-        # leaves every produced PR a labeled member the gate holds. The outer loop runs on fd 3 (like
-        # detect-partial-landing) so an inner git/gh call can't consume its stdin; the inner revert loop
-        # runs on fd 5.
+        # ---- PASS 1a: per repo — clone base, integrity-assert, revert newest-first, push, open the
+        # PR, then apply epic:<M> inline, fatally on failure. Labeling as it goes means a mid-loop
+        # abort still leaves every produced PR a labeled member the gate holds. The outer loop runs on
+        # fd 3 so an inner git or gh call cannot consume its stdin; the inner revert loop runs on fd 5.
         while IFS= read -r repo <&3; do
           [ -n "$repo" ] || continue
           owner="${repo%%/*}"
@@ -579,9 +575,9 @@ runs:
           orig_list=$(printf '%s' "$rows" | jq -r '[.[] | "\(.repo)#\(.number)"] | join(", ")')
 
           dir=$(mktemp -d)
-          # Bot checkout (the pull-bot pattern, inlined per-repo since a composite action can't loop
-          # actions/checkout): full history so the squash commit + its parent are reachable. The token
-          # lives only in this throwaway clone's remote URL on the ephemeral runner.
+          # Bot checkout, inlined per repo because a composite action cannot loop actions/checkout.
+          # Full history keeps the squash commit and its parent reachable, and the token lives only in
+          # this throwaway clone's remote URL on the ephemeral runner.
           if ! git clone --quiet --branch "$base" \
             "https://x-access-token:${WRITE_TOKEN}@github.com/${owner}/${name}.git" "$dir" 2>/dev/null; then
             echo "::error::could not clone ${repo}@${base}." | tee -a "$GITHUB_STEP_SUMMARY"
@@ -599,8 +595,8 @@ runs:
             [ -n "$pair" ] || continue
             r_sha=$(printf '%s' "$pair" | awk '{print $1}')
             r_pre=$(printf '%s' "$pair" | awk '{print $2}')
-            # Integrity: the squash commit's real parent must equal the ledger's pre-merge SHA, or the
-            # branch was rewritten / we identified the wrong landing — refuse to revert a wrong target.
+            # The squash commit's real parent has to equal the ledger's pre-merge SHA; otherwise the
+            # branch was rewritten or the wrong landing was identified, and the target is wrong.
             actual_parent=$(git -C "$dir" rev-parse "${r_sha}^" 2>/dev/null || echo "")
             if [ "$actual_parent" != "$r_pre" ]; then
               conflict=true
@@ -616,16 +612,16 @@ runs:
           done 5< <(printf '%s' "$rows" | jq -r '.[] | "\(.sha) \(.premerge)"')
 
           if [ "$conflict" = true ]; then
-            # Fail LOUD, never auto-resolve. Reset to a clean base tip and open an explicit DRAFT
-            # placeholder (an empty commit so GitHub accepts the PR) labeled epic:#M below — a
-            # not-ready member holds the ENTIRE wave, so no partial rollback is possible.
+            # Fail loudly, never auto-resolve. Reset to a clean base tip and open a draft placeholder
+            # on an empty commit, which GitHub needs to accept the PR, labeled epic:#M below: a
+            # not-ready member holds the entire wave, so no partial rollback is possible.
             echo "::error::${repo}: ${detail}" | tee -a "$GITHUB_STEP_SUMMARY"
             git -C "$dir" reset --hard "origin/${base}" >/dev/null 2>&1
             git -C "$dir" commit --allow-empty --quiet \
               -m "HELD rollback placeholder for epic:#${EPIC} (rollback #${M}) — DO NOT MERGE"
             if ! git -C "$dir" push --quiet -u origin "$branch" 2>/dev/null; then
-              # A branch ruleset may reject an empty commit (a required file-change / linear rule). Fall
-              # back to a one-file marker commit so the held draft still exists to hold the wave.
+              # A branch ruleset may reject an empty commit, so fall back to a one-file marker commit
+              # and the held draft still exists to hold the wave.
               echo "::warning::${repo}: held-placeholder empty commit rejected (ruleset?) — retrying with a ${MARKER} marker commit."
               git -C "$dir" reset --hard "origin/${base}" >/dev/null 2>&1
               printf 'HELD rollback placeholder for epic:#%s (rollback #%s) — DO NOT MERGE.\n\nThe automated revert for %s could not be produced:\n\n%s\n\nFinish by hand: reset to `%s`, `git revert --no-edit` %s newest-first, resolve conflicts, delete this file, push, mark the PR ready.\n' \
@@ -675,9 +671,9 @@ runs:
             --argjson draft "$draft" '$acc + [{repo:$repo, number:$num, draft:$draft}]')
           echo "${repo}: opened $([ "$draft" = true ] && echo 'DRAFT ' )revert PR #${pr_num} ($pr_url)." | tee -a "$GITHUB_STEP_SUMMARY"
 
-          # Apply epic:<M> INLINE, FATAL on failure — the epic:<M> membership is the load-bearing
-          # no-partial-rollback guarantee. epic:<N> labels are ad-hoc (not in the managed set), so create
-          # epic:<M> in the repo first (idempotent — ignore "already exists").
+          # Apply epic:<M> inline, fatally on failure: that membership is what guarantees no partial
+          # rollback. epic:<N> labels are ad-hoc rather than part of the managed set, so create
+          # epic:<M> in the repo first, ignoring an "already exists".
           GH_TOKEN="$WRITE_TOKEN" gh label create "epic:${M}" --repo "$repo" --color BFD4F2 \
             --description "Rollback epic #${M} (reverts epic:#${EPIC})" >/dev/null 2>&1 || true
           if ! GH_TOKEN="$WRITE_TOKEN" gh pr edit "$pr_num" --repo "$repo" --add-label "epic:${M}" >/dev/null 2>&1; then
@@ -687,10 +683,10 @@ runs:
           fi
         done 3< <(printf '%s\n' "$repos")
 
-        # ---- PASS 1b: HARD-VERIFY epic:<M> actually stuck on EVERY produced PR (re-read labels) ----
-        # `gh pr edit` returning 0 does not prove the label persisted (eventual consistency, or it was
-        # stripped). Re-read each PR's labels; a missing epic:<M> is FATAL — an unlabeled member escapes
-        # the wave and could land alone, exactly the partial rollback this design forbids.
+        # ---- PASS 1b: verify epic:<M> stuck on every produced PR by re-reading its labels ---------
+        # `gh pr edit` returning 0 does not prove the label persisted; it may lag or have been
+        # stripped. A missing epic:<M> is fatal, because an unlabeled member escapes the wave and
+        # could land alone.
         prod_count=$(printf '%s' "$produced" | jq 'length')
         for i in $(seq 0 $((prod_count - 1))); do
           repo=$(printf '%s' "$produced" | jq -r ".[$i].repo")
@@ -704,10 +700,10 @@ runs:
         done
         echo "All ${prod_count} revert PR(s) verified as epic:${M} members." | tee -a "$GITHUB_STEP_SUMMARY"
 
-        # ---- Surface the wave for a HUMAN to review + approve ----------------------------------
-        # The App AUTHORS these reverts and GitHub 422s approving your own PR, so it never self-approves.
-        # The merge-gate's APPROVED requirement PARKS the wave until a human approves. Publish the revert
-        # PR list into both the Epic body and the step summary so the human has one place to act on.
+        # ---- Surface the wave for a human to review and approve ---------------------------------
+        # The App authors these reverts and GitHub 422s approving your own PR, so it never
+        # self-approves, and the merge-gate's approval requirement parks the wave until a human acts.
+        # The revert PR list goes into both the Epic body and the step summary.
         pr_list=$(printf '%s' "$produced" | jq -r '.[] | "- \(.repo)#\(.number)\(if .draft then " — HELD draft (finish by hand first)" else "" end)"')
         approve_body=$(printf '%s\n\n---\n\n### Revert PRs awaiting human approval\nThe [Agent] App authored these reverts and GitHub forbids approving your own PR, so the merge-gate holds the whole wave until a human approves them. **Review and APPROVE each PR below** (and finish any HELD draft); once all are approved the gate greens and they land together in reverse.\n\n%s' \
           "$epic_body" "$pr_list")
@@ -721,10 +717,10 @@ runs:
           echo "- Rollback-Epic: ${ORG}/${PLANNING_REPO}#${M}"
         } | tee -a "$GITHUB_STEP_SUMMARY"
 
-        # ---- PASS 2: only NOW (full set labeled + verified) arm native auto-merge on each ready revert.
-        # Arming here — never earlier — closes the race where an early member is auto-merge-armed before
-        # the set is complete. Auto-merge PARKS: the APPROVED requirement is unmet until a human approves,
-        # so nothing lands yet. A HELD draft is left unarmed (it is the member that holds the wave).
+        # ---- PASS 2: with the full set labeled and verified, arm native auto-merge on each ready
+        # revert. Arming only here closes the race where an early member is armed before the set is
+        # complete. Auto-merge parks, since the approval requirement is unmet until a human approves,
+        # so nothing lands yet. A held draft is left unarmed, being the member that holds the wave.
         for i in $(seq 0 $((prod_count - 1))); do
           repo=$(printf '%s' "$produced" | jq -r ".[$i].repo")
           pr_num=$(printf '%s' "$produced" | jq -r ".[$i].number")
@@ -743,22 +739,22 @@ runs:
           if [ "$arm_ok" = true ]; then
             echo "${repo}#${pr_num}: auto-merge armed — PARKED pending human approval." | tee -a "$GITHUB_STEP_SUMMARY"
           else
-            # An un-armed revert whose siblings ARE armed half-lands the rollback the moment the human
-            # approves (approved siblings auto-merge, this one does not). Fail the whole run loud so the
-            # operator arms it by hand BEFORE approving — atomicity over convenience.
+            # An un-armed revert whose siblings are armed half-lands the rollback the moment the human
+            # approves, since the armed siblings auto-merge and this one does not. Fail the whole run
+            # so the operator arms it by hand before approving.
             had_failure=true
             echo "::error::could not arm auto-merge on ${repo}#${pr_num} after retries — enable it by hand before approving the wave." | tee -a "$GITHUB_STEP_SUMMARY"
           fi
         done
 
-        # ---- Board reset: walk each FORWARD PR's Tasks → Status "Ready" -------------------------
-        # A revert is a forward commit: the originals stay MERGED, so nothing walks the Tasks back on
-        # its own. Reset each rolled-back Task to "Ready" (the same column derive-status uses for an
-        # abandoned attempt). Mirrors board-write inline (a composite action can't loop it): resolve
-        # the field + option once, then add-if-missing + compare-before-write per Task.
+        # ---- Board reset: walk each forward PR's Tasks to Status "Ready" -------------------------
+        # A revert is a forward commit and the originals stay MERGED, so nothing walks the Tasks back
+        # on its own. Each rolled-back Task is reset to "Ready", the column derive-status uses for an
+        # abandoned attempt. board-write is mirrored inline, since a composite action cannot loop it:
+        # resolve the field and option once, then add-if-missing and compare-before-write per Task.
         #
-        # Scope (fix): SKIP any Task whose repo revert was HELD as a draft — it did not land, so marking
-        # it "Ready" would lie. A Task touched by ANY held repo is excluded until that draft finishes.
+        # A Task whose repo revert was held as a draft is skipped: that revert did not land, so
+        # marking it "Ready" would lie. Any Task touched by a held repo waits for that draft.
         held_repos=$(printf '%s' "$produced" | jq -c '[.[] | select(.draft==true) | .repo]')
         reset_task_ids=$(printf '%s' "$ledger" | jq -r --argjson held "$held_repos" '
           ( [ .[] | select(.repo as $r | $held | index($r)) | .tasks[] ] | unique ) as $blocked
@@ -806,8 +802,8 @@ runs:
             echo "board: Task ${content} already \"Ready\" — no-op." | tee -a "$GITHUB_STEP_SUMMARY"
             return 0
           fi
-          # INLINE the single-select option id into the mutation string (mirror board-write): passing it
-          # via -F would let gh coerce an all-digit option id to an integer and the mutation would reject
+          # Inline the single-select option id into the mutation string, as board-write does: passed
+          # via -F, gh would coerce an all-digit option id to an integer and the mutation would reject
           # it. board_ready_opt came from GitHub's own options list, so it is safe to interpolate.
           wm="mutation(\$proj:ID!,\$item:ID!,\$field:ID!){ updateProjectV2ItemFieldValue(input:{projectId:\$proj,itemId:\$item,fieldId:\$field,value:{singleSelectOptionId:\"${board_ready_opt}\"}}){ projectV2Item{ id } } }"
           GH_TOKEN="$BOARD_TOKEN" gh api graphql -f query="$wm" -F proj="$PROJECT_ID" -F item="$item_id" -F field="$board_status_field" >/dev/null || return 1

--- a/generic-actions/epic-rollback/action.yaml
+++ b/generic-actions/epic-rollback/action.yaml
@@ -198,7 +198,7 @@ runs:
           echo "::error::epic_number must be an integer, got \"${EPIC:-}\""
           exit 1
         fi
-        # org feeds `org:<ORG>`, so require GitHub-login characters: a stray value would broaden scope.
+        # org feeds `org:<ORG>`, so require GitHub-login characters: a stray value broadens the scope.
         if ! [[ "${ORG:-}" =~ ^[A-Za-z0-9-]+$ ]]; then
           echo "::error::org must be a valid GitHub login (alphanumeric + hyphens), got \"${ORG:-}\""
           exit 1
@@ -407,7 +407,7 @@ runs:
         # ---- Blast cap, before any mutation, on both dry and live runs -------------------------
         # A rollback fans a destructive revert across every repo in the ledger, so a distinct-repo
         # count over the cap aborts. The plan above is already in the summary, so the operator sees
-        # what it would have touched and raises max_rollback_repos if the width is genuine.
+        # the planned targets and raises max_rollback_repos if the width is genuine.
         repo_n=$(printf '%s' "$repos" | grep -c . || true)
         if [ "$repo_n" -gt "$MAX_ROLLBACK_REPOS" ]; then
           echo "::error::BLAST-CAP: rollback of epic:#${EPIC} would touch ${repo_n} repos (> max_rollback_repos=${MAX_ROLLBACK_REPOS}) — aborting before any revert. A rollback this wide is almost certainly a mis-scoped Epic; investigate, or re-dispatch with a higher max_rollback_repos if it is genuinely intended." | tee -a "$GITHUB_STEP_SUMMARY"
@@ -416,7 +416,7 @@ runs:
 
         # ---- Multi-base assert, before any mutation, on both dry and live runs -----------------
         # A repo's siblings all target one base branch. Reverting an older-base sibling onto the
-        # newest base would revert a change that is not on that base, so abort instead.
+        # newest base reverts a change that is not on that base, so a multi-base ledger aborts.
         multibase=$(printf '%s' "$ledger" | jq -r '
           group_by(.repo)[] | select((map(.base) | unique | length) > 1)
           | "\(.[0].repo): \((map(.base) | unique) | join(", "))"')
@@ -513,8 +513,8 @@ runs:
         # write token was minted for. The derived sets the mutation uses are recomputed from it —
         # repos as owner/name for the per-repo loop, task_n as the total Task count.
         # The mutation derives its repo set from this ledger alone and never re-searches the epic:<N>
-        # set, since the write token covers only these repos plus planning and a repo from a fresh
-        # query would 403 mid-wave.
+        # set: the write token covers only these repos plus planning, and a repo from a fresh query
+        # 403s mid-wave.
         ledger="$LEDGER"
         repos=$(printf '%s' "$ledger" | jq -r '[.[].repo] | unique | .[]')
         task_n=$(printf '%s' "$ledger" | jq -r '[.[].tasks[]] | unique | length')
@@ -672,8 +672,8 @@ runs:
           echo "${repo}: opened $([ "$draft" = true ] && echo 'DRAFT ' )revert PR #${pr_num} ($pr_url)." | tee -a "$GITHUB_STEP_SUMMARY"
 
           # Apply epic:<M> inline, fatally on failure: that membership is what guarantees no partial
-          # rollback. epic:<N> labels are ad-hoc rather than part of the managed set, so create
-          # epic:<M> in the repo first, ignoring an "already exists".
+          # rollback. epic:<N> labels are ad-hoc, outside the managed set, so create epic:<M> in the
+          # repo first, ignoring an "already exists".
           GH_TOKEN="$WRITE_TOKEN" gh label create "epic:${M}" --repo "$repo" --color BFD4F2 \
             --description "Rollback epic #${M} (reverts epic:#${EPIC})" >/dev/null 2>&1 || true
           if ! GH_TOKEN="$WRITE_TOKEN" gh pr edit "$pr_num" --repo "$repo" --add-label "epic:${M}" >/dev/null 2>&1; then
@@ -753,8 +753,8 @@ runs:
         # abandoned attempt. board-write is mirrored inline, since a composite action cannot loop it:
         # resolve the field and option once, then add-if-missing and compare-before-write per Task.
         #
-        # A Task whose repo revert was held as a draft is skipped: that revert did not land, so
-        # marking it "Ready" would lie. Any Task touched by a held repo waits for that draft.
+        # A Task whose repo revert was held as a draft is skipped: that revert did not land, so the
+        # Task keeps its current Status. Any Task touched by a held repo waits for that draft.
         held_repos=$(printf '%s' "$produced" | jq -c '[.[] | select(.draft==true) | .repo]')
         reset_task_ids=$(printf '%s' "$ledger" | jq -r --argjson held "$held_repos" '
           ( [ .[] | select(.repo as $r | $held | index($r)) | .tasks[] ] | unique ) as $blocked
@@ -802,9 +802,9 @@ runs:
             echo "board: Task ${content} already \"Ready\" — no-op." | tee -a "$GITHUB_STEP_SUMMARY"
             return 0
           fi
-          # Inline the single-select option id into the mutation string, as board-write does: passed
-          # via -F, gh would coerce an all-digit option id to an integer and the mutation would reject
-          # it. board_ready_opt came from GitHub's own options list, so it is safe to interpolate.
+          # Inline the single-select option id into the mutation string, as board-write does: gh
+          # coerces an all-digit option id passed via -F to an integer, which the mutation rejects.
+          # board_ready_opt came from GitHub's own options list, so it is safe to interpolate.
           wm="mutation(\$proj:ID!,\$item:ID!,\$field:ID!){ updateProjectV2ItemFieldValue(input:{projectId:\$proj,itemId:\$item,fieldId:\$field,value:{singleSelectOptionId:\"${board_ready_opt}\"}}){ projectV2Item{ id } } }"
           GH_TOKEN="$BOARD_TOKEN" gh api graphql -f query="$wm" -F proj="$PROJECT_ID" -F item="$item_id" -F field="$board_status_field" >/dev/null || return 1
           echo "board: Task ${content} \"${cur:-<unset>}\" → \"Ready\"." | tee -a "$GITHUB_STEP_SUMMARY"

--- a/generic-actions/escalate/action.yaml
+++ b/generic-actions/escalate/action.yaml
@@ -324,7 +324,7 @@ runs:
         pred='.[] | select(((.body // "") | split("\n")[0] | rtrimstr("\r")) == $m)'
 
         # Strongly consistent dedup, failing closed on a list error: an API hiccup swallowed as an
-        # empty list would spawn a duplicate ticket or falsely report nothing to resolve. `open`
+        # empty list spawns a duplicate ticket, or falsely reports nothing to resolve. `open`
         # lists open tickets only, since a closed one means resolved; `resolve` lists all, so a
         # ticket whose board drive failed after close is re-driven.
         list_state=open
@@ -483,13 +483,13 @@ runs:
         fi
 
         # POST with a small retry and explicit timeouts: composite steps cannot set timeout-minutes,
-        # so a black-hole webhook would hang the page. Discord answers 204 on success, 429 when rate
+        # so a black-hole webhook hangs the page. Discord answers 204 on success, 429 when rate
         # limited, 5xx transiently; curl runs without --fail so those codes are captured and retried.
         max=3
         code=000
         for attempt in $(seq 1 "$max"); do
           # The fallback sits outside the substitution: curl already prints "000" via -w on failure,
-          # so `|| echo 000` inside would append and yield "000000".
+          # so `|| echo 000` inside appends to it and yields "000000".
           code=$(curl -sS --connect-timeout 5 --max-time 15 \
             -o "$RUNNER_TEMP/esc_push_resp" -w '%{http_code}' \
             -X POST -H 'Content-Type: application/json' --data "$payload" "$PUSH_WEBHOOK") || code=000

--- a/generic-actions/escalate/action.yaml
+++ b/generic-actions/escalate/action.yaml
@@ -153,10 +153,9 @@ outputs:
 runs:
   using: composite
   steps:
-    # Validate + normalize everything up front, before any token is minted, so a bad severity or a
-    # malformed dedup_key fails loudly with nothing half-done. Also decides routing (do_push /
-    # do_mention), the target board Status, and cleans free-text (summary/mention) that lands in a
-    # log line — so later steps stay dumb and injection-safe.
+    # Validate and normalize up front, before any token is minted, so a bad severity or a malformed
+    # dedup_key fails with nothing half-done. Also decides routing (do_push / do_mention), the target
+    # board Status, and cleans the free text that reaches a log line.
     - name: Resolve inputs and routing
       id: resolve
       shell: bash
@@ -189,8 +188,8 @@ runs:
         st=$(printf '%s' "${STATE:-open}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
         case "$st" in open | resolve) : ;; *) echo "::error::state must be open|resolve (got \"${STATE:-}\")"; exit 1 ;; esac
 
-        # dry_run is normalized here (severity/state are), so a "True"/" true " can't silently
-        # perform real mutations. Everything downstream reads this normalized value.
+        # Normalize dry_run here so a "True" or " true " cannot perform real mutations. Everything
+        # downstream reads this normalized value.
         dry=$(printf '%s' "${DRY_RUN:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
         case "$dry" in true | 1 | yes) dry=true ;; *) dry=false ;; esac
 
@@ -213,9 +212,9 @@ runs:
           echo "::error::planning_repo must be owner/name (got \"$PLANNING_REPO\")"; exit 1
         fi
 
-        # Collapse newlines in the free-text that reaches a title / a log line, so it can't inject a
-        # ::workflow-command:: or break the single-line title. Body keeps its newlines (it's Markdown
-        # detail, written only to a --body-file, never echoed to stdout).
+        # Collapse newlines in the free text that reaches a title or a log line, so it cannot inject
+        # a ::workflow-command:: or break the single-line title. The body keeps its newlines: it is
+        # Markdown detail, written only to a --body-file.
         clean_summary=$(printf '%s' "$SUMMARY" | tr -d '\r' | tr '\n' ' ')
         clean_mention=$(printf '%s' "${MENTION:-}" | tr -d '\r' | tr '\n' ' ')
 
@@ -223,8 +222,8 @@ runs:
         run_url="${RUN_URL:-}"
         [ -z "$run_url" ] && run_url="${SERVER_URL}/${REPO_FULL}/actions/runs/${RUN_ID}"
 
-        # Routing. Push only for a genuine SEV1 page that is being RAISED and only when a webhook is
-        # wired (empty webhook = channel off). @mention for SEV1/SEV2 raises; SEV3 stays silent.
+        # Routing. Push only for a SEV1 being raised, and only when a webhook is wired (an empty
+        # webhook turns the channel off). @mention for SEV1/SEV2 raises; SEV3 stays silent.
         do_push=false
         if [ "$sev" = "sev1" ] && [ "$st" = "open" ] && [ -n "${PUSH_WEBHOOK:-}" ]; then do_push=true; fi
         do_mention=false
@@ -247,8 +246,7 @@ runs:
           echo "clean_mention=$clean_mention"
         } >> "$GITHUB_OUTPUT"
 
-    # A token that can only touch issues (create/edit/close/comment/label) in the planning repo.
-    # The [Agent] App can do more; requesting only issues:write on the one repo bounds a leak.
+    # A token scoped to issues:write on the planning repo alone, which bounds a leak.
     - name: Mint issues token
       id: token
       uses: actions/create-github-app-token@v3
@@ -259,8 +257,8 @@ runs:
         repositories: ${{ steps.resolve.outputs.planning_name }}
         permission-issues: write
 
-    # The ticket channel: find the open escalation carrying this dedup marker (a strongly consistent
-    # list read, never the eventually-consistent search index), then create / update / close it. The
+    # The ticket channel: find the escalation carrying this dedup marker with a strongly consistent
+    # list read (the search index is eventually consistent), then create, update or close it. The
     # body is bot-owned and regenerated each occurrence.
     - name: File or update the ticket
       id: ticket
@@ -298,9 +296,9 @@ runs:
           esac
         fi
 
-        # Regenerate the whole (bot-owned) body. The marker is ALWAYS the first line — dedup matches
-        # it anchored there (not "contains" anywhere), so a marker pasted into prose can't false-match.
-        # first/count live in hidden markers so the next occurrence reads them back.
+        # Regenerate the whole bot-owned body. The marker is the first line and dedup matches it
+        # anchored there, so a marker pasted into prose cannot false-match. first/count live in
+        # hidden markers so the next occurrence reads them back.
         render_body() { # $1 = first-seen ISO, $2 = occurrence count
           local first="$1" count="$2"
           {
@@ -321,15 +319,14 @@ runs:
           } > "$RUNNER_TEMP/esc_body.md"
         }
 
-        # jq predicate: the marker must be the EXACT first body line (CRLF-tolerant — GitHub stores
-        # bodies with CRLF). Reused by both the open (first match) and resolve (all matches) paths.
+        # jq predicate: the marker is the exact first body line, tolerating the CRLF GitHub stores
+        # bodies with. Shared by the open (first match) and resolve (all matches) paths.
         pred='.[] | select(((.body // "") | split("\n")[0] | rtrimstr("\r")) == $m)'
 
-        # Strongly consistent dedup. FAIL CLOSED on a list error (do NOT default to []): swallowing
-        # an API hiccup — likeliest during the very incident being escalated — would either spawn a
-        # duplicate ticket (open) or falsely report nothing to resolve (leaving a zombie).
-        # open looks only at OPEN tickets (a closed one means resolved → open a fresh ticket); resolve
-        # looks at ALL (so a ticket whose board drive failed after close still gets re-driven).
+        # Strongly consistent dedup, failing closed on a list error: an API hiccup swallowed as an
+        # empty list would spawn a duplicate ticket or falsely report nothing to resolve. `open`
+        # lists open tickets only, since a closed one means resolved; `resolve` lists all, so a
+        # ticket whose board drive failed after close is re-driven.
         list_state=open
         [ "$STATE" = "resolve" ] && list_state=all
         if ! existing_json=$(gh issue list --repo "$PLANNING_REPO" --label "$ESC_LABEL" \
@@ -345,8 +342,8 @@ runs:
           } >> "$GITHUB_OUTPUT"
         }
 
-        # ---- resolve: close ALL tickets carrying the key (self-heals a create race); drive the
-        #      first (most recent) terminal via the board step ----
+        # ---- resolve: close all tickets carrying the key (self-heals a create race); the board
+        #      step drives the first (most recent) to a terminal Status ----
         if [ "$STATE" = "resolve" ]; then
           matches=$(printf '%s' "$existing_json" | jq -c --arg m "$marker" "$pred")
           if [ -z "$matches" ]; then
@@ -390,8 +387,7 @@ runs:
             echo "[dry-run] would FILE \"$title\" in $PLANNING_REPO (label $ESC_LABEL) and drive board Status → \"$TARGET_STATUS\"." | tee -a "$GITHUB_STEP_SUMMARY"
             emit created false "" "" ""; exit 0
           fi
-          # Ensure the umbrella label exists (idempotent) so `--label` on create can't fail on a
-          # fresh repo; repocfg may also declare it for board-view consistency.
+          # Ensure the umbrella label exists so `--label` on create cannot fail on a fresh repo.
           gh label create "$ESC_LABEL" --repo "$PLANNING_REPO" --force \
             --color B60205 --description "Automated governance escalation (escalate action)." >/dev/null 2>&1 || true
           url=$(gh issue create --repo "$PLANNING_REPO" --title "$title" \
@@ -406,8 +402,8 @@ runs:
         num=$(printf '%s' "$match" | jq -r '.number')
         url=$(printf '%s' "$match" | jq -r '.url')
         ebody=$(printf '%s' "$match" | jq -r '.body // ""')
-        # Guard both parses with a fallback (|| ...): under set -e a grep-no-match returns non-zero
-        # and would abort the step, killing the intended default below.
+        # Guard both parses with a fallback: under set -e a grep that matches nothing returns
+        # non-zero and aborts the step before the default below applies.
         first=$(printf '%s' "$ebody" | grep -oE 'escalate:first=[^ ]+' | head -1 | sed 's/.*escalate:first=//') || first=""
         [ -n "$first" ] || first="$now"
         count=$(printf '%s' "$ebody" | grep -oE 'escalate:count=[0-9]+' | head -1 | grep -oE '[0-9]+' || echo 0)
@@ -425,8 +421,8 @@ runs:
         fi
 
         gh issue edit "$num" --repo "$PLANNING_REPO" --body-file "$RUNNER_TEMP/esc_body.md" >/dev/null
-        # Editing the body does NOT notify anyone — so re-notify SEV1/SEV2 with a comment. SEV3 stays
-        # silent (body edit only), which is the whole point of the silent tier.
+        # Editing the body notifies nobody, so SEV1/SEV2 re-notify with a comment. SEV3 stays a
+        # body edit alone.
         if [ "$DO_MENTION" = "true" ]; then
           ping=""
           [ -n "${MENTION:-}" ] && ping=" cc ${MENTION}"
@@ -437,12 +433,10 @@ runs:
         echo "Updated escalation #$num (occurrence $count)." | tee -a "$GITHUB_STEP_SUMMARY"
         emit updated true "$num" "$node" "$url"
 
-    # The push channel FIRST (before the board write): one loud SEV1 page is the most critical
-    # output. `always()` so a failed ticket/token step can't swallow the page — do_push is already
-    # false unless resolve succeeded and set it, so always() can't over-fire. A composite step also
-    # cannot continue-on-error, so running the board write earlier could suppress the page; it runs
-    # last instead. A failed page after the ticket is filed exits non-zero on purpose — a page that
-    # silently didn't deliver is exactly the failure mode this whole action guards against.
+    # The push channel runs before the board write: the SEV1 page is the most critical output, and a
+    # composite step cannot continue-on-error, so a board write ahead of it could suppress the page.
+    # `always()` keeps a failed ticket or token step from swallowing it; do_push is false unless
+    # resolve set it. A page that fails after the ticket is filed exits non-zero.
     - name: SEV1 push
       id: push
       if: ${{ always() && steps.resolve.outputs.do_push == 'true' }}
@@ -460,7 +454,7 @@ runs:
       run: |
         set -euo pipefail
 
-        # Build the message. Discord's `content` caps at 2000 CHARACTERS.
+        # Build the message. Discord's `content` caps at 2000 characters.
         content="🚨 **[SEV1] ${SUMMARY}**"
         content="${content}"$'\n'"repo: ${REPO}"
         [ -n "${EPIC:-}" ] && content="${content} · epic: ${EPIC}"
@@ -468,14 +462,15 @@ runs:
         [ -n "${RUNBOOK:-}" ] && content="${content}"$'\n'"runbook: ${RUNBOOK}"
         [ -n "${ISSUE_URL:-}" ] && content="${content}"$'\n'"ticket: ${ISSUE_URL}"
         [ -n "${MENTION:-}" ] && content="${content}"$'\n'"cc ${MENTION}"
-        # Cap the WHOLE message (head -c is total, not per-line) well under the limit, then iconv -c
-        # drops any multibyte char the byte-cut split in half (invalid UTF-8 → Discord would 400).
+        # Cap the whole message well under the limit (head -c counts bytes over the whole stream),
+        # then `iconv -c` drops any multibyte character the cut split in half — Discord 400s on
+        # invalid UTF-8.
         content=$(printf '%s' "$content" | head -c 1900)
         content=$(printf '%s' "$content" | iconv -f UTF-8 -t UTF-8 -c 2>/dev/null) || true
 
-        # jq builds the JSON so the message can hold any character without escaping bugs. allowed_mentions
-        # restricts pings to users/roles — an accidental @everyone/@here in `mention` can't mass-ping.
-        # The payload shape is Discord's — swapping channels (Slack/ntfy) is a localized edit here.
+        # jq builds the JSON so the message can hold any character. allowed_mentions restricts pings
+        # to users and roles, so an @everyone or @here in `mention` cannot mass-ping. The payload
+        # shape is Discord's, and swapping chat providers is a local edit here.
         payload=$(jq -n --arg c "$content" '{content: $c, allowed_mentions: {parse: ["users", "roles"]}}')
 
         if [ "$DRY_RUN" = "true" ]; then
@@ -487,14 +482,14 @@ runs:
           exit 0
         fi
 
-        # POST with a small retry + timeouts (a black-hole webhook must not hang the emergency page —
-        # composite steps can't set timeout-minutes). Discord returns 204 on success, 429 rate-limit,
-        # 5xx transient. curl doesn't --fail, so those codes are captured (not thrown) and retried.
+        # POST with a small retry and explicit timeouts: composite steps cannot set timeout-minutes,
+        # so a black-hole webhook would hang the page. Discord answers 204 on success, 429 when rate
+        # limited, 5xx transiently; curl runs without --fail so those codes are captured and retried.
         max=3
         code=000
         for attempt in $(seq 1 "$max"); do
-          # Fallback OUTSIDE the substitution so a failed connection overwrites the code (curl already
-          # prints "000" via -w on failure; `|| echo 000` inside would append → "000000").
+          # The fallback sits outside the substitution: curl already prints "000" via -w on failure,
+          # so `|| echo 000` inside would append and yield "000000".
           code=$(curl -sS --connect-timeout 5 --max-time 15 \
             -o "$RUNNER_TEMP/esc_push_resp" -w '%{http_code}' \
             -X POST -H 'Content-Type: application/json' --data "$payload" "$PUSH_WEBHOOK") || code=000
@@ -511,14 +506,12 @@ runs:
         echo "pushed=false" >> "$GITHUB_OUTPUT"
         exit 1
 
-    # Drive the ticket's board Status LAST, through the single privileged board writer (reused, not
-    # re-implemented — keeps the board single-writer). `always()` so it still runs when a SEV1 page
-    # failed above: a filed ticket must never be left without a Status. Runs whenever a ticket exists
-    # (all severities get a board card). NO kill_switch is threaded ON PURPOSE: escalation is the
-    # emergency path, exempt from the org-wide HALT — the STOP must not mute the channel that reports
-    # the automation is stuck. board-write defaults kill_switch to "" = running. The board-write pin
-    # is a REMOTE ref (not ./): a `./` path in a composite action resolves against the CONSUMER's
-    # checkout, not this repo. `publish stamp` re-stamps this version at release, so the two co-version.
+    # Drive the ticket's board Status last, through the single privileged board writer that keeps the
+    # board single-writer. `always()` so a filed ticket is never left without a Status when the SEV1
+    # page above failed; every severity gets a board card. No kill_switch is threaded: escalation is
+    # the emergency path, exempt from the org-wide halt, and board-write defaults kill_switch to ""
+    # (running). The pin is a remote ref because a `./` path in a composite action resolves against
+    # the consumer's checkout; `publish stamp` re-stamps it at release so the two co-version.
     - name: Drive the ticket's board Status
       id: board
       if: ${{ always() && steps.ticket.outputs.issue_node_id != '' }}

--- a/generic-actions/hotfix-reconcile/action.yaml
+++ b/generic-actions/hotfix-reconcile/action.yaml
@@ -73,9 +73,9 @@ outputs:
 runs:
   using: composite
   steps:
-    # Scoped to THIS repo: push the reconcile branch (contents) and open the PR (pull-requests).
-    # No kill-switch guard — the hotfix path (this included) is exempt (the emergency STOP must not
-    # disable the emergency PATH).
+    # Scoped to this repo: push the reconcile branch (contents) and open the PR (pull-requests).
+    # No kill-switch guard: the hotfix path is exempt, since the emergency stop must not disable
+    # the emergency path.
     - name: Mint reconcile token
       id: token
       uses: actions/create-github-app-token@v3
@@ -103,8 +103,8 @@ runs:
       run: |
         set -euo pipefail
 
-        # cleanup_task feeds `Closes #<n>` — must be a bare integer (a stray value could break the
-        # closing keyword or the PR body).
+        # cleanup_task feeds `Closes #<n>`, so a bare integer: a stray value would break the closing
+        # keyword or the PR body.
         if ! printf '%s' "$CLEANUP_TASK" | grep -qE '^[0-9]+$'; then
           echo "::error::cleanup_task must be an integer, got \"$CLEANUP_TASK\"."
           exit 1
@@ -118,24 +118,23 @@ runs:
           } >> "$GITHUB_OUTPUT"
         }
 
-        # Clone the default branch (full history so baseline + fix commits are reachable), token in
-        # the throwaway clone's remote URL only (the epic-rollback / pull-bot pattern).
+        # Clone the default branch with full history, so the baseline and fix commits are reachable.
+        # The token lives only in this throwaway clone's remote URL.
         dir=$(mktemp -d)
         git clone --quiet --branch "$default_branch" \
           "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$dir"
         git -C "$dir" config user.name "${APP_SLUG}[bot]"
         git -C "$dir" config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
-        # Bring in the fix commits + the baseline tag so the range resolves.
+        # Bring in the fix commits and the baseline tag so the range resolves.
         git -C "$dir" fetch --quiet origin "$SOURCE_REF"
         git -C "$dir" fetch --quiet origin "refs/tags/${BASELINE}:refs/tags/${BASELINE}" 2>/dev/null || true
 
-        # Short-circuit: is the fix already on the default branch? `git cherry` marks each commit in
-        # baseline..fix_head '+' (not upstream) or '-' (already upstream, by patch-id). Zero '+' → the
-        # fix is already reconciled (e.g. a re-run after the PR merged, or the fix also went to master
-        # directly) → close the loop without a redundant PR.
-        # Capture git-cherry's output and check its EXIT explicitly — piping straight into grep would
-        # swallow a real error (unresolvable baseline/fix_head) as "0 pending" and skip the reconcile
-        # on a genuine failure (fails open on the emergency path).
+        # Is the fix already on the default branch? `git cherry` marks each commit in
+        # baseline..fix_head '+' when it is not upstream and '-' when it is, matching by patch-id.
+        # No '+' means the fix is already reconciled — a re-run after the PR merged, or a fix that
+        # also went to master directly — so close the loop without a redundant PR.
+        # git-cherry's output is captured and its exit checked explicitly: piped straight into grep,
+        # an unresolvable baseline or fix_head would read as "0 pending" and skip the reconcile.
         if ! cherry_out=$(git -C "$dir" cherry "origin/${default_branch}" "$FIX_HEAD" "$BASELINE" 2>&1); then
           echo "::error::git cherry failed (baseline/fix_head unresolvable?): ${cherry_out}"
           rm -rf "$dir"
@@ -152,22 +151,22 @@ runs:
         branch="hotfix-reconcile/v${LINE}-${CLEANUP_TASK}"
         git -C "$dir" switch -c "$branch" "origin/${default_branch}" >/dev/null 2>&1
 
-        # The full range, for the draft-PR body when we degrade (so the human knows EVERY commit to
-        # finish, not just the one that stopped it). Computed before the cherry-pick mutates the tree.
+        # The full range for the draft-PR body on the degraded path, so the human sees every commit
+        # still to finish. Computed before the cherry-pick mutates the tree.
         range_commits=$(git -C "$dir" log --oneline --reverse "${BASELINE}..${FIX_HEAD}" 2>/dev/null | sed 's/^/- /')
 
-        # Cherry-pick the fix range (fix diff only — the bump is excluded by construction, it is past
-        # fix_head). -x records "(cherry picked from …)" — one of the reached-master signals. On a
-        # conflict, DON'T abort: stage whatever's there and commit it so a human resolves in the PR.
+        # Cherry-pick the fix range. It carries the fix diff alone, since the version bump sits past
+        # fix_head. -x records "(cherry picked from …)", one of the reached-master signals. A conflict
+        # does not abort: stage what is there and commit it, so a human resolves it in the PR.
         conflicted=false
         if git -C "$dir" cherry-pick -x "${BASELINE}..${FIX_HEAD}" >/dev/null 2>&1; then
           conflicted=false
         else
           conflicted=true
           conflict_paths=$(git -C "$dir" diff --name-only --diff-filter=U | tr '\n' ' ')
-          # Commit whatever the cherry-pick left — conflict markers (unmerged paths) OR nothing (an
-          # already-applied intermediate commit stops it "empty"). --allow-empty so the empty case
-          # can't hard-fail under set -e. Then abandon the remaining range; the draft PR lists it all.
+          # Commit whatever the cherry-pick left: conflict markers on unmerged paths, or nothing when
+          # an already-applied intermediate commit stopped it empty. --allow-empty keeps the empty
+          # case from failing under set -e. The remaining range is abandoned and listed in the draft.
           git -C "$dir" add -A
           git -C "$dir" commit --quiet --allow-empty --no-edit \
             -m "hotfix reconcile v${LINE} (INCOMPLETE — resolve/finish before merge)" \

--- a/generic-actions/hotfix-reconcile/action.yaml
+++ b/generic-actions/hotfix-reconcile/action.yaml
@@ -103,7 +103,7 @@ runs:
       run: |
         set -euo pipefail
 
-        # cleanup_task feeds `Closes #<n>`, so a bare integer: a stray value would break the closing
+        # cleanup_task feeds `Closes #<n>`, so a bare integer: a stray value breaks the closing
         # keyword or the PR body.
         if ! printf '%s' "$CLEANUP_TASK" | grep -qE '^[0-9]+$'; then
           echo "::error::cleanup_task must be an integer, got \"$CLEANUP_TASK\"."
@@ -134,7 +134,7 @@ runs:
         # No '+' means the fix is already reconciled — a re-run after the PR merged, or a fix that
         # also went to master directly — so close the loop without a redundant PR.
         # git-cherry's output is captured and its exit checked explicitly: piped straight into grep,
-        # an unresolvable baseline or fix_head would read as "0 pending" and skip the reconcile.
+        # an unresolvable baseline or fix_head reads as "0 pending" and skips the reconcile.
         if ! cherry_out=$(git -C "$dir" cherry "origin/${default_branch}" "$FIX_HEAD" "$BASELINE" 2>&1); then
           echo "::error::git cherry failed (baseline/fix_head unresolvable?): ${cherry_out}"
           rm -rf "$dir"

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -88,7 +88,7 @@ runs:
     # Mint an [Agent] token: checks:write to post the status, plus org-wide issues and
     # pull-requests read. The read stays org-wide because the `Closes` hint resolves a
     # closing issue's parent Epic, which lives in the org's planning repo; a repo-scoped
-    # token would resolve that parent to null and drop the "add the `epic:<N>` label"
+    # token resolves that parent to null and drops the "add the `epic:<N>` label"
     # nudge. Membership needs no cross-repo read here — the nested epic-membership action
     # mints its own org-wide token.
     - name: Mint token
@@ -155,7 +155,7 @@ runs:
         # no, disabled — while any other value engages the halt. It arrives as an input because a
         # composite action cannot read the `vars` context, so the caller passes vars.AGENT_KILL_SWITCH
         # and the value resolves with no token and no API call before anything gates. A required-check
-        # gate holds by posting `failure`; skipping would leave a neutral check that passes. The hold
+        # gate holds by posting `failure`, since a skipped check stays neutral and passes. The hold
         # also dequeues a live merge_group. It is posted before every success path — the standalone
         # fast-path, the misconfig branch, the merge_group re-affirm — because the org-wide halt rests
         # on merge-gate holding every PR.
@@ -169,7 +169,7 @@ runs:
         esac
 
         # planning_repo becomes an API path component in the Epic-pause read below, so require a bare
-        # repo name: an owner slash, whitespace or an injected path would redirect the request. It is
+        # repo name: an owner slash, whitespace or an injected path redirects the request. It is
         # validated after the read-free kill-switch, so the halt wins even on a malformed value.
         if ! [[ "${PLANNING_REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
           echo "::error::planning_repo must be a bare repository name (no owner/slash), got \"${PLANNING_REPO:-}\""
@@ -192,8 +192,8 @@ runs:
         # passing. A null `pullRequest` — a valid-looking number that resolves to nothing,
         # such as a deleted PR or a merge_group ref naming a PR in another repo — comes back
         # with no GraphQL `.errors`, so it is guarded explicitly and treated as a fetch
-        # failure; otherwise the later `.labels.nodes[]` aborts under `set -e` and leaves no
-        # check posted at all instead of the caller's explicit `failure` hold.
+        # failure; otherwise the later `.labels.nodes[]` aborts under `set -e`, leaving the
+        # caller's explicit `failure` hold unposted and no check on the head at all.
         fetch_pr() { # $1=pr number
           local q data
           q='query($owner:String!,$repo:String!,$num:Int!){ repository(owner:$owner,name:$repo){
@@ -212,8 +212,8 @@ runs:
         }
 
         # A head SHA with neither a PR nor a merge_group is a misconfigured caller, so fail
-        # closed: passing a required check on a real SHA with nothing evaluated would let it
-        # satisfy the ruleset unchecked.
+        # closed: a required check passed on a real SHA with nothing evaluated satisfies the
+        # ruleset unchecked.
         if [ -z "${IN_QUEUE:-}" ] && [ -z "${PR_NUMBER:-}" ]; then
           post_check failure "No pull_request_number for ${HEAD_SHA:0:12} and not a merge_group event — refusing to pass a required check without evaluating a PR."
           emit ""
@@ -320,8 +320,8 @@ runs:
       with:
         epic_number: ${{ steps.discover.outputs.epic_number }}
         # Threaded through because this gate writes the snapshot to planning_repo below and this
-        # step reads it back. On its own default the two would target different repos the moment a
-        # caller overrides planning_repo, and the gate would gate on a set it never froze.
+        # step reads it back. On its own default the two target different repos as soon as a caller
+        # overrides planning_repo, and the gate then gates on a set it never froze.
         planning_repo: ${{ inputs.planning_repo }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
@@ -372,9 +372,9 @@ runs:
         # set no longer all-ready and the `failure` below dequeues the group. A shrinking
         # set — a member closed unmerged — belongs to the partial-landing detector.
         # A PR carrying epic:<N> that is absent from the resolved set, labeled after the
-        # snapshot froze or missed at capture, is held rather than inheriting the wave's
-        # verdict, which would merge it un-gated for its own readiness: it belongs to a later
-        # wave. Pre-snapshot the live set is the PR's own set, so this is a no-op, and a
+        # snapshot froze or missed at capture, is held: it belongs to a later wave, and the
+        # wave's verdict says nothing about its own readiness. Pre-snapshot the live set is
+        # the PR's own set, so this is a no-op, and a
         # merge_group event gates the whole group.
         if [ -z "${IN_QUEUE:-}" ] && [ -n "${PR_NUMBER:-}" ]; then
           if [ "$(printf '%s' "$MEMBERS" | jq --arg r "$REPO_FULL" --argjson n "${PR_NUMBER}" \
@@ -458,13 +458,11 @@ runs:
         # passes reach here. GitHub stores bodies with CRLF; strip \r so the marker lines match.
         body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' | tr -d '\r')
 
-        # Repository names are canonicalized to lower case, not merely deduped case-insensitively.
-        # GitHub resolves them case-insensitively and can answer with either casing, so folding only
-        # in the dedup would leave the surviving element carrying whatever spelling arrived first, and
-        # two passes would compute byte-different sets for the same members. The decision reads that
-        # as "members moved", resets the stabilization clock, and the Epic never freezes. Lower case
-        # is safe to store: every lookup built from it is case-insensitive, and both readers match
-        # members by alias index and number.
+        # Repository names are canonicalized to lower case, so every pass computes a byte-identical
+        # set for the same members. GitHub resolves names case-insensitively and answers with either
+        # casing, and the decision reads a byte-different set as "members moved", resets the
+        # stabilization clock, and the Epic never freezes. Lower case is safe to store: every lookup
+        # built from it is case-insensitive, and both readers match members by alias index and number.
         # The normalization matches what the readers validate, so the writer cannot emit a marker they
         # reject: a frozen marker is never rewritten, so one they refuse is a permanently dead
         # snapshot that degrades every Epic to live membership. The 50-member cap matches theirs.
@@ -485,7 +483,7 @@ runs:
         # the snapshot was frozen to remember. All three participants extract this way.
         marker=$(current_marker "$body")
         # An unparseable marker, such as hand-edited garbage, counts as absent and yields a fresh
-        # pending, which self-heals it rather than crashing or freezing corruption.
+        # pending, which self-heals the region.
         if [ -z "$marker" ] || ! printf '%s' "$marker" | jq empty 2>/dev/null; then marker=null; fi
         now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -499,7 +497,7 @@ runs:
           elif ($mk.status == "pending" and ($mk.members | type == "array") and ($mk.at | type == "string"))
             then (
               if (($mk.members | sort_by((.repo | ascii_downcase), .number)) != $cur) then "pending"
-              # An unparseable `at` rewrites a fresh pending rather than promoting or waiting. Read as
+              # An unparseable `at` rewrites a fresh pending. Read as
               # epoch 0 a corrupt timestamp is infinitely old and promotes on the next pass, skipping
               # the stabilization window; read as "now" it never ages, and with the member set
               # unchanged the reset branch above never fires either, so the marker stalls and the Epic
@@ -574,9 +572,9 @@ runs:
         # it win. So each attempt re-checks the decision against what is actually there.
 
         # The marker says what we intend and can still make progress: same status, same member set.
-        # `at` is per-writer and ignored, since byte equality would leave two writers with an identical
-        # set unable to satisfy each other, ping-ponging until both gave up on a failure that never
-        # happened. Both the entry short-circuit and the post-write verify call this, so a repair that
+        # `at` is per-writer and ignored: under byte equality two writers with an identical set never
+        # satisfy each other, ping-ponging until both give up on a failure that never happened. Both
+        # the entry short-circuit and the post-write verify call this, so a repair that
         # was clobbered cannot read as a repair that landed.
         marker_settled() { # $1 = live marker json, $2 = our payload json
           same_marker "$1" "$2" || return 1
@@ -598,18 +596,18 @@ runs:
           for attempt in 1 2 3; do
             # Re-read every attempt, the first included.
             if ! body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
-              # Record it: a read failure has no diagnostic of its own, and clearing `err` each
-              # attempt would leave the give-up message empty when the last attempts fail here.
+              # Record it: a read failure has no diagnostic of its own, and `err` survives the
+              # attempt so the give-up message is populated when the last attempts fail here.
               err="could not read ${ORG}/${PLANNING_REPO}#${EPIC} (attempt ${attempt})"
               [ "$attempt" -lt 3 ] && sleep 2
               continue
             fi
             marker=$(current_marker "$body")
 
-            # The body already says what this pass would write, so nothing needs writing. A `pending`
+            # The body already carries this pass's payload, so nothing needs writing. A `pending`
             # marker whose `at` does not parse is not equivalent, however close its members look: the
             # decision step routes that case here to repair it, since a timestamp that cannot be read
-            # never ages and the marker would sit pending while every sweep logged success.
+            # never ages and leaves the marker pending while every sweep logs success.
             if marker_settled "$marker" "$payload"; then
               rc=0
               break
@@ -628,7 +626,7 @@ runs:
 
             # Re-derive the freeze. `do=frozen` means the set has held still long enough, judged
             # against the marker this pass read at the start. If a peer has since seen the set change
-            # and reset the clock, that judgment is stale and freezing would make a wrong set
+            # and reset the clock, that judgment is stale and a freeze on it makes a wrong set
             # permanent. Age is re-checked too: without it a freeze lands seconds after a peer's
             # reset, skipping the window that lets the lagging label index surface a missing member.
             # Abandon, and the next pass decides on current truth.
@@ -648,9 +646,9 @@ runs:
             printf '%s' "$body" > "$bodyf"
             splice "$bodyf" "$regionf" > "$outf"
             err=$(gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" 2>&1 >/dev/null) || true
-            # Verify rather than trust the edit's exit code, since a peer write can land after ours.
-            # The comparison is semantic and scoped to the region: grepping the whole body would also
-            # match an orphaned payload line that splice's recovery path leaves behind as prose.
+            # Verify the result: a peer write can land after ours and the edit's exit code says
+            # nothing about that. The comparison is semantic and scoped to the region, so an orphaned
+            # payload line that splice's recovery path leaves behind as prose does not match.
             if body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r') \
               && marker_settled "$(current_marker "$body")" "$payload"; then
               rc=0

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -85,12 +85,12 @@ inputs:
 runs:
   using: composite
   steps:
-    # Mint an [Agent] token: checks:write to post the status, and org-wide issues +
-    # pull-requests read. The read stays org-wide (not scoped to `repo`) on purpose: the
-    # `Closes` hint resolves a closing issue's PARENT Epic, which lives in another repo
-    # (the org's planning repo), so a repo-scoped token would resolve that parent to null
-    # and silently drop the "add the `epic:<N>` label" nudge. Membership itself needs no
-    # cross-repo read here — the nested epic-membership action mints its own org-wide token.
+    # Mint an [Agent] token: checks:write to post the status, plus org-wide issues and
+    # pull-requests read. The read stays org-wide because the `Closes` hint resolves a
+    # closing issue's parent Epic, which lives in the org's planning repo; a repo-scoped
+    # token would resolve that parent to null and drop the "add the `epic:<N>` label"
+    # nudge. Membership needs no cross-repo read here — the nested epic-membership action
+    # mints its own org-wide token.
     - name: Mint token
       id: token
       uses: actions/create-github-app-token@v3
@@ -102,9 +102,10 @@ runs:
         permission-issues: read
         permission-pull-requests: read
 
-    # Classify the PR: standalone (post success + exit) or an Epic member (emit the Epic
-    # number for the resolve + evaluate steps). Standalone is decided from the event
-    # payload's labels with no API call, so an ordinary PR is immune to a GraphQL blip.
+    # Classify the PR as standalone, which posts success and exits, or as an Epic member,
+    # which emits the Epic number for the resolve and evaluate steps. Standalone is decided
+    # from the event payload's labels with no API call, so an ordinary PR survives a
+    # GraphQL blip.
     - name: Classify PR (standalone vs Epic member)
       id: discover
       shell: bash
@@ -119,9 +120,9 @@ runs:
         PR_NUMBER: ${{ inputs.pull_request_number }}
         IN_QUEUE: ${{ github.event.merge_group.head_sha }}
         MG_HEAD_REF: ${{ github.event.merge_group.head_ref }}
-        # The triggering PR's own labels, straight from the event payload: the full set on
-        # a pull_request event, empty on a merge_group / sweep run (there is no pull_request
-        # payload there). Lets the native pull_request path classify with no API call.
+        # The triggering PR's labels from the event payload: the full set on a pull_request
+        # event, empty on a merge_group or sweep run, which carry no pull_request payload.
+        # The native pull_request path classifies from these with no API call.
         EVENT_PR: ${{ github.event.pull_request.number }}
         EVENT_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
       run: |
@@ -135,7 +136,7 @@ runs:
         fi
 
         # Post the check-run as the App. jq builds the payload so a summary with quotes
-        # or newlines can't break the JSON.
+        # or newlines cannot break the JSON.
         post_check() { # $1=conclusion  $2=summary
           jq -n --arg sha "$HEAD_SHA" --arg concl "$1" --arg summary "$2" \
             '{name: "merge-gate", head_sha: $sha, status: "completed", conclusion: $concl,
@@ -144,22 +145,20 @@ runs:
           echo "merge-gate=$1 @ ${HEAD_SHA:0:12} — $2" | tee -a "$GITHUB_STEP_SUMMARY"
         }
 
-        # empty = terminal (this step already posted the check); non-empty = the Epic
-        # number for the resolve + evaluate steps to gate against.
+        # An empty value is terminal — this step already posted the check. A non-empty one
+        # is the Epic number the resolve and evaluate steps gate against.
         emit() { echo "epic_number=$1" >> "$GITHUB_OUTPUT"; }
 
-        # ---- Org-level HALT: AGENT_KILL_SWITCH (read FIRST, before any membership work) ----
-        # The [Agent]'s emergency brake — and it must FAIL-SAFE, i.e. fail TOWARD halting. RUNNING
-        # only when the value (lowercased, whitespace-stripped) is an explicit off-token —
-        # empty/unset, 0, off, false, no, disabled; ANYTHING ELSE (a fat-fingered "halt"/"engage", or
-        # garbage) ENGAGES the halt. Threaded in as an input because a composite action cannot read
-        # the `vars` context — the caller passes vars.AGENT_KILL_SWITCH, so the value is
-        # resolved with NO token and NO API call before anything gates. A required-check gate must
-        # HOLD (post `failure`), never skip: a skipped or neutral required check passes OPEN. So when
-        # halted we post `failure` on the head (which also dequeues a live merge_group) and stop. This
-        # HOLD is posted BEFORE every success path (standalone fast-path, misconfig, merge_group
-        # re-affirm) because the whole org-wide halt rests on merge-gate holding EVERY PR — no success
-        # branch may run first.
+        # ---- Org-level halt: AGENT_KILL_SWITCH, read before any membership work -------------
+        # The [Agent]'s emergency brake, and it fails toward halting: running only when the value,
+        # lowercased and whitespace-stripped, is an explicit off-token — empty/unset, 0, off, false,
+        # no, disabled — while any other value engages the halt. It arrives as an input because a
+        # composite action cannot read the `vars` context, so the caller passes vars.AGENT_KILL_SWITCH
+        # and the value resolves with no token and no API call before anything gates. A required-check
+        # gate holds by posting `failure`; skipping would leave a neutral check that passes. The hold
+        # also dequeues a live merge_group. It is posted before every success path — the standalone
+        # fast-path, the misconfig branch, the merge_group re-affirm — because the org-wide halt rests
+        # on merge-gate holding every PR.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)
@@ -169,10 +168,9 @@ runs:
             ;;
         esac
 
-        # planning_repo becomes an API path component (the Epic-pause read below); require a bare
-        # repo name so a stray value (owner/slash, whitespace, an injected path) can't redirect the
-        # request. Mirrors detect-partial-landing. Validated AFTER the read-free kill-switch so the
-        # halt always wins even when planning_repo is malformed.
+        # planning_repo becomes an API path component in the Epic-pause read below, so require a bare
+        # repo name: an owner slash, whitespace or an injected path would redirect the request. It is
+        # validated after the read-free kill-switch, so the halt wins even on a malformed value.
         if ! [[ "${PLANNING_REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
           echo "::error::planning_repo must be a bare repository name (no owner/slash), got \"${PLANNING_REPO:-}\""
           exit 1
@@ -188,15 +186,14 @@ runs:
           printf '%s\n' "$out" | grep -qx 'automation:paused'
         }
 
-        # Read a PR's labels + its `Closes` parent (the discovery hint) in one query,
-        # retrying transient GraphQL errors. Prints the response JSON on success;
-        # returns 1 (nothing printed) after retries so the caller decides hold-vs-pass.
-        # A null `pullRequest` (a valid-looking number that resolves to nothing — a
-        # deleted PR, or a merge_group ref naming a PR not in this repo) comes back with
-        # no GraphQL `.errors`, so guard it explicitly and treat it as a fetch failure
-        # (return 1) — otherwise the later `.labels.nodes[]` would abort under `set -e`
-        # and leave NO check posted (a silent expected-check hang), instead of the
-        # caller's explicit `failure` HOLD.
+        # Read a PR's labels and its `Closes` parent, the discovery hint, in one query,
+        # retrying transient GraphQL errors. Prints the response JSON on success; returns 1
+        # and prints nothing after retries, leaving the caller to choose between holding and
+        # passing. A null `pullRequest` — a valid-looking number that resolves to nothing,
+        # such as a deleted PR or a merge_group ref naming a PR in another repo — comes back
+        # with no GraphQL `.errors`, so it is guarded explicitly and treated as a fetch
+        # failure; otherwise the later `.labels.nodes[]` aborts under `set -e` and leaves no
+        # check posted at all instead of the caller's explicit `failure` hold.
         fetch_pr() { # $1=pr number
           local q data
           q='query($owner:String!,$repo:String!,$num:Int!){ repository(owner:$owner,name:$repo){
@@ -214,25 +211,25 @@ runs:
           return 1
         }
 
-        # A head SHA but neither a PR nor a merge_group is a misconfigured caller — fail
-        # CLOSED rather than passing a required check on a real SHA with nothing evaluated
-        # (which would let it satisfy the ruleset unchecked).
+        # A head SHA with neither a PR nor a merge_group is a misconfigured caller, so fail
+        # closed: passing a required check on a real SHA with nothing evaluated would let it
+        # satisfy the ruleset unchecked.
         if [ -z "${IN_QUEUE:-}" ] && [ -z "${PR_NUMBER:-}" ]; then
           post_check failure "No pull_request_number for ${HEAD_SHA:0:12} and not a merge_group event — refusing to pass a required check without evaluating a PR."
           emit ""
           exit 0
         fi
 
-        # Which PR are we classifying? On a merge_group event the queued PR number is
+        # Identify the PR to classify. On a merge_group event the queued PR number is
         # encoded in the group ref (refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>); a
-        # batch names one PR and the gate evaluates only that PR's Epic. Off the queue it
-        # is the input PR number.
+        # batch names one PR, and the gate evaluates that PR's Epic. Off the queue it is the
+        # input PR number.
         if [ -n "${IN_QUEUE:-}" ]; then
           classify_pr=$(printf '%s' "${MG_HEAD_REF:-}" | grep -oE 'pr-[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
           if [ -z "$classify_pr" ]; then
-            # Can't identify the queued PR from the group ref — HOLD (a failing required
-            # check dequeues the group) rather than pass blind; the sweep re-checks the
-            # PR head, and the PR returns to the pool to re-enqueue.
+            # The group ref does not identify the queued PR, so hold: a failing required
+            # check dequeues the group, the sweep re-checks the PR head, and the PR returns
+            # to the pool to re-enqueue.
             post_check failure "merge_group head_ref \"${MG_HEAD_REF:-}\" — couldn't identify the queued PR to re-check its Epic; holding (dequeues) rather than passing blind."
             emit ""
             exit 0
@@ -241,11 +238,11 @@ runs:
           classify_pr="$PR_NUMBER"
         fi
 
-        # Get this PR's labels (authority) and its `Closes` parent (hint). On the native
-        # pull_request event the labels are already in the payload, so classify with NO
-        # API call — the standalone fast path can't be frozen by a GraphQL outage. The
-        # sweep and merge_group paths have no PR payload, so read the labels via the API;
-        # if that read can't complete, HOLD rather than guess.
+        # Get this PR's labels, the authority, and its `Closes` parent, the hint. The native
+        # pull_request event carries the labels in its payload, so the standalone fast path
+        # classifies with no API call and a GraphQL outage cannot freeze it. The sweep and
+        # merge_group paths have no PR payload and read the labels via the API; a read that
+        # cannot complete holds.
         labels=""
         parent=""
         labels_truncated=false
@@ -263,13 +260,12 @@ runs:
           fi
         fi
 
-        # The membership authority: the `epic:<N>` label. First match wins (one Epic per
-        # PR by convention). A numeric-only match keeps the value safe for downstream use.
+        # The `epic:<N>` label decides membership; the first match wins, one Epic per PR by
+        # convention. A numeric-only match keeps the value safe for downstream use.
         epic=$(printf '%s' "$labels" | jq -r 'map(select(test("^epic:[0-9]+$")))[0] // empty' | grep -oE '[0-9]+' || true)
 
-        # A gate must not fail open on a technicality: if the fetched label page was
-        # truncated (a PR with >100 labels — pathological) and no epic:<N> turned up in it,
-        # we cannot conclude "standalone" — HOLD instead. Only the API path can truncate;
+        # A truncated label page — a PR with more than 100 labels — with no epic:<N> in it
+        # does not establish "standalone", so hold instead. Only the API path can truncate;
         # the native path reads the full label set from the event payload.
         if [ -z "$epic" ] && [ "$labels_truncated" = "true" ]; then
           post_check failure "PR #${classify_pr} has >100 labels; couldn't confirm it carries no \`epic:<N>\` label — holding rather than passing as standalone."
@@ -278,8 +274,8 @@ runs:
         fi
 
         if [ -n "$epic" ]; then
-          # Per-Epic pause: `automation:paused` on the Epic issue HOLDS its members (post failure),
-          # leaving every OTHER Epic moving. Read FIRST here so a paused Epic never resolves/evaluates.
+          # Per-Epic pause: `automation:paused` on the Epic issue holds its members by posting
+          # failure, leaving every other Epic moving. Read first, so a paused Epic never resolves.
           ps=0; epic_paused "$epic" || ps=$?
           if [ "$ps" -eq 0 ]; then
             post_check failure "Epic #${epic} is automation:paused — holding its members. Remove the \`automation:paused\` label from Epic #${epic} to resume atomic landing."
@@ -287,16 +283,16 @@ runs:
             exit 0
           fi
           [ "$ps" -eq 2 ] && echo "::warning::couldn't read Epic #${epic} pause state (planning-repo read failed) — proceeding with normal readiness evaluation."
-          # Labeled Epic member — hand off to epic-membership (the authority) + evaluate.
+          # A labeled Epic member hands off to epic-membership, the authority, then evaluates.
           echo "PR #${classify_pr} carries \`epic:${epic}\` — resolving the authorized member set." | tee -a "$GITHUB_STEP_SUMMARY"
           emit "$epic"
           exit 0
         fi
 
-        # No `epic:<N>` label → standalone, always passes. The `Closes` walk is a HINT
-        # only: if the closing issue has a parent Epic, suggest adding the label (the
-        # native path skipped the API above, so do the best-effort walk now — a failure
-        # just drops the hint, the PR still passes).
+        # No `epic:<N>` label means standalone, which always passes. The `Closes` walk is a
+        # hint: when the closing issue has a parent Epic, suggest adding the label. The
+        # native path skipped the API above, so the walk happens here, best-effort — a
+        # failure drops the hint and the PR still passes.
         if [ -n "${EVENT_PR:-}" ] && [ "$classify_pr" = "${EVENT_PR}" ]; then
           if data=$(fetch_pr "$classify_pr"); then
             parent=$(printf '%s' "$data" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[0].parent.number // empty')
@@ -311,11 +307,11 @@ runs:
         emit ""
         exit 0
 
-    # Resolve the Epic's authorized member set — the open PRs carrying `epic:<N>`, org-wide.
-    # This is the membership AUTHORITY (the label, not the author-controlled `Closes` walk).
-    # Pinned remote ref, never `./`: a local path resolves against the CONSUMER repo's
-    # workspace, not this repo. continue-on-error so a resolve failure does not abort the
-    # composite — the evaluate step turns an empty/failed resolve into a HOLD, not a crash.
+    # Resolve the Epic's authorized member set: the open PRs carrying `epic:<N>`, org-wide.
+    # The label is the membership authority, ahead of the author-controlled `Closes` walk.
+    # The ref is pinned remotely because a `./` path resolves against the consumer repo's
+    # workspace. continue-on-error keeps a resolve failure from aborting the composite; the
+    # evaluate step turns an empty or failed resolve into a hold.
     - name: Resolve authorized member set
       id: membership
       if: ${{ steps.discover.outputs.epic_number != '' }}
@@ -323,15 +319,15 @@ runs:
       uses: a-novel-kit/workflows/generic-actions/epic-membership@v1.20.2
       with:
         epic_number: ${{ steps.discover.outputs.epic_number }}
-        # Thread it through: this gate WRITES the snapshot to planning_repo below, and this step READS
-        # it back. Left to its own default the two would target different repos the moment a caller
-        # overrides planning_repo, and the gate would gate on a set it never froze.
+        # Threaded through because this gate writes the snapshot to planning_repo below and this
+        # step reads it back. On its own default the two would target different repos the moment a
+        # caller overrides planning_repo, and the gate would gate on a set it never froze.
         planning_repo: ${{ inputs.planning_repo }}
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
 
-    # Recompute readiness over the member set and post the gate. Runs for the labeled-Epic
-    # path only; standalone / misconfig / hold cases were already posted by the classify step.
+    # Recompute readiness over the member set and post the gate. Only the labeled-Epic path
+    # reaches here; the classify step already posted the standalone, misconfig and hold cases.
     - name: Evaluate readiness + post merge-gate
       id: evaluate
       if: ${{ steps.discover.outputs.epic_number != '' }}
@@ -358,28 +354,28 @@ runs:
         where="on the PR head"
         [ -n "${IN_QUEUE:-}" ] && where="on the merge-queue group head"
 
-        # epic-membership ran with continue-on-error: an EMPTY output means it FAILED to
-        # resolve (transport / rate-limit after its own retries); a resolved-but-empty set
-        # is "[]". Either way we can't confirm readiness for a PR we KNOW is labeled
-        # `epic:<N>` — it should appear in its own set, so "[]" means the label search index
-        # is still lagging. HOLD (failure), never pass: an uncertain set that turns out
-        # unready must not merge. The reconcile sweep re-runs and lands the set once ready.
+        # epic-membership ran with continue-on-error, so an empty output means it failed to
+        # resolve after its own retries, while a resolved-but-empty set is "[]". Neither
+        # confirms readiness for a PR known to carry `epic:<N>`: it should appear in its own
+        # set, so "[]" means the label search index is still lagging. Hold by posting
+        # failure; the reconcile sweep re-runs and lands the set once ready.
         if [ -z "${MEMBERS:-}" ] || [ "${MEMBERS}" = "[]" ]; then
           post_check failure "Epic #${EPIC} — couldn't confirm the member set ${where} (resolve errored, or the label index is lagging); holding rather than passing on uncertainty. The reconcile sweep re-checks."
           exit 0
         fi
 
-        # A member is merge-ready iff non-draft AND approved. Merged siblings have already
-        # left the open set (epic-membership returns open PRs only), so an all-ready open
-        # set means the whole Epic is ready to land together. On a merge_group event this
-        # same recompute runs on the group head: if a member regressed since enqueue (back
-        # to draft, or approval dismissed) the set is no longer all-ready and the `failure`
-        # below dequeues the group. (Set-shrink — a member closed unmerged — is the
-        # partial-landing detector's job, not this gate's.)
-        # A PR carrying epic:<N> that is NOT in the resolved set — labelled after the snapshot froze, or
-        # missed at capture — must not inherit the wave's verdict (it would merge un-gated for its own
-        # readiness). Hold it: it belongs to a later wave, not this landing. Pre-snapshot the live set
-        # is the PR's own set, so this is a no-op; a merge_group event gates the whole group, not one PR.
+        # A member is merge-ready when it is non-draft and approved. Merged siblings have
+        # already left the open set, since epic-membership returns open PRs only, so an
+        # all-ready open set means the whole Epic is ready to land together. The same
+        # recompute runs on a merge_group event against the group head: a member that
+        # regressed since enqueue, back to draft or with its approval dismissed, makes the
+        # set no longer all-ready and the `failure` below dequeues the group. A shrinking
+        # set — a member closed unmerged — belongs to the partial-landing detector.
+        # A PR carrying epic:<N> that is absent from the resolved set, labeled after the
+        # snapshot froze or missed at capture, is held rather than inheriting the wave's
+        # verdict, which would merge it un-gated for its own readiness: it belongs to a later
+        # wave. Pre-snapshot the live set is the PR's own set, so this is a no-op, and a
+        # merge_group event gates the whole group.
         if [ -z "${IN_QUEUE:-}" ] && [ -n "${PR_NUMBER:-}" ]; then
           if [ "$(printf '%s' "$MEMBERS" | jq --arg r "$REPO_FULL" --argjson n "${PR_NUMBER}" \
                 'any(.[]; .repo == $r and .number == $n)')" != "true" ]; then
@@ -388,11 +384,10 @@ runs:
           fi
         fi
 
-        # Readiness is about the still-OPEN members: with a snapshot the set is frozen and can carry
-        # merged / closed members, which have already left (or abandoned) the landing and are the
-        # partial-landing detector's concern, not the gate's. `state == null` tolerates an older
-        # epic-membership (pre-`state`) so a version skew degrades to the all-open live behavior rather
-        # than passing every set.
+        # Readiness covers the still-open members. Under a snapshot the set is frozen and can carry
+        # merged or closed members, which have left or abandoned the landing and belong to the
+        # partial-landing detector. `state == null` tolerates an epic-membership version without
+        # `state`, so a version skew degrades to the all-open live behavior.
         unready=$(printf '%s' "$MEMBERS" | jq -r '.[]
           | select(.state == "OPEN" or .state == null)
           | select(.isDraft or (.reviewDecision != "APPROVED"))
@@ -401,7 +396,7 @@ runs:
         total=$(printf '%s' "$MEMBERS" | jq '[.[] | select(.state == "OPEN" or .state == null)] | length')
         if [ -z "$unready" ]; then
           post_check success "Epic #${EPIC} — all ${total} open member(s) merge-ready ${where}. Atomic landing OK."
-          # The set is approved and merge-ready. Trigger the two-phase capture (pending→frozen) below.
+          # The set is approved and merge-ready, so trigger the two-phase capture below.
           echo "capture=true" >> "$GITHUB_OUTPUT"
         else
           count=$(printf '%s\n' "$unready" | grep -c '')
@@ -409,9 +404,9 @@ runs:
             "$EPIC" "$where" "$count" "$total" "$unready")"
         fi
 
-    # Activation snapshot: freeze the member set the first time the whole Epic is merge-ready — before
-    # any member merges or is de-labelled. A separate, minimal issues:write token: the gate's own token
-    # stays read-only on issues, so the write capability lives only in this step.
+    # Activation snapshot: freeze the member set the first time the whole Epic is merge-ready, before
+    # any member merges or is de-labeled. The issues:write token is separate and minimal, so the
+    # gate's own token stays read-only on issues and the write capability lives in this step alone.
     - name: Mint snapshot-write token
       id: snap_token
       if: ${{ steps.evaluate.outputs.capture == 'true' }}
@@ -422,7 +417,7 @@ runs:
         client-id: ${{ inputs.client_id }}
         private-key: ${{ inputs.app_private_key }}
         owner: ${{ github.repository_owner }}
-        # Scoped to the planning repo. This token exists to edit ONE issue, and that issue is the
+        # Scoped to the planning repo. This token exists to edit one issue, and that issue is the
         # trust boundary the readers act on, so org-wide issues:write would let a bug here reach
         # every issue in the org.
         repositories: ${{ inputs.planning_repo }}
@@ -430,8 +425,8 @@ runs:
 
     - name: Capture activation snapshot
       if: ${{ steps.evaluate.outputs.capture == 'true' }}
-      # Best-effort: a failed capture must NEVER fail the gate — the merge-gate check is already posted
-      # success. Membership just stays live-derived until the next ready-pass writes the marker.
+      # Best-effort: the merge-gate check is already posted success, so a failed capture never fails
+      # the gate. Membership stays live-derived until the next ready pass writes the marker.
       continue-on-error: true
       shell: bash
       env:
@@ -443,7 +438,7 @@ runs:
         STABILIZE_SECONDS: "120"
       run: |
         set -euo pipefail
-        # The marker currently in the body, as JSON — empty when there is none or it is unusable.
+        # The marker currently in the body, as JSON; empty when there is none or it is unusable.
         current_marker() { # $1 = body
           printf '%s\n' "$1" \
             | awk -v s="$START" -v e="$END" '$0 == s {f=1;next} $0 == e {f=0} f' \
@@ -454,26 +449,25 @@ runs:
         START='<!-- epic-membership:snapshot:start -->'
         END='<!-- epic-membership:snapshot:end -->'
 
-        # Two-phase capture, so the eventually-consistent label search never freezes an INCOMPLETE set
-        # (an index-lagging member is exactly why "all ready" can trip early on a short set). The first
-        # all-ready pass writes a `pending` marker with a timestamp; a later pass promotes it to `frozen`
-        # only once the set is UNCHANGED and has aged past STABILIZE_SECONDS — giving the index time to
+        # Two-phase capture, so the eventually-consistent label search never freezes an incomplete set:
+        # an index-lagging member is why "all ready" can trip early on a short set. The first all-ready
+        # pass writes a `pending` marker with a timestamp, and a later pass promotes it to `frozen`
+        # once the set is unchanged and has aged past STABILIZE_SECONDS, giving the index time to
         # surface any missing member. A changed set resets the clock. epic-membership treats only
-        # `frozen` as the set; `pending` reads as no-snapshot. Runs per member PR (several passes reach
-        # here). GitHub stores bodies with CRLF; strip \r so the exact marker matches (grep + splice).
+        # `frozen` as the set and reads `pending` as no snapshot. This runs per member PR, so several
+        # passes reach here. GitHub stores bodies with CRLF; strip \r so the marker lines match.
         body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' | tr -d '\r')
 
-        # Repository names are CANONICALIZED to lower case, not merely deduped case-insensitively.
-        # GitHub resolves them case-insensitively and can answer with either casing, so folding only in
-        # the dedup left the surviving element carrying whatever spelling arrived first — two passes
-        # then computed byte-different sets for the same members. The decision reads that as "members
-        # moved", resets the stabilization clock, and the Epic never freezes. Lower case is safe to
-        # store: every lookup built from it is case-insensitive, and both readers match members by
-        # alias index and number rather than by name.
-        # Normalize exactly as the readers validate, so the writer cannot emit a marker they reject —
-        # a frozen marker is never rewritten, so one they refuse is a permanently dead snapshot that
-        # silently degrades every Epic to live membership. Dedup is case-folded (GitHub resolves repo
-        # names case-insensitively) and the 50-member cap matches theirs.
+        # Repository names are canonicalized to lower case, not merely deduped case-insensitively.
+        # GitHub resolves them case-insensitively and can answer with either casing, so folding only
+        # in the dedup would leave the surviving element carrying whatever spelling arrived first, and
+        # two passes would compute byte-different sets for the same members. The decision reads that
+        # as "members moved", resets the stabilization clock, and the Epic never freezes. Lower case
+        # is safe to store: every lookup built from it is case-insensitive, and both readers match
+        # members by alias index and number.
+        # The normalization matches what the readers validate, so the writer cannot emit a marker they
+        # reject: a frozen marker is never rewritten, so one they refuse is a permanently dead
+        # snapshot that degrades every Epic to live membership. The 50-member cap matches theirs.
         cur=$(printf '%s' "$MEMBERS" | jq -c '
           [.[] | {repo: (.repo | ascii_downcase), number}]
           | unique_by(.repo, .number) | sort_by(.repo, .number)')
@@ -485,19 +479,19 @@ runs:
             | tee -a "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
-        # The fenced region holds a human-readable note and then the JSON, so skip to the first line that
-        # opens a value before parsing. Both failure modes here are silent and this one is destructive:
-        # an unreadable FROZEN marker falls to the `pending` branch below, which OVERWRITES it with the
-        # current live set — erasing exactly the de-labeled member the snapshot was frozen to remember.
-        # All three participants extract identically.
+        # The fenced region holds a human-readable note and then the JSON, so skip to the first line
+        # that opens a value before parsing. A frozen marker this fails to read falls to the `pending`
+        # branch below, which overwrites it with the current live set, erasing the de-labeled member
+        # the snapshot was frozen to remember. All three participants extract this way.
         marker=$(current_marker "$body")
-        # An unparseable marker (hand-edited garbage) is treated as absent → a fresh pending, which
-        # self-heals it rather than crashing or freezing corruption.
+        # An unparseable marker, such as hand-edited garbage, counts as absent and yields a fresh
+        # pending, which self-heals it rather than crashing or freezing corruption.
         if [ -z "$marker" ] || ! printf '%s' "$marker" | jq empty 2>/dev/null; then marker=null; fi
         now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-        # frozen → skip; a valid pending → reset (members changed) / promote (unchanged + aged) / wait;
-        # anything else (missing, malformed, other status) → write a fresh pending.
+        # A frozen marker is skipped. A valid pending one resets when the members changed, promotes
+        # when it is unchanged and aged, and otherwise waits. Anything else — missing, malformed, or
+        # carrying another status — gets a fresh pending.
         do=$(jq -rn --argjson cur "$cur" --argjson mk "$marker" --arg now "$now" \
           --argjson thr "${STABILIZE_SECONDS}" '
           if ($mk | type) != "object" then "pending"
@@ -505,12 +499,11 @@ runs:
           elif ($mk.status == "pending" and ($mk.members | type == "array") and ($mk.at | type == "string"))
             then (
               if (($mk.members | sort_by((.repo | ascii_downcase), .number)) != $cur) then "pending"
-              # An unparseable `at` rewrites a fresh pending rather than promoting or waiting. Reading it
-              # as epoch 0 made a corrupt timestamp infinitely old and promoted on the next pass, skipping
-              # the stabilization window; reading it as "now" never ages, and since the member set is
-              # unchanged the reset branch above never fires either, so the marker stalls forever and the
-              # Epic silently keeps live membership. Rewriting is the only answer that both refuses the
-              # premature freeze and repairs the marker.
+              # An unparseable `at` rewrites a fresh pending rather than promoting or waiting. Read as
+              # epoch 0 a corrupt timestamp is infinitely old and promotes on the next pass, skipping
+              # the stabilization window; read as "now" it never ages, and with the member set
+              # unchanged the reset branch above never fires either, so the marker stalls and the Epic
+              # keeps live membership. Rewriting refuses the premature freeze and repairs the marker.
               elif (($mk.at | try (fromdateiso8601 | true) catch false) | not) then "pending"
               elif (($now | fromdateiso8601) - ($mk.at | fromdateiso8601)) >= $thr then "frozen"
               else "skip" end)
@@ -530,9 +523,10 @@ runs:
           note="_Epic membership, PENDING — stabilizing before it freezes (the label index is eventually consistent). Do not edit._"
         fi
 
-        # splice(): hand-edit-safe marker writer, lifted verbatim from render-epic-status. Replaces a
-        # well-formed region in place (pending→pending reset, pending→frozen promote); otherwise strips
-        # any stray marker lines and appends one fresh region — human prose is never dropped.
+        # splice(): a hand-edit-safe marker writer, shared with render-epic-status. It replaces a
+        # well-formed region in place, covering both the pending reset and the frozen promote;
+        # otherwise it strips any stray marker lines and appends one fresh region. Human prose
+        # survives either path.
         splice() { # $1 = body file, $2 = region file (already wrapped in the markers)
           local bodyf="$1" regionf="$2" ns ne sl el wellformed=false
           ns=$(grep -cxF -- "$START" "$bodyf" || true)
@@ -557,12 +551,7 @@ runs:
           fi
         }
 
-        # Write under a read-modify-verify loop. The reconcile sweep runs this gate as a matrix over
-        # every open member pull request with no concurrency bound, and the read-model renderer edits
-        # the same body from another job, so several writers overlap by design. GitHub's issues API has
-        # no conditional update — a GET returns an ETag but PATCH accepts no If-Match — so the closest
-        # available guarantee is: splice into a body read moments ago, then confirm the write survived.
-        # A losing writer retries against whatever landed instead of overwriting it.
+        # The region write_marker splices in below.
         regionf=$(mktemp)
         {
           echo "$START"
@@ -571,30 +560,30 @@ runs:
           echo "$END"
         } > "$regionf"
 
-        # Read-modify-VERIFY, as a function so the test harness can extract and drive it against a
-        # stubbed gh. The sweep runs this gate as a matrix over every open member pull request with no
-        # concurrency bound, and the read-model renderer edits the same body from another job, so
-        # writers overlap by design. GitHub's issues API offers no conditional update — a GET returns an
-        # ETag, PATCH accepts no If-Match — so the guarantee has to be built from reads.
+        # Read-modify-verify, written as a function so the test harness can extract it and drive it
+        # against a stubbed gh. The sweep runs this gate as a matrix over every open member pull
+        # request with no concurrency bound, and the read-model renderer edits the same body from
+        # another job, so writers overlap by design. GitHub's issues API offers no conditional update
+        # — a GET returns an ETag, PATCH accepts no If-Match — so the guarantee is built from reads:
+        # splice into a body read moments ago, then confirm the write survived, and a losing writer
+        # retries against whatever landed.
         #
-        # Re-reading is not enough on its own: the decision ($do / $payload) was computed from a body
-        # fetched earlier, and a peer may have moved the set since. A writer that re-reads but does not
-        # RE-DERIVE will happily freeze a member set the world has already moved past, and the retry
-        # below would make it win. So each attempt re-checks the decision against what is actually there.
+        # Re-reading alone is not enough: the decision ($do / $payload) was computed from a body
+        # fetched earlier, and a peer may have moved the set since. A writer that re-reads without
+        # re-deriving freezes a member set the world has already moved past, and the retry below makes
+        # it win. So each attempt re-checks the decision against what is actually there.
 
-
-        # Same marker for our purposes: same status and same member set. Deliberately ignores `at`,
-        # which is per-writer — byte equality would make two writers with an identical set unable to
-        # satisfy each other and ping-pong until both gave up, reporting a failure that never happened.
-        # "The marker already says what we intend, AND it is a marker that can still make progress."
-        # Used for BOTH the entry short-circuit and the post-write verify: if these two ever answer
-        # differently, a repair that was clobbered reads as a repair that landed.
+        # The marker says what we intend and can still make progress: same status, same member set.
+        # `at` is per-writer and ignored, since byte equality would leave two writers with an identical
+        # set unable to satisfy each other, ping-ponging until both gave up on a failure that never
+        # happened. Both the entry short-circuit and the post-write verify call this, so a repair that
+        # was clobbered cannot read as a repair that landed.
         marker_settled() { # $1 = live marker json, $2 = our payload json
           same_marker "$1" "$2" || return 1
-          # A frozen marker carries no `at` and needs none — it is terminal.
+          # A frozen marker is terminal, so it carries no `at` and needs none.
           [ "$(printf '%s' "$1" | jq -r '.status // ""')" = "frozen" ] && return 0
           # A pending marker whose `at` cannot be parsed can never age, so it is not settled however
-          # equal its members look: the decision step routes exactly that case to a repairing write.
+          # equal its members look; the decision step routes that case to a repairing write.
           printf '%s' "$1" | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null 2>&1
         }
 
@@ -609,28 +598,27 @@ runs:
           for attempt in 1 2 3; do
             # Re-read every attempt, the first included.
             if ! body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
-              # Record it: a read failure has no diagnostic of its own, and clearing `err` each attempt
-              # would otherwise leave the give-up message empty when the last attempts fail here.
+              # Record it: a read failure has no diagnostic of its own, and clearing `err` each
+              # attempt would leave the give-up message empty when the last attempts fail here.
               err="could not read ${ORG}/${PLANNING_REPO}#${EPIC} (attempt ${attempt})"
               [ "$attempt" -lt 3 ] && sleep 2
               continue
             fi
             marker=$(current_marker "$body")
 
-            # Already says what we were going to say — nothing to write, by us or anyone. A `pending`
-            # marker whose `at` does not parse is NOT equivalent, however close its members look: the
-            # decision step routes exactly that case here to REPAIR it, because a timestamp that cannot
-            # be read can never age, so the marker would sit pending forever and the Epic would keep
-            # live membership with a success line in the log every sweep.
+            # The body already says what this pass would write, so nothing needs writing. A `pending`
+            # marker whose `at` does not parse is not equivalent, however close its members look: the
+            # decision step routes that case here to repair it, since a timestamp that cannot be read
+            # never ages and the marker would sit pending while every sweep logged success.
             if marker_settled "$marker" "$payload"; then
               rc=0
               break
             fi
 
-            # A frozen marker is terminal: it is the authority every reader has been using, and
-            # rewriting it mid-landing is the one thing "frozen" forbids. Yield, whatever we intended.
-            # This narrows the window rather than closing it — a freeze landing between this check and
-            # the write below is still clobbered, and no conditional-update API exists to prevent that.
+            # A frozen marker is terminal: it is the authority every reader has been using, so yield
+            # whatever this pass intended. The check narrows the window without closing it — a freeze
+            # landing between here and the write below is still clobbered, and no conditional-update
+            # API exists to prevent that.
             if [ -n "$marker" ] && [ "$(printf '%s' "$marker" | jq -r '.status // ""')" = "frozen" ]; then
               echo "Epic #${EPIC}: the snapshot is already frozen (a peer got there first) — leaving it." \
                 | tee -a "$GITHUB_STEP_SUMMARY"
@@ -638,12 +626,12 @@ runs:
               break
             fi
 
-            # RE-DERIVE the freeze. `do=frozen` means "the set has held still long enough", judged
-            # against the marker this pass read at the start. If the marker has moved since — a peer
-            # saw the set change and reset the clock — that judgement is stale, and freezing it would
-            # make a wrong set permanent. Age is re-checked too: without it a freeze can land seconds
-            # after a peer's reset, skipping the very window that lets the lagging label index surface
-            # a missing member. Abandon; the next pass decides on current truth.
+            # Re-derive the freeze. `do=frozen` means the set has held still long enough, judged
+            # against the marker this pass read at the start. If a peer has since seen the set change
+            # and reset the clock, that judgment is stale and freezing would make a wrong set
+            # permanent. Age is re-checked too: without it a freeze lands seconds after a peer's
+            # reset, skipping the window that lets the lagging label index surface a missing member.
+            # Abandon, and the next pass decides on current truth.
             if [ "$do" = "frozen" ] \
               && ! jq -e -n --argjson m "${marker:-null}" --argjson cur "$cur" \
                    --arg now "$now" --argjson thr "${STABILIZE_SECONDS}" \
@@ -660,9 +648,9 @@ runs:
             printf '%s' "$body" > "$bodyf"
             splice "$bodyf" "$regionf" > "$outf"
             err=$(gh issue edit "$EPIC" --repo "${ORG}/${PLANNING_REPO}" --body-file "$outf" 2>&1 >/dev/null) || true
-            # Verify rather than trust the edit's exit code: a peer write can land after ours. Compare
-            # the REGION semantically — grepping the whole body would also match an orphaned payload
-            # line that splice's recovery path leaves behind as prose.
+            # Verify rather than trust the edit's exit code, since a peer write can land after ours.
+            # The comparison is semantic and scoped to the region: grepping the whole body would also
+            # match an orphaned payload line that splice's recovery path leaves behind as prose.
             if body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null | tr -d '\r') \
               && marker_settled "$(current_marker "$body")" "$payload"; then
               rc=0

--- a/generic-actions/release-train/action.yaml
+++ b/generic-actions/release-train/action.yaml
@@ -69,9 +69,9 @@ inputs:
 runs:
   using: composite
   steps:
-    # Org-level HALT (read FIRST, before the admin check or any token mint): AGENT_KILL_SWITCH engaged
-    # → refuse to run. Cutting releases is a deliberate, un-halted decision, so this aborts loud rather
-    # than silently no-opping. FAIL-SAFE: running only for an explicit off-token.
+    # Org-level halt, read before the admin check or any token mint. Cutting releases is a
+    # deliberate, un-halted decision, so an engaged switch aborts loudly. Fail-safe: running only
+    # for an explicit off-token.
     - name: Halt guard (kill-switch)
       shell: bash
       env:
@@ -86,10 +86,9 @@ runs:
             ;;
         esac
 
-    # Defense in depth: re-check the dispatcher is a repo admin HERE, as the action's own step — the
-    # gate must not live ONLY in the caller's dispatch shell. Copied from epic-rollback: the
-    # collaborator-permission endpoint needs only Metadata:read; `|| echo ""` keeps a failed lookup
-    # from tripping `set -e` (empty permission fails closed).
+    # Re-check the dispatcher is a repo admin here as well as in the caller's dispatch shell. The
+    # collaborator-permission endpoint needs only Metadata:read, and `|| echo ""` keeps a failed
+    # lookup from tripping `set -e`; an empty permission fails closed.
     - name: Require admin (defense in depth)
       shell: bash
       env:
@@ -105,8 +104,8 @@ runs:
         fi
         echo "@${ACTOR} is a repo admin (action-level re-check passed)." | tee -a "$GITHUB_STEP_SUMMARY"
 
-    # Read token: the ledger search + per-repo commit-range + tag/release reads span every repo in the
-    # org, and the single-repo GITHUB_TOKEN can't see siblings. Least privilege: read only.
+    # Read token: the ledger search, per-repo commit ranges and tag or release reads span every repo
+    # in the org, and the single-repo GITHUB_TOKEN cannot see siblings.
     - name: Mint read token
       id: read
       uses: actions/create-github-app-token@v3
@@ -118,8 +117,9 @@ runs:
         permission-pull-requests: read
         permission-contents: read
 
-    # Dispatch token: actions:write to trigger each repo's release.yaml (the dispatches endpoint) and
-    # read the runs. NOT contents:write — the orchestrator never pushes; release-core mints its own.
+    # Dispatch token: actions:write to trigger each repo's release.yaml through the dispatches
+    # endpoint and read the runs. The orchestrator never pushes, so it holds no contents:write;
+    # release-core mints its own.
     - name: Mint dispatch token
       id: dispatch
       uses: actions/create-github-app-token@v3
@@ -129,8 +129,8 @@ runs:
         owner: ${{ inputs.org }}
         permission-actions: write
 
-    # Issue token: issues:write, scoped to the planning repo only, to splice the receipt block into the
-    # Epic body (best-effort audit; the receipt is NEVER the source of truth for resume — live tags are).
+    # Issue token: issues:write, scoped to the planning repo alone, to splice the receipt block into
+    # the Epic body. The receipt is a best-effort audit; resume reads live tags.
     - name: Mint issue token
       id: issue
       uses: actions/create-github-app-token@v3
@@ -144,8 +144,9 @@ runs:
     - name: Reconstruct the Epic, derive bumps, drive each release.yaml
       shell: bash
       env:
-        # Default GH_TOKEN is the READ token (bare `gh` for every read); the dispatch + issue tokens are
-        # applied inline at their call sites so a read can't hold a write scope.
+        # The default GH_TOKEN is the read token, which every bare-`gh` read picks up; the dispatch
+        # and issue tokens are applied inline at their call sites, so a read never holds a write
+        # scope.
         GH_TOKEN: ${{ steps.read.outputs.token }}
         DISPATCH_TOKEN: ${{ steps.dispatch.outputs.token }}
         ISSUE_TOKEN: ${{ steps.issue.outputs.token }}
@@ -168,11 +169,11 @@ runs:
         if ! [[ "${PLANNING_REPO:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
           echo "::error::planning_repo must be a bare repository name (no owner/slash), got \"${PLANNING_REPO:-}\""; exit 1
         fi
-        # dry_run defaults on; only the literal "false" mutates (cuts real releases).
+        # dry_run defaults on; only the literal "false" cuts real releases.
         dry=$(printf '%s' "${DRY_RUN:-true}" | tr '[:upper:]' '[:lower:]')
 
-        # ---- Per-Epic pause: refuse to release a paused Epic (best-effort read; a read error does NOT
-        # block — the admin gate already fenced this dispatch). Mirrors epic-rollback.
+        # ---- Per-Epic pause: refuse to release a paused Epic. The label read is best-effort, since
+        # the admin gate already fenced this dispatch, so a read error does not block.
         paused=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.labels[].name' 2>/dev/null || echo "")
         if printf '%s\n' "$paused" | grep -qx 'automation:paused'; then
           echo "::error::epic:#${EPIC} is automation:paused — remove the \`automation:paused\` label from the Epic issue before releasing it."
@@ -181,15 +182,15 @@ runs:
 
         # ================= Shared helpers ==========================================================
 
-        # PR-search node: number + repo + mergedAt (to anchor the ship-test on the NEWEST-merged sibling
-        # per repo, not an arbitrary first — a later sibling not yet in the tag must not be masked).
+        # PR-search node: number, repo and mergedAt, which anchors the ship test on each repo's
+        # newest-merged sibling, so a later sibling not yet in the tag cannot be masked.
         SEARCH_Q='query($q:String!,$cursor:String){
           search(query:$q, type:ISSUE, first:100, after:$cursor){
             pageInfo{ hasNextPage endCursor }
             nodes{ ... on PullRequest{ number mergedAt repository{ nameWithOwner } } } } }'
 
         # Page an ISSUE search to completion, retrying transient GraphQL errors; prints the aggregated
-        # PR-node array. Returns 1 on failure so the caller fails closed. (epic-rollback pattern.)
+        # PR-node array. Returns 1 on failure so the caller fails closed.
         search_prs() { # $1 = search query
           local search="$1" cursor="" agg='[]' data page ok args
           while :; do
@@ -212,7 +213,7 @@ runs:
           printf '%s' "$agg"
         }
 
-        # REST authority for one PR: prints "<merged> <merge_commit_sha>" (the search index lags).
+        # REST authority for one PR, which the search index lags: prints "<merged> <merge_commit_sha>".
         rest_pr_merge() { # $1=owner/repo $2=number
           local data
           for attempt in 1 2 3; do
@@ -224,12 +225,12 @@ runs:
           printf 'rest_pr_merge failed for %s#%s\n' "$1" "$2" >&2; return 1
         }
 
-        # Newest release tag of a repo, honoring the sub-dir Go-module prefix (<dir>/vX.Y.Z). Retries a
-        # transient read (a swallowed error must NOT look like a first-release repo — that would
-        # double-release on a live resume): prints "__ERR__" on hard failure (caller aborts the repo),
-        # empty on a genuine no-tags repo. NOTE: `sort -V` over mixed namespaces is correct for the
-        # single go.mod release-core enforces; a repo that RELOCATED its module (both `v*` and `dir/v*`
-        # present) could pick the wrong namespace — a documented limitation, not reachable today.
+        # Newest release tag of a repo, honoring the sub-dir Go-module prefix (<dir>/vX.Y.Z). A
+        # transient read is retried and a hard failure prints "__ERR__", on which the caller aborts
+        # that repo: a swallowed error would look like a first-release repo and double-release on a
+        # live resume. A genuine no-tags repo prints empty. `sort -V` over mixed namespaces is correct
+        # for the single go.mod release-core enforces; a repo that relocated its module, carrying both
+        # `v*` and `dir/v*`, could pick the wrong namespace.
         latest_tag() { # $1=owner/repo
           local refs
           for attempt in 1 2 3; do
@@ -242,8 +243,9 @@ runs:
           printf '__ERR__'
         }
 
-        # Does <tag> contain <merge_sha>? compare base=merge_sha head=tag: ahead|identical = the tag is
-        # at/after the merge, i.e. the sibling shipped in it. Retries; returns 2 on a hard read error.
+        # Does <tag> contain <merge_sha>? Compare with base=merge_sha and head=tag: `ahead` or
+        # `identical` puts the tag at or after the merge, so the sibling shipped in it. Retries, and
+        # returns 2 on a hard read error.
         tag_contains() { # $1=owner/repo $2=tag $3=merge_sha
           local st
           for attempt in 1 2 3; do
@@ -255,10 +257,10 @@ runs:
           return 2
         }
 
-        # Does a PUBLISHED GitHub Release exist for <tag>? (A tag-only botched cut has none.) Retries all
-        # failures 3× (can't cheaply distinguish a definitive 404 from a transient error over --silent);
-        # any persistent failure returns 1 → fail-closed to "botched", which is loud and self-heals on
-        # a re-dispatch, so a transient blip at worst costs one extra loud-and-recoverable cycle.
+        # Does a published GitHub Release exist for <tag>? A tag-only botched cut has none. Every
+        # failure is retried three times, since `--silent` does not cheaply distinguish a definitive
+        # 404 from a transient error, and a persistent failure returns 1, failing closed to "botched".
+        # That is loud and self-heals on a re-dispatch, so a transient blip costs one extra cycle.
         release_exists() { # $1=owner/repo $2=tag
           for attempt in 1 2 3; do
             if gh api "repos/$1/releases/tags/$2" --silent >/dev/null 2>&1; then return 0; fi
@@ -267,11 +269,12 @@ runs:
           return 1
         }
 
-        # Derive the semver bump for a repo from its commit range since the last tag (this is what the
-        # release cuts — everything on the default branch since the last tag, not only the Epic's
-        # commits). Highest-wins: `!`/BREAKING footer → major; any feat → minor; else patch. Empty range
-        # → "none" (skip). Subject-line scan for feat/`!` (a body line starting `feat:` is not a type);
-        # full-body scan for the BREAKING-CHANGE footer. Uses the compare API (no checkout).
+        # Derive the semver bump for a repo from its commit range since the last tag, which is what
+        # the release cuts: everything on the default branch since that tag, wider than the Epic's own
+        # commits. Highest wins — a `!` or BREAKING footer gives major, any feat gives minor, else
+        # patch — and an empty range gives "none", which skips the repo. feat and `!` are read from
+        # subject lines, since a body line starting `feat:` is not a type, while the BREAKING-CHANGE
+        # footer is read from the full body. The compare API supplies both, so there is no checkout.
         commit_messages() { # $1=api path  $2=jq filter  $3=paginate(true|false)
           local out attempt
           for attempt in 1 2 3; do
@@ -288,20 +291,20 @@ runs:
         derive_bump() { # $1=owner/repo $2=last_tag ("" = first release) $3=default_branch
           local repo="$1" last="$2" head="$3" subjects bodies path paginate jq_bodies jq_subjects
           if [ -z "$last" ]; then
-            # First release: scan the recent default-branch history; default minor if quiet. Not
-            # paginated — answering "is there anything here" does not need the whole history.
+            # First release: scan the recent default-branch history, defaulting to minor when quiet.
+            # Unpaginated, since "is there anything here" does not need the whole history.
             path="repos/$repo/commits"; paginate=false
             jq_bodies='.[].commit.message'; jq_subjects='.[].commit.message | split("\n")[0]'
           else
             # Paginated: the compare API pages its commit list, and a feat past the first page would
-            # otherwise be invisible — shipping a minor as a patch.
+            # be invisible, shipping a minor as a patch.
             path="repos/$repo/compare/${last}...${head}"; paginate=true
             jq_bodies='.commits[].commit.message'; jq_subjects='.commits[].commit.message | split("\n")[0]'
           fi
-          # Fail-closed, like latest_tag and tag_contains. A read that failed is not an empty range;
-          # collapsing the two onto one value let a transient API error read as "nothing to release",
-          # so the repo was skipped, recorded as nochange, and the run stayed green — and because
-          # nothing recorded a failure, a re-dispatch recomputed the same skip forever.
+          # Fail closed, as latest_tag and tag_contains do. A failed read is not an empty range:
+          # collapsing the two onto one value makes a transient API error read as "nothing to
+          # release", so the repo is skipped and recorded as nochange while the run stays green, and
+          # with no failure recorded a re-dispatch recomputes the same skip.
           if ! bodies=$(commit_messages "$path" "$jq_bodies" "$paginate") \
             || ! subjects=$(commit_messages "$path" "$jq_subjects" "$paginate"); then
             printf '__ERR__'; return 0
@@ -317,11 +320,11 @@ runs:
           fi
         }
 
-        # Dispatch a repo's release.yaml and return the created run id. return_run_details gives the run
-        # id directly (GA 2026-02-19); on the older 204 answer, correlate by the App-bot actor + a
-        # created>= filter with a 60s skew margin (runner clock may lead GitHub's server time). Inputs
-        # are passed as STRINGS (the dispatches API takes string input values regardless of the input's
-        # declared type; release.yaml/`release-core` compare the string).
+        # Dispatch a repo's release.yaml and return the created run id. return_run_details gives that
+        # id directly; on the older 204 answer, correlate by the App-bot actor and a created>= filter
+        # with a 60s skew margin, since the runner clock may lead GitHub's server time. Inputs travel
+        # as strings, which is what the dispatches API takes whatever an input's declared type, and
+        # release.yaml and release-core compare the string.
         dispatch_release() { # $1=owner/repo $2=default_branch $3=release_type $4=run_dry(true|false) $5=since_ts
           local repo="$1" ref="$2" rt="$3" rdry="$4" ts="$5" body resp run_id enc
           body=$(jq -n --arg ref "$ref" --arg rt "$rt" --arg dry "$rdry" \
@@ -343,10 +346,10 @@ runs:
           printf '%s' "$run_id"
         }
 
-        # Poll a run to completion. Prints its conclusion (success/failure/…), or "blocked" if it parks
-        # at the protected `release` environment approval gate (`waiting`) — a fully-autonomous train
-        # needs the bot allowed as an approver, so surface it rather than hang; a blocked run is PENDING
-        # (may still complete on approval), never a hard failure.
+        # Poll a run to completion. Prints its conclusion, or "blocked" when it parks at the protected
+        # `release` environment approval gate in `waiting`: a fully-autonomous train needs the bot
+        # allowed as an approver, so the state is surfaced rather than waited out. A blocked run is
+        # pending and may still complete on approval, so it is not a hard failure.
         poll_run() { # $1=owner/repo $2=run_id
           local repo="$1" run_id="$2" i st cc
           for i in $(seq 1 180); do   # ~30 min cap at 10s (release-core can go install + build on a cold runner)
@@ -370,19 +373,19 @@ runs:
             | sed 's|refs/tags/||' | grep -E '(^|/)v[0-9]' | sort -u || true
         }
 
-        # Splice a marker-delimited region into the Epic body (render-epic-status discipline): exactly
-        # one balanced START/END pair → replace the region in place (markers + old content); otherwise
-        # strip any stray marker LINES and append one fresh region — a hand-edit can never drop the
-        # human prose, and stale content never accumulates. Prints the new body.
+        # Splice a marker-delimited region into the Epic body. Exactly one balanced START/END pair
+        # replaces the region in place, markers and old content together; anything else strips any
+        # stray marker lines and appends one fresh region, so a hand-edit never drops human prose and
+        # stale content never accumulates. Prints the new body.
         splice_body() { # $1=current body   $2=new region (incl. its markers)
           local body="$1" block="$2" s='<!-- release-train:receipts:start -->' e='<!-- release-train:receipts:end -->' ns ne sl el
           ns=$(printf '%s\n' "$body" | grep -cxF "$s" || true)
           ne=$(printf '%s\n' "$body" | grep -cxF "$e" || true)
           sl=$(printf '%s\n' "$body" | grep -nxF "$s" | head -1 | cut -d: -f1)
           el=$(printf '%s\n' "$body" | grep -nxF "$e" | head -1 | cut -d: -f1)
-          # In-place replace ONLY for a well-formed single pair with START before END (render-epic-status
-          # discipline) — an END-before-START hand-edit must fall through to strip+append, never eat prose.
-          # BLK via the environment (ENVIRON), not -v, so awk does not interpret backslash escapes.
+          # Replace in place only for a well-formed single pair with START before END; an
+          # END-before-START hand-edit falls through to strip-and-append rather than eating prose.
+          # BLK arrives through the environment (ENVIRON) so awk does not interpret backslash escapes.
           if [ "$ns" = "1" ] && [ "$ne" = "1" ] && [ -n "$sl" ] && [ -n "$el" ] && [ "$sl" -lt "$el" ]; then
             printf '%s\n' "$body" | BLK="$block" awk -v s="$s" -v e="$e" '
               $0==s { print ENVIRON["BLK"]; skip=1; next } $0==e { skip=0; next } !skip { print }'
@@ -398,9 +401,9 @@ runs:
         if ! cands=$(search_prs "is:pr is:merged label:\"epic:${EPIC}\" org:${ORG}"); then
           echo "::error::could not reconstruct the Epic (GraphQL search failed after retries)"; exit 1
         fi
-        # One row per repo, anchored on the NEWEST-merged sibling (max mergedAt): if the tag contains the
-        # newest epic commit it contains them all (they share a base under the atomic-Epic invariant), so
-        # a later sibling can't be masked by an earlier one.
+        # One row per repo, anchored on the newest-merged sibling by mergedAt: a tag containing the
+        # newest Epic commit contains them all, since they share a base under the atomic-landing
+        # invariant, so an earlier sibling cannot mask a later one.
         newest=$(printf '%s' "$cands" | jq -c '
           group_by(.repository.nameWithOwner)
           | map(max_by(.mergedAt) | {repo: .repository.nameWithOwner, number: .number})')
@@ -430,7 +433,7 @@ runs:
           repo=$(printf '%s' "$ledger" | jq -r ".[$i].repo")
           merge_sha=$(printf '%s' "$ledger" | jq -r ".[$i].sha")
 
-          # Resolve the default branch ONCE (retry; fail-closed — never guess a wrong ref).
+          # Resolve the default branch once, with retries, and fail closed rather than guess a ref.
           default_branch=""
           for attempt in 1 2 3; do
             default_branch=$(gh api "repos/$repo" --jq '.default_branch' 2>/dev/null || echo "")
@@ -442,7 +445,7 @@ runs:
             echo "- ❌ **${repo}** — could not read the default branch; skipping." | tee -a "$GITHUB_STEP_SUMMARY"; continue
           fi
 
-          # -- Ship-state of THIS Epic's merge, from LIVE tags (never the receipt) -------------------
+          # -- Ship-state of this Epic's merge, read from live tags ----------------------------------
           last=$(latest_tag "$repo")
           if [ "$last" = "__ERR__" ]; then
             had_failure=true
@@ -450,9 +453,9 @@ runs:
             echo "- ❌ **${repo}** — tag read failed after retries; skipping (fail-closed, never assume first-release)." | tee -a "$GITHUB_STEP_SUMMARY"; continue
           fi
           if [ -n "$last" ]; then
-            # Capture via `|| tc=$?` — a bare `tag_contains ...; tc=$?` would let the function's
-            # non-zero return (1 = not-yet-shipped, the normal case; 2 = read error) trip `set -e` and
-            # abort the whole action before tc is read. The `||` list suspends set -e through the call.
+            # Capture via `|| tc=$?`: the `||` list suspends set -e through the call. A bare
+            # `tag_contains ...; tc=$?` would let the function's non-zero return — 1 for the ordinary
+            # not-yet-shipped case, 2 for a read error — abort the action before tc is read.
             tc=0; tag_contains "$repo" "$last" "$merge_sha" || tc=$?
             if [ "$tc" -eq 2 ]; then
               had_failure=true
@@ -465,10 +468,11 @@ runs:
                 receipts=$(jq -cn --argjson a "$receipts" --arg r "$repo" --arg t "$last" '$a + [{repo:$r, tag:$t, status:"skipped"}]')
                 continue
               fi
-              # BOTCHED: tag exists at/after the merge but has NO published Release (release-core failed
-              # between tag-push and release-create). The orchestrator can't create the Release (no
-              # contents:write, by design), and re-cutting would produce a HIGHER tag orphaning this one
-              # — so fail loud for manual repair (publish the Release for `$last`, or delete the tag to re-cut).
+              # A botched cut: the tag sits at or after the merge but has no published Release, so
+              # release-core failed between pushing the tag and creating it. The orchestrator holds no
+              # contents:write and cannot create the Release, and re-cutting would produce a higher
+              # tag that orphans this one, so fail loudly for manual repair — publish the Release for
+              # `$last`, or delete the tag to let a re-dispatch re-cut it.
               had_failure=true
               receipts=$(jq -cn --argjson a "$receipts" --arg r "$repo" --arg t "$last" '$a + [{repo:$r, tag:$t, status:"botched"}]')
               echo "::error::${repo} — tag \`${last}\` exists (contains the Epic merge) but has NO published Release — a botched cut. Publish the Release for \`${last}\`, or delete the tag to let a re-dispatch re-cut it. Not skipping, not re-cutting." | tee -a "$GITHUB_STEP_SUMMARY"
@@ -524,8 +528,8 @@ runs:
           fi
           concl=$(poll_run "$repo" "$rid")
           if [ "$concl" = "blocked" ]; then
-            # PENDING, not failed: the run may still cut the tag on approval. Do NOT re-dispatch on
-            # resume until it clears (a fresh dispatch would double-release once approved).
+            # Pending rather than failed: the run may still cut the tag on approval, so a resume
+            # waits for it to clear — a fresh dispatch would double-release once approved.
             receipts=$(jq -cn --argjson a "$receipts" --arg r "$repo" '$a + [{repo:$r, tag:null, status:"parked"}]')
             had_failure=true
             echo "- ⏸️  **${repo}** — live release parked at the release-env approval gate (pending). Approve the run, then re-dispatch to record the receipt." | tee -a "$GITHUB_STEP_SUMMARY"; continue
@@ -541,10 +545,10 @@ runs:
             echo "- ✅ **${repo}** — released \`${newtag}\` (${bump})." | tee -a "$GITHUB_STEP_SUMMARY"
             receipts=$(jq -cn --argjson a "$receipts" --arg r "$repo" --arg t "$newtag" '$a + [{repo:$r, tag:$t, status:"shipped"}]')
           elif [ "$concl" = "success" ]; then
-            # Ran clean but the new tag isn't visible yet (ref-index lag) — the run succeeded, so a tag
-            # WAS cut; record success with a null tag and let resume confirm it from live tags (it
-            # self-heals; never double-releases). (Gating on the run conclusion alone — NOT on the OLD
-            # tag's Release, which is absent for a first-release repo.)
+            # Ran clean but the new tag is not visible yet, the ref index lagging. The run succeeded,
+            # so a tag was cut: record success with a null tag and let resume confirm it from live
+            # tags, which self-heals without double-releasing. The gate is the run conclusion alone,
+            # since a first-release repo has no old tag whose Release could be checked.
             echo "- ✅ **${repo}** — release ${bump} ran clean (new tag not yet visible; resume will confirm)." | tee -a "$GITHUB_STEP_SUMMARY"
             receipts=$(jq -cn --argjson a "$receipts" --arg r "$repo" '$a + [{repo:$r, tag:null, status:"shipped"}]')
           else
@@ -569,17 +573,17 @@ runs:
         if [ "$dry" = "false" ]; then
           block=$(printf '<!-- release-train:receipts:start -->\n### 🚂 Release train — epic:#%s (%s)\n%s\n<!-- release-train:receipts:end -->' \
             "$EPIC" "$(date -u +%Y-%m-%dT%H:%MZ)" "$table")
-          # Abort the write when the read that feeds it failed, as merge-gate and render-epic-status
-          # already do. `|| echo ""` here mapped a failed read onto an empty body, splice_body turned
-          # that into a body holding only the receipt block, and the PATCH then SUCCEEDED — so the
-          # error path never fired while the Epic's prose and its frozen activation snapshot were
-          # overwritten. That snapshot is what epic-membership, merge-gate and detect-partial-landing
-          # read, so losing it degrades the whole landing saga back to live-label membership.
+          # Abort the write when the read that feeds it failed. Mapping a failed read onto an empty
+          # body would make splice_body return a body holding only the receipt block, and the PATCH
+          # would succeed, overwriting the Epic's prose and its frozen activation snapshot without
+          # ever reaching the error path. That snapshot is what epic-membership, merge-gate and
+          # detect-partial-landing read, so losing it degrades the whole landing saga back to
+          # live-label membership.
           #
-          # An empty body read successfully is a different thing and still splices normally; only the
-          # exit status distinguishes them, which is why the guard is on the status and not on "$cur".
-          # The receipts are a best-effort audit — the same table is already in the run summary — so
-          # declining to write is strictly safer than writing one derived from a failure.
+          # A body that reads successfully as empty is a different thing and still splices normally.
+          # Only the exit status separates the two, which is why the guard reads the status rather
+          # than "$cur". The receipts are a best-effort audit and the same table is already in the run
+          # summary, so declining to write costs nothing.
           if ! cur=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' 2>/dev/null); then
             echo "::warning::could not read epic:#${EPIC} — leaving its body untouched; the receipt table is in the run summary."
           else

--- a/generic-actions/release-train/action.yaml
+++ b/generic-actions/release-train/action.yaml
@@ -227,8 +227,8 @@ runs:
 
         # Newest release tag of a repo, honoring the sub-dir Go-module prefix (<dir>/vX.Y.Z). A
         # transient read is retried and a hard failure prints "__ERR__", on which the caller aborts
-        # that repo: a swallowed error would look like a first-release repo and double-release on a
-        # live resume. A genuine no-tags repo prints empty. `sort -V` over mixed namespaces is correct
+        # that repo: a swallowed error looks like a first-release repo and double-releases on a live
+        # resume. A genuine no-tags repo prints empty. `sort -V` over mixed namespaces is correct
         # for the single go.mod release-core enforces; a repo that relocated its module, carrying both
         # `v*` and `dir/v*`, could pick the wrong namespace.
         latest_tag() { # $1=owner/repo
@@ -348,8 +348,8 @@ runs:
 
         # Poll a run to completion. Prints its conclusion, or "blocked" when it parks at the protected
         # `release` environment approval gate in `waiting`: a fully-autonomous train needs the bot
-        # allowed as an approver, so the state is surfaced rather than waited out. A blocked run is
-        # pending and may still complete on approval, so it is not a hard failure.
+        # allowed as an approver, so the state is surfaced to the operator. A blocked run is pending
+        # and may still complete on approval, so it is not a hard failure.
         poll_run() { # $1=owner/repo $2=run_id
           local repo="$1" run_id="$2" i st cc
           for i in $(seq 1 180); do   # ~30 min cap at 10s (release-core can go install + build on a cold runner)
@@ -384,7 +384,7 @@ runs:
           sl=$(printf '%s\n' "$body" | grep -nxF "$s" | head -1 | cut -d: -f1)
           el=$(printf '%s\n' "$body" | grep -nxF "$e" | head -1 | cut -d: -f1)
           # Replace in place only for a well-formed single pair with START before END; an
-          # END-before-START hand-edit falls through to strip-and-append rather than eating prose.
+          # END-before-START hand-edit falls through to strip-and-append, which leaves prose intact.
           # BLK arrives through the environment (ENVIRON) so awk does not interpret backslash escapes.
           if [ "$ns" = "1" ] && [ "$ne" = "1" ] && [ -n "$sl" ] && [ -n "$el" ] && [ "$sl" -lt "$el" ]; then
             printf '%s\n' "$body" | BLK="$block" awk -v s="$s" -v e="$e" '
@@ -433,7 +433,7 @@ runs:
           repo=$(printf '%s' "$ledger" | jq -r ".[$i].repo")
           merge_sha=$(printf '%s' "$ledger" | jq -r ".[$i].sha")
 
-          # Resolve the default branch once, with retries, and fail closed rather than guess a ref.
+          # Resolve the default branch once, with retries, and fail closed on an unresolved ref.
           default_branch=""
           for attempt in 1 2 3; do
             default_branch=$(gh api "repos/$repo" --jq '.default_branch' 2>/dev/null || echo "")
@@ -453,9 +453,9 @@ runs:
             echo "- ❌ **${repo}** — tag read failed after retries; skipping (fail-closed, never assume first-release)." | tee -a "$GITHUB_STEP_SUMMARY"; continue
           fi
           if [ -n "$last" ]; then
-            # Capture via `|| tc=$?`: the `||` list suspends set -e through the call. A bare
-            # `tag_contains ...; tc=$?` would let the function's non-zero return — 1 for the ordinary
-            # not-yet-shipped case, 2 for a read error — abort the action before tc is read.
+            # Capture via `|| tc=$?`: the `||` list suspends set -e through the call. The function
+            # returns non-zero on ordinary outcomes too — 1 for the not-yet-shipped case, 2 for a read
+            # error — and under `set -e` that aborts the action before tc is read.
             tc=0; tag_contains "$repo" "$last" "$merge_sha" || tc=$?
             if [ "$tc" -eq 2 ]; then
               had_failure=true
@@ -470,9 +470,9 @@ runs:
               fi
               # A botched cut: the tag sits at or after the merge but has no published Release, so
               # release-core failed between pushing the tag and creating it. The orchestrator holds no
-              # contents:write and cannot create the Release, and re-cutting would produce a higher
-              # tag that orphans this one, so fail loudly for manual repair — publish the Release for
-              # `$last`, or delete the tag to let a re-dispatch re-cut it.
+              # contents:write and cannot create the Release, and a re-cut produces a higher tag that
+              # orphans this one, so fail loudly for manual repair — publish the Release for `$last`,
+              # or delete the tag to let a re-dispatch re-cut it.
               had_failure=true
               receipts=$(jq -cn --argjson a "$receipts" --arg r "$repo" --arg t "$last" '$a + [{repo:$r, tag:$t, status:"botched"}]')
               echo "::error::${repo} — tag \`${last}\` exists (contains the Epic merge) but has NO published Release — a botched cut. Publish the Release for \`${last}\`, or delete the tag to let a re-dispatch re-cut it. Not skipping, not re-cutting." | tee -a "$GITHUB_STEP_SUMMARY"
@@ -528,8 +528,8 @@ runs:
           fi
           concl=$(poll_run "$repo" "$rid")
           if [ "$concl" = "blocked" ]; then
-            # Pending rather than failed: the run may still cut the tag on approval, so a resume
-            # waits for it to clear — a fresh dispatch would double-release once approved.
+            # Recorded as pending: the run may still cut the tag on approval, so a resume waits for
+            # it to clear. A fresh dispatch double-releases once the parked run is approved.
             receipts=$(jq -cn --argjson a "$receipts" --arg r "$repo" '$a + [{repo:$r, tag:null, status:"parked"}]')
             had_failure=true
             echo "- ⏸️  **${repo}** — live release parked at the release-env approval gate (pending). Approve the run, then re-dispatch to record the receipt." | tee -a "$GITHUB_STEP_SUMMARY"; continue
@@ -573,10 +573,10 @@ runs:
         if [ "$dry" = "false" ]; then
           block=$(printf '<!-- release-train:receipts:start -->\n### 🚂 Release train — epic:#%s (%s)\n%s\n<!-- release-train:receipts:end -->' \
             "$EPIC" "$(date -u +%Y-%m-%dT%H:%MZ)" "$table")
-          # Abort the write when the read that feeds it failed. Mapping a failed read onto an empty
-          # body would make splice_body return a body holding only the receipt block, and the PATCH
-          # would succeed, overwriting the Epic's prose and its frozen activation snapshot without
-          # ever reaching the error path. That snapshot is what epic-membership, merge-gate and
+          # Abort the write when the read that feeds it failed. A failed read mapped onto an empty
+          # body makes splice_body return a body holding only the receipt block, and the PATCH then
+          # succeeds, overwriting the Epic's prose and its frozen activation snapshot without ever
+          # reaching the error path. That snapshot is what epic-membership, merge-gate and
           # detect-partial-landing read, so losing it degrades the whole landing saga back to
           # live-label membership.
           #

--- a/generic-actions/render-epic-status/action.yaml
+++ b/generic-actions/render-epic-status/action.yaml
@@ -78,10 +78,10 @@ inputs:
 runs:
   using: composite
   steps:
-    # One org-wide token, three scopes: the sibling search spans the whole org (the single-repo
-    # GITHUB_TOKEN can't see it), editing the Epic body needs issues:write (⊇ read, to read the body
-    # first), and the release-tag matching-refs + compare reads need contents:read. Narrower than any
-    # sibling recovery action — no checks, no contents:write, no org-projects.
+    # One org-wide token with three scopes: the sibling search spans the whole org, which the
+    # single-repo GITHUB_TOKEN cannot see; editing the Epic body needs issues:write, which also
+    # covers reading the body first; and the release-tag matching-refs and compare reads need
+    # contents:read.
     - name: Mint token
       id: token
       uses: actions/create-github-app-token@v3
@@ -105,15 +105,10 @@ runs:
       run: |
         set -euo pipefail
 
-        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
-        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
-        # engages. When engaged, render nothing (no Epic-body edits); the guard and the render share
-        # THIS one step, so the exit is sufficient. Display-only, so a skipped render is cosmetic and
-        # the next sweep re-derives once the switch is lifted.
-        # The issues:write token is minted above, ahead of this guard, on purpose: nothing past the
-        # `exit 0` exercises it, so mint-vs-halt ordering is not blast radius here (token SCOPE, not
-        # mint timing, is the enforced bound) — and every action keeps one "mint per least-privilege,
-        # then halt-first" shape instead of duplicating this fail-safe parse pre-mint.
+        # Org-level halt, read before the render. Fail-safe: running only for an explicit off-token
+        # (empty/unset, 0, off, false, no, disabled); any other value engages the halt and nothing is
+        # rendered. The guard and the render share this one step, so the exit is enough. The render is
+        # display-only, so a skipped one is cosmetic and the next sweep re-derives.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)
@@ -123,9 +118,9 @@ runs:
         esac
 
         # ---- Validate the untrusted inputs before they reach a search grammar or a date argument.
-        # org feeds `org:<ORG>` search qualifiers — require GitHub-login chars so a stray value can't
-        # broaden the scope or break the query. planning_repo becomes an API path component. lookback
-        # feeds `date`; reject anything non-numeric.
+        # org feeds `org:<ORG>` search qualifiers, so require GitHub-login characters: a stray value
+        # would broaden the scope or break the query. planning_repo becomes an API path component,
+        # and lookback feeds `date`.
         if ! [[ "${ORG:-}" =~ ^[A-Za-z0-9-]+$ ]]; then
           echo "::error::org must be a valid GitHub login (alphanumeric + hyphens), got \"${ORG:-}\""
           exit 1
@@ -139,21 +134,20 @@ runs:
           exit 1
         fi
 
-        # dry_run defaults on; only the literal "false" (any case) writes. Lowercase via tr
-        # (portable), not ${VAR,,} (bash-4 only).
+        # dry_run defaults on; only the literal "false" (any case) writes. `tr` lowercases because
+        # ${VAR,,} is a Bash 4+ expansion.
         dry=$(printf '%s' "${DRY_RUN:-true}" | tr '[:upper:]' '[:lower:]')
 
-        # Markers delimiting the managed region. Everything outside them in the Epic body is a human's
-        # to write and is preserved; only the bytes between them are regenerated.
+        # Markers delimiting the managed region. Everything outside them in the Epic body belongs to
+        # a human and is preserved; only the bytes between them are regenerated.
         START='<!-- epic-read-model:start -->'
         END='<!-- epic-read-model:end -->'
 
         # ---- Shared GraphQL document + read helpers --------------------------------------------
 
-        # PR search node — detect-partial-landing's SEARCH_Q extended with `mergeCommit{oid}` and
-        # `reviewDecision` for the display fold. `labels` drives Epic enumeration; the rest drive the
-        # per-sibling state + released columns. (No `state` field: the fold classifies by search
-        # bucket — open / merged / closed-unmerged — not by the PR's own state.)
+        # PR search node. `labels` drives Epic enumeration, while `mergeCommit{oid}` and
+        # `reviewDecision` drive the per-sibling state and released columns. There is no `state`
+        # field: the fold classifies by search bucket — open, merged, closed-unmerged.
         SEARCH_Q='query($q:String!,$cursor:String){
           search(query:$q, type:ISSUE, first:100, after:$cursor){
             pageInfo{ hasNextPage endCursor }
@@ -191,12 +185,12 @@ runs:
           printf '%s' "$agg"
         }
 
-        # Highest-semver `v*` tag of a repo (its latest release), or empty if it has none. Only the
-        # tag NAME is needed — compare resolves it to a commit — so annotated vs lightweight doesn't
-        # matter. `--paginate` + a jq slurp aggregate ALL pages of matching refs before taking the max,
-        # so a repo with >30 `v*` tags isn't mis-read as unreleased (the endpoint pages at 30). A read
-        # error yields empty (that repo's merged siblings just show as unreleased), never an abort:
-        # this is display-only.
+        # Highest-semver `v*` tag of a repo, its latest release, or empty when it has none. Only the
+        # tag name is needed, since compare resolves it to a commit, so annotated and lightweight tags
+        # behave alike. `--paginate` and a jq slurp aggregate every page of matching refs before
+        # taking the max, so a repo with more than the endpoint's 30 `v*` tags is not read as
+        # unreleased. A read error yields empty, showing that repo's merged siblings as unreleased,
+        # since this is display-only.
         latest_tag() { # $1 = owner/repo
           local repo="$1" data
           for attempt in 1 2 3; do
@@ -216,10 +210,10 @@ runs:
           printf ''
         }
 
-        # Whether a release tag contains a merge commit: compare with the merge SHA as base and the tag
-        # as head — `ahead` (merge is an ancestor of the tag) or `identical` (they are the same commit)
-        # means the tag shipped that merge. Prints "yes" / "no"; an error or a missing SHA is "no"
-        # (unreleased), never an abort.
+        # Whether a release tag contains a merge commit: compare with the merge SHA as base and the
+        # tag as head. `ahead` means the merge is an ancestor of the tag and `identical` means they
+        # are the same commit; either way the tag shipped that merge. Prints "yes" or "no"; an error
+        # or a missing SHA reads as "no", i.e. unreleased.
         tag_contains() { # $1=owner/repo $2=merge-sha $3=tag
           local repo="$1" sha="$2" tag="$3" data status
           [ -n "$sha" ] && [ "$sha" != "null" ] || { printf 'no'; return 0; }
@@ -238,32 +232,31 @@ runs:
         }
 
         # Drop the volatile "_Rendered … " stamp line and all blank lines from stdin, so
-        # compare-before-write sees only material content and a fresh timestamp alone never counts as
-        # a change (which would edit-spam every Epic each sweep).
+        # compare-before-write sees only material content and a fresh timestamp on its own never
+        # counts as a change, which would edit-spam every Epic each sweep.
         strip_volatile() {
           grep -v '^_Rendered ' | sed '/^[[:space:]]*$/d' || true
         }
 
-        # Replace the managed region in an Epic body with a freshly rendered one, preserving everything
-        # the humans wrote outside the markers. The invariant is absolute: a hand-edit that leaves an
-        # unbalanced or duplicated marker must NEVER cause human prose to be dropped.
+        # Replace the managed region in an Epic body with a freshly rendered one, keeping everything
+        # the humans wrote outside the markers. A hand-edit that leaves an unbalanced or duplicated
+        # marker never causes human prose to be dropped:
         #
-        #   - Exactly one START then one END → rewrite that single region in place.
-        #   - Anything else (fresh Epic with no markers, a lone/orphaned START or END, a DUPLICATE
-        #     marker, or END-before-START — all things a hand-edit can leave) → strip every marker
-        #     line, THEN append one fresh region after a blank line. Repairing to a single balanced
-        #     pair is what guarantees the next sweep's in-place path applies, so a malformed marker
-        #     can never make a later sweep skip (drop) the human text around it.
+        #   - Exactly one START then one END rewrites that single region in place.
+        #   - Anything else — a fresh Epic with no markers, an orphaned START or END, a duplicate
+        #     marker, an END before a START — strips every marker line, then appends one fresh region
+        #     after a blank line. Repairing to a single balanced pair is what guarantees the next
+        #     sweep's in-place path applies.
         #
-        # Whole-line marker matching throughout (grep -x, awk $0==) so a marker embedded inline in prose
-        # is treated as prose, not a managed boundary. Prints the new body.
+        # Markers match whole lines throughout (grep -x, awk $0==), so a marker embedded inline in
+        # prose stays prose. Prints the new body.
         splice() { # $1 = body file, $2 = region file (already wrapped in the markers)
           local bodyf="$1" regionf="$2" ns ne sl el wellformed=false
-          # Well-formed = EXACTLY one START, EXACTLY one END, START before END → replace in place.
-          # Anything else (none, duplicate, orphaned, or END-before-START a hand-edit left) → strip
-          # ALL marker lines and append one fresh region. Gating on well-formedness (not mere
-          # existence) is what stops an unclosed trailing START from making awk swallow the human
-          # text after it — the strip-and-append path only ever removes marker LINES, never prose.
+          # Well-formed means exactly one START, exactly one END, START before END, which replaces in
+          # place; anything else strips all marker lines and appends one fresh region. Gating on
+          # well-formedness rather than mere existence is what stops an unclosed trailing START from
+          # making awk swallow the human text after it, since the strip-and-append path only ever
+          # removes marker lines.
           ns=$(grep -cxF -- "$START" "$bodyf" || true)
           ne=$(grep -cxF -- "$END" "$bodyf" || true)
           if [ "$ns" = "1" ] && [ "$ne" = "1" ]; then
@@ -306,12 +299,12 @@ runs:
         # ---- Render one Epic --------------------------------------------------------------------
 
         # Called under `||` from the loop, so `set -e` is inactive here: every failure path returns 0
-        # after a warning and the next sweep re-derives — a display render never fails the sweep.
+        # after a warning and the next sweep re-derives, and a display render never fails the sweep.
         render_epic() { # $1 = Epic number (validated numeric)
           local epic="$1"
 
-          # The Epic issue itself. Not found (deleted / wrong planning repo) or already closed → leave
-          # it alone: a wrapped-up Epic stops churning, and there is nothing to render into a ghost.
+          # The Epic issue itself. An issue that is missing — deleted, or in another planning repo —
+          # or already closed is left alone, so a wrapped-up Epic stops churning.
           local issue state body
           if ! issue=$(gh issue view "$epic" --repo "${ORG}/${PLANNING_REPO}" --json state,body 2>/dev/null); then
             echo "::warning::Epic ${ORG}/${PLANNING_REPO}#${epic} not found — skipping (display-only)." | tee -a "$GITHUB_STEP_SUMMARY"
@@ -323,11 +316,11 @@ runs:
             return 0
           fi
           # GitHub stores bodies with CRLF; normalize to LF so the marker match and the compare are
-          # line-ending agnostic (and the write settles on LF).
+          # line-ending agnostic, and the write settles on LF.
           body=$(printf '%s' "$issue" | jq -r '.body // ""' | tr -d '\r')
 
-          # Full member set (not lookback-bounded — an Epic's older merged siblings must still appear),
-          # each tagged with the bucket it came from and sorted stably by repo then number.
+          # The full member set, unbounded by the lookback window so an Epic's older merged siblings
+          # still appear, each tagged with the bucket it came from and sorted by repo then number.
           local base_q open merged closed members
           base_q="label:\"epic:${epic}\" org:${ORG}"
           if ! open=$(search_prs "is:pr is:open $base_q"); then
@@ -339,9 +332,9 @@ runs:
           if ! closed=$(search_prs "is:pr is:closed is:unmerged $base_q"); then
             echo "::warning::could not resolve closed epic:${epic} members — skipping this sweep." | tee -a "$GITHUB_STEP_SUMMARY"; return 0
           fi
-          # Dedup by (repo, number) before render: a PR that flips state between the three searches (a
-          # race) can surface in two buckets; keep the highest-priority one (merged > closed-unmerged >
-          # open) so a just-merged sibling never lingers as "open". Keys are repo#number.
+          # Dedup by (repo, number) before rendering: a PR that flips state between the three searches
+          # surfaces in two buckets, and keeping the highest-priority one — merged, then
+          # closed-unmerged, then open — stops a just-merged sibling lingering as "open".
           members=$(jq -s '
             def prio: {"merged":0,"closed":1,"open":2}[.bucket];
             ( [.[0][] | . + {bucket:"open"}]
@@ -359,9 +352,9 @@ runs:
             return 0
           fi
 
-          # Released resolution: one latest-tag lookup per repo that has a merged sibling, then one
-          # compare per merged sibling → a repo#number ⇒ release-tag (or "") map. fd 7 isolates this
-          # loop's stdin from the gh calls inside it.
+          # Released resolution: one latest-tag lookup per repo with a merged sibling, then one
+          # compare per merged sibling, yielding a repo#number to release-tag map, empty where
+          # unreleased. fd 7 isolates this loop's stdin from the gh calls inside it.
           local repo_tags='{}' released='{}' merged_repos r t
           merged_repos=$(printf '%s' "$members" | jq -r '[.[] | select(.bucket=="merged") | .repository.nameWithOwner] | unique | .[]')
           while IFS= read -r r <&7; do
@@ -371,9 +364,9 @@ runs:
           done 7< <(printf '%s\n' "$merged_repos")
 
           local m_repo m_num m_sha m_tag rel
-          # Stream ONLY the merged members once (a single jq scan of $members), tab-separated, into
-          # the loop — avoids the per-index re-parse of the whole array. fd 8 keeps this loop's stdin
-          # free for the tag_contains gh calls inside it.
+          # Stream the merged members into the loop tab-separated from a single jq scan of $members,
+          # which avoids re-parsing the whole array per index. fd 8 keeps this loop's stdin free for
+          # the tag_contains gh calls inside it.
           while IFS=$'\t' read -r m_repo m_num m_sha <&8; do
             m_tag=$(printf '%s' "$repo_tags" | jq -r --arg k "$m_repo" '.[$k] // ""')
             rel=""
@@ -384,8 +377,8 @@ runs:
           done 8< <(printf '%s' "$members" | jq -r '.[] | select(.bucket=="merged")
             | [.repository.nameWithOwner, (.number|tostring), (.mergeCommit.oid // "")] | @tsv')
 
-          # Fold each member into a display row + the summary counts. State is a pure fold over live
-          # fields; SHA is the head (open / closed) or the merge commit (merged), shortened.
+          # Fold each member into a display row and the summary counts. State is a pure fold over live
+          # fields; the SHA is the head for open and closed members, the merge commit for merged ones.
           local rows counts
           rows=$(printf '%s' "$members" | jq -r --argjson rel "$released" '
             .[]
@@ -409,19 +402,19 @@ runs:
             + "\([.[] | select(.bucket=="open")] | length) open · "
             + "\([.[] | select(.bucket=="closed")] | length) closed-unmerged"')
 
-          # The managed region, timestamp included. %s args keep the backticks in $rows literal
-          # (printf never does command substitution), unlike an unquoted heredoc.
+          # The managed region, timestamp included. Passing $rows as a %s argument keeps its backticks
+          # literal, where an unquoted heredoc would run them as command substitution.
           local ts region_inner
           ts=$(date -u '+%Y-%m-%d %H:%M')
           region_inner=$(printf '### Epic status — display-only, derived from live GitHub truth (not authority)\n\n_Rendered %s UTC by the reconcile sweep. A lost or hand-edited table is cosmetic — every decision reads live state._\n\n%s\n\n| Repo | PR | State | SHA | Released |\n|------|----|-------|-----|----------|\n%s' \
             "$ts" "$counts" "$rows")
 
-          # Re-read before deciding anything. The body fetched at the top of this pass is stale by now:
-          # the member searches, tag walks and compares between here and there take seconds to tens of
-          # seconds, and merge-gate writes the activation snapshot into this same body from a matrix of
-          # concurrent jobs. Rewriting the stale copy would carry the whole body back and erase a frozen
-          # member set with a cosmetic table. It has to happen BEFORE the compare too, or the compare
-          # answers about a body nobody is going to write.
+          # Re-read before deciding anything. The body fetched at the top of this pass is stale by
+          # now: the member searches, tag walks and compares take seconds to tens of seconds, and
+          # merge-gate writes the activation snapshot into this same body from a matrix of concurrent
+          # jobs. Rewriting the stale copy would carry the whole body back and erase a frozen member
+          # set with a cosmetic table. The re-read also precedes the compare, which would otherwise
+          # answer about a body nobody is going to write.
           local fresh
           if fresh=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${epic}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
             body="$fresh"
@@ -431,9 +424,9 @@ runs:
             return 0
           fi
 
-          # Compare-before-write: material content already in the body (region between markers, minus
-          # the volatile stamp) vs. the fresh render. Equal → the table is current, so no edit and no
-          # notification.
+          # Compare-before-write: the material content already in the body — the region between the
+          # markers, minus the volatile stamp — against the fresh render. When they match the table is
+          # current, so there is no edit and no notification.
           local new_norm old_inner old_norm
           new_norm=$(printf '%s\n' "$region_inner" | strip_volatile)
           old_inner=$(printf '%s\n' "$body" | awk -v s="$START" -v e="$END" '
@@ -452,9 +445,8 @@ runs:
             return 0
           fi
 
-          # A window remains between the re-read above and this write — narrow now, not closed. If a
-          # snapshot write lands inside it this table wins and the marker is lost; merge-gate's own
-          # verify-and-retry is what recovers that, not anything here.
+          # A narrow window remains between the re-read above and this write. A snapshot write landing
+          # inside it loses to this table, and merge-gate's own verify-and-retry recovers it.
           local region_file body_file spliced_file
           region_file=$(mktemp); body_file=$(mktemp); spliced_file=$(mktemp)
           {
@@ -477,9 +469,9 @@ runs:
 
         echo "## Epic read-model render (org=${ORG}, planning=${PLANNING_REPO}, lookback=${LOOKBACK_DAYS}d, dry_run=${dry})" | tee -a "$GITHUB_STEP_SUMMARY"
 
-        # Fail soft even here: a total org-wide enumeration failure warns and exits 0 — it must never
-        # redden the reconcile sweep (this is a display-only leaf). The next sweep re-derives from live
-        # truth. (Per-Epic errors already warn-and-continue below.)
+        # Fail soft even here: a total org-wide enumeration failure warns and exits 0, so this
+        # display-only leaf never reddens the reconcile sweep, and the next sweep re-derives from live
+        # truth. Per-Epic errors warn and continue below.
         epics=$(enumerate_epics) || {
           echo "::warning::could not enumerate active Epics (GraphQL search failed after retries) — nothing rendered this sweep; next sweep re-derives (display-only, sweep not failed)." | tee -a "$GITHUB_STEP_SUMMARY"
           exit 0

--- a/generic-actions/render-epic-status/action.yaml
+++ b/generic-actions/render-epic-status/action.yaml
@@ -119,7 +119,7 @@ runs:
 
         # ---- Validate the untrusted inputs before they reach a search grammar or a date argument.
         # org feeds `org:<ORG>` search qualifiers, so require GitHub-login characters: a stray value
-        # would broaden the scope or break the query. planning_repo becomes an API path component,
+        # broadens the scope or breaks the query. planning_repo becomes an API path component,
         # and lookback feeds `date`.
         if ! [[ "${ORG:-}" =~ ^[A-Za-z0-9-]+$ ]]; then
           echo "::error::org must be a valid GitHub login (alphanumeric + hyphens), got \"${ORG:-}\""
@@ -233,7 +233,7 @@ runs:
 
         # Drop the volatile "_Rendered … " stamp line and all blank lines from stdin, so
         # compare-before-write sees only material content and a fresh timestamp on its own never
-        # counts as a change, which would edit-spam every Epic each sweep.
+        # counts as a change. Counting one edit-spams every Epic each sweep.
         strip_volatile() {
           grep -v '^_Rendered ' | sed '/^[[:space:]]*$/d' || true
         }
@@ -253,10 +253,9 @@ runs:
         splice() { # $1 = body file, $2 = region file (already wrapped in the markers)
           local bodyf="$1" regionf="$2" ns ne sl el wellformed=false
           # Well-formed means exactly one START, exactly one END, START before END, which replaces in
-          # place; anything else strips all marker lines and appends one fresh region. Gating on
-          # well-formedness rather than mere existence is what stops an unclosed trailing START from
-          # making awk swallow the human text after it, since the strip-and-append path only ever
-          # removes marker lines.
+          # place; anything else strips all marker lines and appends one fresh region. The gate is on
+          # well-formedness, so an unclosed trailing START takes the strip-and-append path, which only
+          # ever removes marker lines and leaves the human text after it intact.
           ns=$(grep -cxF -- "$START" "$bodyf" || true)
           ne=$(grep -cxF -- "$END" "$bodyf" || true)
           if [ "$ns" = "1" ] && [ "$ne" = "1" ]; then
@@ -403,7 +402,7 @@ runs:
             + "\([.[] | select(.bucket=="closed")] | length) closed-unmerged"')
 
           # The managed region, timestamp included. Passing $rows as a %s argument keeps its backticks
-          # literal, where an unquoted heredoc would run them as command substitution.
+          # literal; an unquoted heredoc runs them as command substitution.
           local ts region_inner
           ts=$(date -u '+%Y-%m-%d %H:%M')
           region_inner=$(printf '### Epic status — display-only, derived from live GitHub truth (not authority)\n\n_Rendered %s UTC by the reconcile sweep. A lost or hand-edited table is cosmetic — every decision reads live state._\n\n%s\n\n| Repo | PR | State | SHA | Released |\n|------|----|-------|-----|----------|\n%s' \
@@ -412,9 +411,9 @@ runs:
           # Re-read before deciding anything. The body fetched at the top of this pass is stale by
           # now: the member searches, tag walks and compares take seconds to tens of seconds, and
           # merge-gate writes the activation snapshot into this same body from a matrix of concurrent
-          # jobs. Rewriting the stale copy would carry the whole body back and erase a frozen member
-          # set with a cosmetic table. The re-read also precedes the compare, which would otherwise
-          # answer about a body nobody is going to write.
+          # jobs. Rewriting the stale copy carries the whole body back and erases a frozen member set
+          # with a cosmetic table. The re-read also precedes the compare, so the compare answers about
+          # the body that is actually going to be written.
           local fresh
           if fresh=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${epic}" --jq '.body // ""' 2>/dev/null | tr -d '\r'); then
             body="$fresh"

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -29,29 +29,27 @@ runs:
         token: ${{ steps.app_token.outputs.token }}
         docker-network: ${{ job.container.network }}
       env:
-        # npm post upgrade tasks require the installation of private npm packages, which is
-        # not supported in postUpgradeTasks. This forces the renovate process to run full
-        # installation from the main process (which has access to the correct token), so
-        # all the node modules are available to the post upgrade tasks.
+        # postUpgradeTasks cannot install private npm packages. Running the full install from
+        # the main renovate process, which holds the right token, leaves every node module
+        # in place before those tasks run.
         RENOVATE_SKIP_INSTALLS: false
-        # Default to a tight pnpm allowlist (install / format / dedupe) so the postUpgradeTasks
-        # run without permitting arbitrary `pnpm exec` / `pnpm dlx`. The `( |$)` suffix matches
-        # the command followed by args OR on its own (e.g. bare `pnpm i`). Callers that pass an
-        # empty `allowed_commands` would otherwise silently skip the tasks, leaving unformatted
-        # pnpm-workspace.yaml and stale lockfiles. Callers can still override.
+        # A tight pnpm allowlist by default — install, format, dedupe — so postUpgradeTasks run
+        # without permitting arbitrary `pnpm exec` or `pnpm dlx`. The `( |$)` suffix matches the
+        # command with arguments or on its own, such as a bare `pnpm i`. The default also covers
+        # a caller passing an empty `allowed_commands`, which would skip the tasks and leave an
+        # unformatted pnpm-workspace.yaml and stale lockfiles. Callers can still override it.
         RENOVATE_ALLOWED_COMMANDS: ${{ inputs.allowed_commands || '["^pnpm (install|i|format|dedupe)( |$)"]' }}
         RENOVATE_REPOSITORIES: "['${{ github.repository }}']"
         RENOVATE_PR_HOURLY_LIMIT: 0
         LOG_LEVEL: debug
         RENOVATE_SECRETS: '{"GITHUB_TOKEN": "${{ inputs.github_token }}"}'
-        # Fetch public deps through the CDN-backed module proxy (reliable, cached) and
-        # fall back to direct only when the proxy can't serve a version. Plain "direct"
-        # made `go mod tidy` resolve every dependency from origin, which intermittently
-        # failed on vanity-import hosts (e.g. gonum.org reset the connection mid-fetch),
-        # aborting the tidy and leaving go.sum un-regenerated after a go.mod bump.
-        # GOPRIVATE keeps our own a-novel / a-novel-kit modules off the proxy and sumdb,
-        # so freshly tagged internal versions are fetched straight from GitHub without
-        # waiting for proxy.golang.org to index them.
+        # Fetch public dependencies through the CDN-backed module proxy, falling back to
+        # direct only when the proxy cannot serve a version. Resolving every dependency from
+        # origin makes `go mod tidy` fail intermittently on vanity-import hosts — gonum.org
+        # resets the connection mid-fetch — which aborts the tidy and leaves go.sum
+        # un-regenerated after a go.mod bump. GOPRIVATE keeps the a-novel and a-novel-kit
+        # modules off the proxy and sumdb, so a freshly tagged internal version is fetched
+        # straight from GitHub without waiting for proxy.golang.org to index it.
         RENOVATE_CUSTOM_ENV_VARIABLES: |
           {
             "GITHUB_TOKEN": "'{{ secrets.GITHUB_TOKEN }}'",

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -35,8 +35,8 @@ runs:
         RENOVATE_SKIP_INSTALLS: false
         # A tight pnpm allowlist by default — install, format, dedupe — so postUpgradeTasks run
         # without permitting arbitrary `pnpm exec` or `pnpm dlx`. The `( |$)` suffix matches the
-        # command with arguments or on its own, such as a bare `pnpm i`. The default also covers
-        # a caller passing an empty `allowed_commands`, which would skip the tasks and leave an
+        # command with arguments or on its own, such as a bare `pnpm i`. The default also covers a
+        # caller passing an empty `allowed_commands`, where the tasks are skipped and leave an
         # unformatted pnpm-workspace.yaml and stale lockfiles. Callers can still override it.
         RENOVATE_ALLOWED_COMMANDS: ${{ inputs.allowed_commands || '["^pnpm (install|i|format|dedupe)( |$)"]' }}
         RENOVATE_REPOSITORIES: "['${{ github.repository }}']"

--- a/generic-actions/rollup-board/action.yaml
+++ b/generic-actions/rollup-board/action.yaml
@@ -66,14 +66,9 @@ runs:
       run: |
         set -euo pipefail
 
-        # Org-level HALT (read FIRST): FAIL-SAFE — RUNNING only for an explicit off-token
-        # (empty/unset, 0, off, false, no, disabled); ANYTHING ELSE (a fat-fingered value or garbage)
-        # engages. The guard and the Python mutation share THIS one step, so an `exit 0` here
-        # genuinely skips the rollup (no board writes) — no later step can run past it.
-        # The org-Projects token is minted above, ahead of this guard, on purpose: nothing past the
-        # `exit 0` exercises it, so mint-vs-halt ordering is not blast radius here (token SCOPE, not
-        # mint timing, is the server-enforced bound) — and every action keeps one "mint per
-        # least-privilege, then halt-first" shape instead of duplicating this fail-safe parse pre-mint.
+        # Org-level halt, read before the rollup. Fail-safe: running only for an explicit off-token
+        # (empty/unset, 0, off, false, no, disabled); any other value engages the halt. The guard and
+        # the Python mutation share this one step, so the `exit 0` here skips the rollup entirely.
         case "$(printf '%s' "${KILL_SWITCH:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
           "" | 0 | off | false | no | disabled) : ;;  # explicit off-token / unset → running
           *)
@@ -117,8 +112,8 @@ runs:
             raise SystemExit("::error::rollup-board: board is missing a Status or Start date field")
         opt = {o["name"]: o["id"] for o in sfield.get("options", [])}
 
-        # Rank statuses by the board's own option order (its canonical progression), so
-        # the rollup never drifts from what the board actually defines.
+        # Rank statuses by the board's own option order, its canonical progression, so the
+        # rollup follows what the board defines.
         ORDER = [o["name"] for o in sfield.get("options", [])]
         RANK = {s: i for i, s in enumerate(ORDER)}
         for needed in ("In review", "Done", "In progress", "Awaiting release", "Tracking"):
@@ -155,8 +150,8 @@ runs:
                 pk = "%s#%s" % (p["repository"]["nameWithOwner"], p["number"])
                 children.setdefault(pk, []).append(it)
             typ = (c.get("issueType") or {}).get("name")
-            # Any parent with children rolls up — Initiatives included (rule 6), so an
-            # Initiative reaches Awaiting release once all its Epics do, over successive passes.
+            # Any parent with children rolls up, Initiatives included, so an Initiative reaches
+            # Awaiting release once all its Epics do, over successive passes.
             if (c.get("subIssues") or {}).get("totalCount", 0) > 0 and typ in ("Epic", "Feature", "Initiative"):
                 epics.append(it)
 
@@ -165,10 +160,9 @@ runs:
             if not rs:
                 return None
             mn, mx = min(rs), max(rs)
-            # An Initiative is a tracker, not a work item: you work its Epics, never the
-            # Initiative itself, so it never shows a pickup status (Ready / In progress). It
-            # holds Tracking until every child has reached Awaiting release, then rolls to the
-            # floor the same way a work item does (Awaiting release, later Applied).
+            # An Initiative is a tracker whose Epics carry the work, so it never shows a pickup
+            # status such as Ready or In progress. It holds Tracking until every child reaches
+            # Awaiting release, then rolls to the floor the way a work item does.
             if parent_type == "Initiative":
                 return ORDER[mn] if mn >= RANK["Awaiting release"] else "Tracking"
             if mn >= RANK["In review"]:     # ALL children In review or above → the floor
@@ -184,10 +178,11 @@ runs:
             c = e["content"]
             ek = "%s#%s" % (c["repository"]["nameWithOwner"], c["number"])
 
-            # Parent-archival (rules 5/6): once EVERY sub-issue is closed (children get archived+closed
-            # on publish), the parent is terminal — archive it off the board and close its tracker. It
-            # propagates up over successive passes (Task -> Feature -> Epic -> Initiative). Guard on the
-            # full node set: an epic with >50 sub-issues isn't fully seen here, so fall through to status.
+            # Parent archival: once every sub-issue is closed — children are archived and closed on
+            # publish — the parent is terminal, so archive it off the board and close its tracker.
+            # This propagates up over successive passes, Task to Feature to Epic to Initiative. The
+            # guard needs the full node set: an epic with more than 50 sub-issues is only partly
+            # visible here, and falls through to the status rollup.
             sub = c.get("subIssues") or {}
             tc = sub.get("totalCount", 0)
             nodes = sub.get("nodes") or []

--- a/generic-actions/token-expiry-notify/action.yaml
+++ b/generic-actions/token-expiry-notify/action.yaml
@@ -67,8 +67,8 @@ runs:
       run: |
         set -euo pipefail
 
-        # A fine-grained PAT's expiry rides on the response header of ANY authenticated request. A
-        # non-expiring credential (classic PAT / App token) has no such header → nothing to remind.
+        # A fine-grained PAT's expiry rides on the response header of any authenticated request. A
+        # non-expiring credential, such as a classic PAT or an App token, sends no such header.
         exp=$(curl -sfS -o /dev/null -D - -H "Authorization: Bearer ${TOKEN}" https://api.github.com/ 2>/dev/null \
           | grep -i '^github-authentication-token-expiration:' | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' || true)
         if [ -z "$exp" ]; then
@@ -88,9 +88,9 @@ runs:
           exit 0
         fi
 
-        # Color-code by percentage of lifetime left (if lifetime_days given) or by absolute days.
-        # Discord embed colors are decimal RGB: green 0x2ECC71 / yellow 0xF1C40F / orange 0xE67E22 /
-        # red 0xE74C3C.
+        # Color-code by percentage of lifetime left when lifetime_days is given, otherwise by
+        # absolute days. Discord embed colors are decimal RGB: green 0x2ECC71, yellow 0xF1C40F,
+        # orange 0xE67E22, red 0xE74C3C.
         pctline=""
         if [ -n "${LIFETIME_DAYS:-}" ] && [ "${LIFETIME_DAYS}" -gt 0 ] 2>/dev/null; then
           pct=$(( days * 100 / LIFETIME_DAYS ))
@@ -107,8 +107,8 @@ runs:
           else color=15158332; fi
         fi
 
-        # The whole message is the embed DESCRIPTION (Discord renders ## / ### headings there) — no
-        # separate title field. Header, then the expiry as `-#` subtext (small + grey), then the
+        # The whole message is the embed description, where Discord renders ## and ### headings, so
+        # there is no separate title field: a header, the expiry as small grey `-#` subtext, then the
         # caller's regen Markdown.
         desc="## ⏳ [Token] ${TOKEN_NAME} - ${days} days left"$'\n'"-# Expires ${exp}${pctline}"
         if [ -n "${REGEN_MD:-}" ]; then
@@ -116,7 +116,7 @@ runs:
         fi
         desc=$(printf '%s' "$desc" | head -c 3900)
         desc=$(printf '%s' "$desc" | iconv -f UTF-8 -t UTF-8 -c 2>/dev/null) || true
-        # allowed_mentions parse:[] — a maintenance nudge should never ping a role/@everyone.
+        # allowed_mentions parse:[] keeps a maintenance nudge from pinging a role or @everyone.
         payload=$(jq -n --arg d "$desc" --argjson c "$color" \
           '{embeds: [{description: $d, color: $c}], allowed_mentions: {parse: []}}')
 

--- a/go-actions/lint-go/action.yaml
+++ b/go-actions/lint-go/action.yaml
@@ -17,12 +17,11 @@ runs:
         # to the repo-root go.mod.
         go-version-file: ${{ inputs.working-directory && format('{0}/go.mod', inputs.working-directory) || 'go.mod' }}
     # Resolve the golangci-lint version from the repo's own tool modfile, so CI
-    # lints with the exact version developers run locally (`go tool -modfile=
-    # golangci-lint.mod golangci-lint`). This is the single source of truth:
-    # Renovate bumps golangci-lint.mod and CI follows on the next run, with no
-    # version literal to keep in sync here — the workflow and the repo cannot
-    # drift, and `latest`'s fleet-wide cache-busting on every upstream release
-    # is avoided.
+    # lints with the version developers run locally (`go tool -modfile=
+    # golangci-lint.mod golangci-lint`). That modfile is the single source of
+    # truth: Renovate bumps it and CI follows on the next run, with no version
+    # literal here to drift, and no fleet-wide cache-busting from `latest` on
+    # every upstream release.
     - id: golangci-version
       shell: bash
       run: |

--- a/go-actions/test-go/action.yaml
+++ b/go-actions/test-go/action.yaml
@@ -57,8 +57,8 @@ runs:
       id: discover
       run: |
         # Enumerate every package across every module. Iterating modules from
-        # `go list -m` (rather than a single `go list ./...`) is what makes this
-        # work in a Go workspace, where packages span more than one module.
+        # `go list -m` is what makes this work in a Go workspace, where packages
+        # span more than one module and a single `go list ./...` would miss them.
         echo "$(for mod in $(go list -m); do go list ${mod//$(go list .)/.}/... ${{ inputs.filter_patterns }} ${{ inputs.filter_extra_patterns }}; done)" > modules.txt
         echo "MODULES=$(cat modules.txt | tr '\n' ' ')" >> $GITHUB_ENV
     - name: run tests

--- a/go-actions/test-go/action.yaml
+++ b/go-actions/test-go/action.yaml
@@ -58,7 +58,7 @@ runs:
       run: |
         # Enumerate every package across every module. Iterating modules from
         # `go list -m` is what makes this work in a Go workspace, where packages
-        # span more than one module and a single `go list ./...` would miss them.
+        # span more than one module and a single `go list ./...` reaches only one.
         echo "$(for mod in $(go list -m); do go list ${mod//$(go list .)/.}/... ${{ inputs.filter_patterns }} ${{ inputs.filter_extra_patterns }}; done)" > modules.txt
         echo "MODULES=$(cat modules.txt | tr '\n' ' ')" >> $GITHUB_ENV
     - name: run tests

--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -39,8 +39,8 @@ runs:
       run: |
         # `pnpm audit --fix` rewrites the overrides but leaves the lockfile stale, so
         # reconcile it before `pnpm format`: pnpm 11 runs a verify-deps-before-run
-        # pre-hook on any `pnpm <script>`, which would spawn a frozen install and
-        # abort with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+        # pre-hook on any `pnpm <script>`, which spawns a frozen install and aborts
+        # with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
         pnpm audit --fix=override
         pnpm i --no-frozen-lockfile
         pnpm format

--- a/node-actions/audit/action.yaml
+++ b/node-actions/audit/action.yaml
@@ -29,18 +29,18 @@ runs:
         GH_TOKEN: ${{ steps.app_token.outputs.token }}
     - name: run audit
       shell: bash
-      # --fix requires a mode since pnpm 11; "override" pins vulnerable
-      # transitive dependencies via pnpm-workspace.yaml overrides without moving direct ones.
+      # --fix takes a mode since pnpm 11; "override" pins vulnerable transitive
+      # dependencies through pnpm-workspace.yaml overrides, leaving direct ones alone.
       env:
-        # Defensive: unfreeze any install pnpm triggers here — under CI the
-        # lockfile is frozen by default, and the overrides audit --fix writes
-        # make that mismatch the committed lockfile.
+        # Unfreeze any install pnpm triggers here: CI freezes the lockfile by
+        # default, and the overrides `audit --fix` writes make it mismatch the
+        # committed one.
         npm_config_frozen_lockfile: "false"
       run: |
-        # `pnpm audit --fix` rewrites the overrides but leaves the lockfile stale.
-        # Reconcile it BEFORE `pnpm format`: pnpm 11 runs a verify-deps-before-run
-        # pre-hook on any `pnpm <script>`, which would otherwise spawn a *frozen*
-        # install and abort with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+        # `pnpm audit --fix` rewrites the overrides but leaves the lockfile stale, so
+        # reconcile it before `pnpm format`: pnpm 11 runs a verify-deps-before-run
+        # pre-hook on any `pnpm <script>`, which would spawn a frozen install and
+        # abort with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
         pnpm audit --fix=override
         pnpm i --no-frozen-lockfile
         pnpm format

--- a/publish-actions/release-core-hotfix/action.yaml
+++ b/publish-actions/release-core-hotfix/action.yaml
@@ -68,7 +68,7 @@ runs:
 
     # Bot-authenticated checkout of the ephemeral branch named by the `ref` input, with full history
     # and tags so the baseline assert and the tag resolve.
-    # The checkout goes into a sub-path: a root checkout would clobber $GITHUB_WORKSPACE with the
+    # The checkout goes into a sub-path: a root checkout replaces $GITHUB_WORKSPACE with the
     # old-baseline tree, breaking this action's own sibling read of ../release-core/*.cjs, absent on
     # old lines, and any local `./` action a caller runs after the cut. With a sub-path the root
     # workspace stays on the caller's ref and $GITHUB_ACTION_PATH/../release-core resolves to the
@@ -142,8 +142,8 @@ runs:
 
         # Assert the ephemeral branch is cut from a real release. bump.cjs derives the next version
         # from package.json at this ref, so the baseline vX.Y.Z it patches from has to be a released
-        # tag and this HEAD has to descend from it; otherwise the branch was cut from the wrong place
-        # and the tag would be bogus.
+        # tag and this HEAD has to descend from it. A branch cut from anywhere else yields a bogus
+        # tag.
         baseline=$(node -p "require('./package.json').version")
         if ! git rev-parse -q --verify "refs/tags/v${baseline}" >/dev/null; then
           echo "::error::baseline v${baseline} (this ref's package.json version) is not a released tag — a hotfix must be cut from a release tag, not an arbitrary commit."
@@ -159,7 +159,7 @@ runs:
         version=$(node -p "require('./package.json').version")
 
         # Refresh doc version refs where a prepublish:doc script exists. The env var skips pnpm's
-        # pre-run install, which would need npm-registry auth.
+        # pre-run install, which needs npm-registry auth.
         if [ "$STAMP_NEEDED" = "true" ]; then
           PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run prepublish:doc
         fi

--- a/publish-actions/release-core-hotfix/action.yaml
+++ b/publish-actions/release-core-hotfix/action.yaml
@@ -51,9 +51,9 @@ outputs:
 runs:
   using: composite
   steps:
-    # No default-branch guard (FORK 1 vs release-core): a hotfix is cut from an ephemeral branch off
-    # a release tag, never from the default branch. The "cut from a real release" invariant is
-    # enforced below by asserting the baseline tag exists, not by pinning the ref to a branch name.
+    # There is no default-branch guard: a hotfix is cut from an ephemeral branch off a release tag.
+    # The step below asserts the baseline tag exists, which is what keeps the cut anchored to a real
+    # release.
 
     # Token that can push the tag + create the release. Scoped to this repo and contents only.
     - name: Mint push token
@@ -66,13 +66,13 @@ runs:
         repositories: ${{ github.event.repository.name }}
         permission-contents: write
 
-    # Bot-authenticated checkout of the EPHEMERAL branch (FORK 2 vs release-core: `ref` is an input,
-    # not github.ref_name); full history + tags so the baseline assert and the tag resolve.
-    # CRITICAL: check out into a SUB-PATH, never the root. A root checkout would clobber
-    # $GITHUB_WORKSPACE with the old-baseline tree — breaking this action's OWN sibling read of
-    # ../release-core/*.cjs (absent on old lines) AND any local `./` action a caller runs AFTER the
-    # cut (the reconcile / escalate steps). With a sub-path the root workspace stays on the caller's
-    # ref, so $GITHUB_ACTION_PATH/../release-core resolves to the CURRENT scripts.
+    # Bot-authenticated checkout of the ephemeral branch named by the `ref` input, with full history
+    # and tags so the baseline assert and the tag resolve.
+    # The checkout goes into a sub-path: a root checkout would clobber $GITHUB_WORKSPACE with the
+    # old-baseline tree, breaking this action's own sibling read of ../release-core/*.cjs, absent on
+    # old lines, and any local `./` action a caller runs after the cut. With a sub-path the root
+    # workspace stays on the caller's ref and $GITHUB_ACTION_PATH/../release-core resolves to the
+    # current scripts.
     - name: Checkout
       uses: actions/checkout@v7
       with:
@@ -90,8 +90,8 @@ runs:
       shell: bash
       run: corepack enable
 
-    # Only repos that stamp docs (a prepublish:doc script) need the a-novel CLI. Read the EPHEMERAL
-    # tree's package.json (working-directory), not the root workspace's.
+    # Only repos that stamp docs, through a prepublish:doc script, need the a-novel CLI. The
+    # working-directory points the read at the ephemeral tree's package.json.
     - name: Detect prepublish:doc
       id: stamp
       working-directory: __hotfix
@@ -115,8 +115,9 @@ runs:
         go install github.com/a-novel-kit/stack/cli/cmd/a-novel@latest
         echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
-    # working-directory: __hotfix — bump/plan/git all operate on the EPHEMERAL tree. $GITHUB_ACTION_PATH
-    # stays absolute (this action's dir in the untouched root), so $RC/*.cjs are the CURRENT scripts.
+    # working-directory __hotfix puts bump, plan and git on the ephemeral tree. $GITHUB_ACTION_PATH
+    # stays absolute, pointing at this action's dir in the untouched root, so $RC/*.cjs are the
+    # current scripts.
     - name: Cut hotfix
       id: cut
       working-directory: __hotfix
@@ -129,20 +130,20 @@ runs:
       run: |
         set -euo pipefail
 
-        # release-core owns bump.cjs / plan.cjs; reuse them UNCHANGED from this action's sibling dir
-        # via the ABSOLUTE $GITHUB_ACTION_PATH (immune to the __hotfix working-directory), so the
-        # CURRENT scripts run regardless of what tree the ephemeral checkout holds. A hotfix is
-        # always a patch bump of its line.
+        # release-core owns bump.cjs and plan.cjs, reused from this action's sibling dir through the
+        # absolute $GITHUB_ACTION_PATH, which the __hotfix working-directory does not affect, so the
+        # current scripts run whatever tree the ephemeral checkout holds. A hotfix is always a patch
+        # bump of its line.
         RC="$GITHUB_ACTION_PATH/../release-core"
         export RELEASE_TYPE=patch
 
         git config user.name "${APP_SLUG}[bot]"
         git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
 
-        # HARD-ASSERT the ephemeral branch is cut from a real release: bump.cjs derives the next
-        # version from package.json at this ref, so the baseline vX.Y.Z it patches from MUST be a
-        # released tag AND this HEAD must descend from it — otherwise the branch was cut from the
-        # wrong place and the tag would be bogus.
+        # Assert the ephemeral branch is cut from a real release. bump.cjs derives the next version
+        # from package.json at this ref, so the baseline vX.Y.Z it patches from has to be a released
+        # tag and this HEAD has to descend from it; otherwise the branch was cut from the wrong place
+        # and the tag would be bogus.
         baseline=$(node -p "require('./package.json').version")
         if ! git rev-parse -q --verify "refs/tags/v${baseline}" >/dev/null; then
           echo "::error::baseline v${baseline} (this ref's package.json version) is not a released tag — a hotfix must be cut from a release tag, not an arbitrary commit."
@@ -157,8 +158,8 @@ runs:
         node "$RC/bump.cjs"
         version=$(node -p "require('./package.json').version")
 
-        # Refresh doc version refs where a prepublish:doc script exists (env skips pnpm's pre-run
-        # install, which would need npm-registry auth).
+        # Refresh doc version refs where a prepublish:doc script exists. The env var skips pnpm's
+        # pre-run install, which would need npm-registry auth.
         if [ "$STAMP_NEEDED" = "true" ]; then
           PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run prepublish:doc
         fi
@@ -167,8 +168,8 @@ runs:
         tags=$(node "$RC/plan.cjs")
         root_tag="v${version}"
 
-        # Tag-monotonicity: refuse if ANY computed tag already exists (a stale-baseline cut, or a
-        # re-run). Check ALL of them up front so we never push a partial set then fail.
+        # Refuse when any computed tag already exists, which means a stale-baseline cut or a re-run.
+        # Every tag is checked up front, so a partial set is never pushed before the failure.
         while IFS= read -r t; do
           [ -n "$t" ] || continue
           if git rev-parse -q --verify "refs/tags/$t" >/dev/null; then
@@ -195,9 +196,9 @@ runs:
           exit 0
         fi
 
-        # Commit the bump, then push ONLY the tags (FORK 3 vs release-core: no `git push HEAD:branch`
-        # — the ephemeral branch is disposable and the caller deletes it; the tag preserves the
-        # bump commit). Each tag points at the bump commit and carries it to the remote.
+        # Commit the bump, then push the tags alone. The ephemeral branch is disposable and the
+        # caller deletes it, so there is no branch push; each tag points at the bump commit and
+        # carries it to the remote.
         git add -A
         git commit -m "$version"
         while IFS= read -r t; do
@@ -206,8 +207,8 @@ runs:
           git push origin "refs/tags/$t"
         done <<< "$tags"
 
-        # --latest=false (FORK 3 cont.): a patch to an old line must NOT become the repo's "Latest"
-        # release over a newer version. release-core lets GitHub pick latest; a hotfix never can.
+        # --latest=false keeps a patch to an old line from becoming the repo's "Latest" release over
+        # a newer version.
         gh release create "$root_tag" --repo "$GITHUB_REPOSITORY" \
           --title "${GITHUB_REPOSITORY#*/} ${version}" --generate-notes --latest=false
         echo "- ✓ hotfix released $(printf '%s\n' "$tags" | grep -c .) tag(s), root \`$root_tag\` (not latest)" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -42,7 +42,7 @@ runs:
   steps:
     # Releases run from the default branch only, so a dispatch or workflow_call
     # from any other ref is rejected before a token is minted or anything is
-    # mutated: a bump tag pushed from a feature branch would be wrong.
+    # mutated: a bump tag pushed from a feature branch names the wrong commit.
     - name: Guard — default branch only
       shell: bash
       run: |

--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -40,9 +40,9 @@ outputs:
 runs:
   using: composite
   steps:
-    # Releases run from the default branch only — reject a dispatch (or a
-    # workflow_call) from any other ref before minting a token or mutating
-    # anything. Pushing the bump tag from a feature branch would be wrong.
+    # Releases run from the default branch only, so a dispatch or workflow_call
+    # from any other ref is rejected before a token is minted or anything is
+    # mutated: a bump tag pushed from a feature branch would be wrong.
     - name: Guard — default branch only
       shell: bash
       run: |
@@ -51,10 +51,10 @@ runs:
           exit 1
         fi
 
-    # Token that can push the bump commit + tag and create the release, scoped to this repo.
-    # `workflows` is required alongside `contents`: the self-pin sync rewrites the version in
-    # `.github/workflows/*` self-refs, and GitHub refuses an App push that touches workflow files
-    # without it (contents alone → GH013 "without workflows permission"). The [Agent] App has it.
+    # Token that can push the bump commit and tag and create the release, scoped to this repo.
+    # `workflows` is needed alongside `contents` because the self-pin sync rewrites the version in
+    # `.github/workflows/*` self-refs, and GitHub refuses an App push touching workflow files without
+    # it, answering GH013 "without workflows permission".
     - name: Mint push token
       id: token
       uses: actions/create-github-app-token@v3
@@ -66,8 +66,8 @@ runs:
         permission-contents: write
         permission-workflows: write
 
-    # Bot-authenticated checkout so the later push carries the bot's rights;
-    # full history + tags so the tag and release notes resolve correctly.
+    # Bot-authenticated checkout so the later push carries the bot's rights, with
+    # full history and tags so the tag and release notes resolve.
     - name: Checkout
       uses: actions/checkout@v7
       with:
@@ -84,7 +84,7 @@ runs:
       shell: bash
       run: corepack enable
 
-    # Only repos that stamp docs (a prepublish:doc script) need the a-novel CLI.
+    # Only repos that stamp docs, through a prepublish:doc script, need the a-novel CLI.
     - name: Detect prepublish:doc
       id: stamp
       shell: bash
@@ -99,7 +99,7 @@ runs:
       uses: actions/setup-go@v7.0.0
       with:
         go-version: stable
-        # Only `go install` the a-novel CLI here; no build, so skip the cache.
+        # This step only `go install`s the a-novel CLI, so there is nothing to cache.
         cache: false
     - name: Install a-novel CLI (for stamp)
       if: ${{ steps.stamp.outputs.needed == 'true' }}
@@ -129,11 +129,11 @@ runs:
         git config user.name "${APP_SLUG}[bot]"
         git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
 
-        # Version bump (package.json, root + workspace members). Plain Node, not
-        # `pnpm version`, to skip pnpm's cold-store supply-chain pass. See bump.cjs.
+        # Version bump across package.json at the root and in every workspace member.
+        # Plain Node runs it, which skips pnpm's cold-store supply-chain pass. See bump.cjs.
         node "$GITHUB_ACTION_PATH/bump.cjs"
 
-        # Refresh doc version refs (a-novel publish stamp) where that script exists.
+        # Refresh doc version refs through `a-novel publish stamp` where that script exists.
         # The env var skips pnpm's pre-run install, which would need npm-registry auth.
         if [ "$STAMP_NEEDED" = "true" ]; then
           PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run prepublish:doc
@@ -141,8 +141,8 @@ runs:
 
         version=$(node -p "require('./package.json').version")
 
-        # Stamp in-repo version refs and compute the tags (root vX.Y.Z plus any
-        # sub-module tags). Add an ecosystem in plan.cjs, never here.
+        # Stamp in-repo version refs and compute the tags: the root vX.Y.Z plus any
+        # sub-module tags. A new ecosystem is added in plan.cjs.
         tags=$(node "$GITHUB_ACTION_PATH/plan.cjs")
         root_tag="v${version}"
 
@@ -158,12 +158,12 @@ runs:
           printf '%s\n' "$tags" | sed 's/^/- `/; s/$/`/'
         } | tee -a "$GITHUB_STEP_SUMMARY"
 
-        # Internal-consistency: rewrite every self-reference to THIS repo's own actions/workflows
-        # (owner/repo/...@vX.Y.Z) to the version being cut, so the released tag runs its OWN siblings —
-        # not whatever older tag the pins lagged at. A reusable workflow can't use a relative ref, so its
-        # sibling pins would otherwise always trail a release (Renovate bumps them, but each bump needs
-        # its own release, so the tag is forever one behind). Only self-refs are rewritten; cross-repo pins
-        # stay Renovate-managed. A no-op in a repo that doesn't self-reference. Discarded under dry-run.
+        # Rewrite every self-reference to this repo's own actions and workflows
+        # (owner/repo/...@vX.Y.Z) to the version being cut, so the released tag runs its own siblings.
+        # A reusable workflow cannot use a relative ref, so without this its sibling pins trail every
+        # release: Renovate bumps them, but each bump needs its own release, leaving the tag one
+        # behind. Only self-refs are rewritten; cross-repo pins stay Renovate-managed. This is a no-op
+        # in a repo that does not self-reference, and is discarded under dry-run.
         repo_esc=$(printf '%s' "$GITHUB_REPOSITORY" | sed 's/\./\\./g')
         selfpin_files=$(git ls-files '*.yaml' '*.yml' | xargs -r grep -lE "${repo_esc}/[A-Za-z0-9._/-]+@v[0-9]+\.[0-9]+\.[0-9]+" 2>/dev/null || true)
         if [ -n "$selfpin_files" ]; then

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -2,20 +2,19 @@
 # Regression tests for detect-partial-landing's membership sourcing.
 #
 # These actions are bash inside a composite manifest, so there is nothing to import: the harness
-# EXTRACTS the functions under test verbatim from the manifest and sources them, which keeps the
-# shipped code the code that runs here — a paraphrase would drift the moment the action changed.
-# Only the network leaves are stubbed (gh, and the three read helpers evaluate_epic calls), so every
-# decision below is the real predicate running on fixture truth. Offline and deterministic.
+# extracts the functions under test verbatim from the manifest and sources them, which keeps the
+# shipped code the code that runs here. Only the network leaves are stubbed (gh, and the three read
+# helpers evaluate_epic calls), so every decision below is the real predicate running on fixture truth.
+# Offline and deterministic.
 #
-# The case that matters: a member de-labeled and closed mid-landing. Live label truth has forgotten
-# it — GitHub indexes no "ever carried label X" — so the detector reads the survivors as a clean
-# landing and clears. The frozen activation snapshot is what keeps it a member.
+# The central case is a member de-labeled and closed mid-landing. Live label truth has forgotten it —
+# GitHub indexes no "ever carried label X" — so the detector reads the survivors as a clean landing
+# and clears. The frozen activation snapshot is what keeps it a member.
 #
-# Note the shape of the fixtures for that case. merge-gate captures the set from OPEN pull requests
-# and freezes it only after the set holds still, while auto-merge is armed earlier — so a real frozen
-# set routinely does NOT contain the members that already merged. The snapshot is therefore added to
-# the live set rather than replacing it, and the fixtures model exactly that: `A` merged is visible
-# only live, `B` abandoned only in the snapshot, and the freeze depends on both.
+# The fixtures model the real capture shape. merge-gate captures the set from open pull requests and
+# freezes it once the set holds still, while auto-merge is armed earlier, so a real frozen set omits
+# the members that already merged. The snapshot is added to the live set: `A` merged is visible only
+# live, `B` abandoned only in the snapshot, and the freeze depends on both.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -39,8 +38,8 @@ for fn in snapshot_buckets union_buckets evaluate_epic; do
   fi
   printf '%s\n' "$out" >> "$WORK/lib.sh"
 done
-# Extraction stops at the first 8-space `}`. If that ever lands mid-function the result is invalid
-# bash, and without this check the suite fails later with a confusing unbound-variable abort.
+# Extraction stops at the first 8-space `}`. Landing mid-function yields invalid bash, and this check
+# names the truncation at its source.
 if ! bash -n "$WORK/lib.sh"; then
   echo "::error::extracted functions do not parse — extraction truncated a definition"
   exit 1
@@ -49,24 +48,22 @@ fi
 export ORG=a-novel-kit PLANNING_REPO=.github GRACE_MINUTES=30
 export GITHUB_STEP_SUMMARY="$WORK/summary.md"
 now_epoch=$(date -u +%s)
-# NOTE: the action computes these outside any extracted function, so the harness necessarily
-# REIMPLEMENTS them rather than deriving them. A change to the action's own arithmetic would not be
-# caught here — keep the two in sync by hand.
+# The action computes these outside any extracted function, so the harness reimplements them. A change
+# to the action's own arithmetic escapes this suite; keep the two in sync by hand.
 grace_seconds=$((GRACE_MINUTES * 60))
 sleep() { :; } # retries are driven by the rehydrate_fails countdown; wall-clock delay is not useful here
 
 # ---- stubbed leaves ---------------------------------------------------------------------
-# Every stub can fail on demand: the action's central promise is that it fails CLOSED, and stubs
-# that cannot fail leave that promise untested.
+# Every stub can fail on demand: the action's central promise is that it fails closed, and only a
+# failing stub tests that promise.
 gh() {
-  # Record every call so the QUERY can be asserted, not just its answer: the document this action
-  # builds is the part no fixture would otherwise exercise, and a wrong field or alias in it is a
-  # total feature outage.
+  # Record every call so the assertions can read the query itself. The document this action builds is
+  # the part no fixture exercises, and a wrong field or alias in it is a total feature outage.
   printf '%s\n' "$*" >> "$WORK/gh_calls"
   case "$*" in
     *graphql*)
-      # The stub runs inside $( ), i.e. a subshell, so a shell-variable countdown would never reach
-      # the parent. Keep it in a file to make "fail twice, then succeed" actually observable.
+      # The stub runs inside $( ), a subshell, so the countdown lives in a file: that is what makes
+      # "fail twice, then succeed" observable from the parent.
       if [ "$(< "$WORK/rehydrate_fails")" -gt 0 ]; then
         printf '%s' "$(($(< "$WORK/rehydrate_fails") - 1))" > "$WORK/rehydrate_fails"
         echo "gh: API rate limit exceeded" >&2
@@ -85,9 +82,9 @@ gh() {
   esac
 }
 search_prs() {
-  # Record the query. The stub dispatches on the `is:` token alone, so without this the rest of the
-  # search grammar — the label qualifier and the org scope that BOUND membership — is unasserted, and
-  # dropping either would silently make every open pull request in the org a member of every Epic.
+  # Record the query. The stub dispatches on the `is:` token alone, so the assertions below are what
+  # cover the rest of the grammar: the label qualifier and the org scope bound membership, and losing
+  # either makes every open pull request in the org a member of every Epic.
   printf '%s\n' "$1" >> "$WORK/searches"
   [ "$FX_SEARCH_FAIL" = true ] && return 1
   # Fail exactly one of the three searches, so each fail-closed guard is pinned separately.
@@ -103,14 +100,12 @@ search_prs() {
     *is:open*) bucket="$FX_LIVE_OPEN" ;;
     *) echo "unexpected search: $1" >&2; return 1 ;;
   esac
-  # Apply the time qualifier the way GITHUB does, not the way the action hopes it does. Asserting the
-  # substring `merged:>=…` appears in the query would pass just as well if the qualifier were inert —
-  # and it is not: a bad one silently returns zero rows. Filtering here is what lets the wave-boundary
-  # assertions below run the real predicate against real truth.
-  # ISO-8601 UTC sorts chronologically, so a string compare IS the date compare (the action's own grace
-  # clock leans on the same property). A node with no terminal timestamp is KEPT: GitHub always has one,
-  # so an undated fixture means "not what this assertion is about", and dropping it would quietly
-  # rewrite the meaning of every fixture written before the boundary existed.
+  # Apply the time qualifier the way GitHub does. A bad qualifier silently returns zero rows, so
+  # filtering here is what lets the wave-boundary assertions below run the real predicate against real
+  # truth.
+  # ISO-8601 UTC sorts chronologically, so a string compare is the date compare; the action's own grace
+  # clock leans on the same property. A node with no terminal timestamp is kept: GitHub always has one,
+  # so an undated fixture means "not what this assertion is about".
   floor=$(printf '%s' "$1" | sed -n 's/.*\(merged\|closed\):>=\([^ ]*\).*/\2/p')
   [ -n "$floor" ] && bucket=$(printf '%s' "$bucket" | jq -c --arg f "$floor" \
     '[.[] | select((.mergedAt // .closedAt // "9999") >= $f)]')
@@ -118,9 +113,8 @@ search_prs() {
 }
 merge_queue_entries() { # $1=owner $2=repo $3=base
   [ "$FX_QUEUE_FAIL" = true ] && return 1
-  # Honour all three arguments the real helper takes. A fixture that ignores them cannot catch an
-  # owner/repo split swapped the wrong way round or a hard-coded base, both of which would read the
-  # wrong queue for every member.
+  # Honor all three arguments the real helper takes, so the assertions catch an owner/repo split
+  # swapped the wrong way round or a hard-coded base; either reads the wrong queue for every member.
   printf '%s' "$FX_QUEUE" | jq -c --arg repo "$1/$2" --arg base "$3" \
     '[.[] | select((.repo // $repo) == $repo and (.base // $base) == $base)]'
 }
@@ -142,10 +136,10 @@ rest_pr_state() {
 #   label    = still carries the label
 #   none     = neither — a pull request named by the marker that was never a member
 node() { # repo number state [terminalAt] [prov: timeline|label|none]
-  # `terminalAt` is when the pull request reached its terminal state — it fills `mergedAt` for a MERGED
+  # `terminalAt` is when the pull request reached its terminal state: it fills `mergedAt` for a MERGED
   # one and `closedAt` otherwise, which is how GitHub reports them (a merged PR carries both, equal).
-  # `closedAt` is not in the action's search-node shape and it never reads it; it exists so the stub
-  # above can apply a `closed:>=` floor, which the real search applies server-side.
+  # `closedAt` sits outside the action's search-node shape and the action never reads it; it is there
+  # so the stub above can apply a `closed:>=` floor, which the real search applies server-side.
   jq -cn --arg r "$1" --argjson n "$2" --arg s "$3" --arg m "${4:-}" --arg p "${5:-timeline}" --arg e "epic:900" \
     '{number:$n, headRefOid:("sha"+($n|tostring)),
       mergedAt:(if $m=="" or $s!="MERGED" then null else $m end),
@@ -158,15 +152,14 @@ rehydrate() { # the aliased re-read response, one alias per member
   jq -s -c '{data: ([.[] | {pullRequest: .}] | to_entries
     | map({key:("m"+(.key|tostring)), value:.value}) | from_entries)}' <<<"$*"
 }
-# Builds the region EXACTLY as merge-gate writes it: fence, a human-readable note line, the compact
-# payload, fence. The note is the part that matters — it lives INSIDE the fence, and a reader that
-# parses the whole region as JSON chokes on it. A fixture that omits the note agrees with whatever the
-# reader happens to do and can never catch that, which is how a parser change once made the feature
-# silently inert end to end. Frozen payloads carry no `at`; only pending does.
+# Builds the region exactly as merge-gate writes it: fence, a human-readable note line, the compact
+# payload, fence. The note is the part that matters. It lives inside the fence, so a reader that parses
+# the whole region as JSON chokes on it, and only a fixture carrying the note catches that. Frozen
+# payloads carry no `at`; only pending does.
 marker() { # status members-json [since]
-  # `since` is the wave boundary. It is OPTIONAL on every status, because that is the shape the reader
-  # has to survive: it is absent on a first wave, present on a tombstone, and carried forward onto the
-  # pending / frozen markers that replace one.
+  # `since` is the wave boundary, optional on every status, because that is the shape the reader has to
+  # survive: absent on a first wave, present on a tombstone, and carried forward onto the pending or
+  # frozen markers that replace one.
   local payload note
   if [ "$1" = retired ]; then
     payload=$(jq -cn --arg since "${3:-}" '{status:"retired"} + (if $since=="" then {} else {since:$since} end)')
@@ -193,8 +186,8 @@ C=$(node a-novel-kit/repo-c 3 OPEN)
 BC='[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-c","number":3}]'
 
 reset_fixtures() {
-  # Every fixture the assertions read lives here: a section that edits one and forgets to restore it
-  # would silently redefine truth for every later assertion.
+  # Every fixture the assertions read lives here, so one section's edit is restored before the next
+  # section reads it.
   FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"closed false","a-novel-kit/repo-c#3":"open false"}'
   FX_LIVE_MERGED="[$A]" # A merged and still labeled: visible to the live search
   FX_LIVE_CLOSED='[]'   # B is de-labeled, so live truth has forgotten it entirely
@@ -248,14 +241,14 @@ check "the snapshot supplies it, and the Epic freezes" frozen live+snapshot 1/1/
 
 echo
 echo "the snapshot is ADDED to the live set, never swapped for it"
-# The real capture shape: merge-gate freezes from open PRs, so an already-merged member is absent
-# from the snapshot. Substituting would zero the merged bucket that gates every decision.
+# The real capture shape: merge-gate freezes from open PRs, so an already-merged member is absent from
+# the snapshot, and the merged bucket that gates every decision comes from the live set.
 FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 MERGED "$AGO5")" "$C")
 check "a member merged after the freeze is not double-counted" clear live+snapshot 2/0/1
 
 echo
 echo "the frozen member reaches the payload the freeze is posted on"
-# A decision is worthless if the head it names is missing: EV_OPEN is what sweep_post_freeze targets.
+# EV_OPEN is what sweep_post_freeze targets, so the head a decision names has to be in it.
 FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 OPEN)" "$C")
 FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"open false","a-novel-kit/repo-c#3":"open false"}'
 evaluate_epic 900 >/dev/null 2>&1
@@ -277,14 +270,13 @@ echo "the marker only widens membership to pull requests that were really member
 # The marker lives in an issue body, so its author is whoever can edit that issue, and every member it
 # names becomes a freeze target posted with an org-wide checks:write token. Membership has to be
 # corroborated against the permission-gated label, or one issue edit blocks merges across the org.
-# In-org, so it clears the owner check and really reaches corroboration.
+# The intruder is in-org, so it clears the owner check and reaches corroboration.
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/VICTIM","number":4242}]')
 FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/VICTIM 4242 OPEN '' none)")
-# `error`, not `clear`: falling back to the live floor would POST success and lift a standing freeze,
-# so an untrustworthy marker must decide nothing rather than decide optimistically.
+# `error`: the live floor posts success and lifts a standing freeze, so an untrustworthy marker decides
+# nothing.
 check "a named pull request that was never a member decides nothing" error
-# A labeled intruder: corroboration must match THIS Epic's label, not merely "has some label", and
-# not a different Epic's.
+# A labeled intruder: corroboration matches this Epic's own label exactly.
 FX_REHYDRATE=$(rehydrate "$B" "$(jq -cn --argjson v "$(node a-novel-kit/VICTIM 4242 OPEN '' none)" \
   '$v | .labels.nodes = [{name:"bug"}]')")
 check "an intruder carrying an unrelated label is still rejected" error
@@ -294,8 +286,8 @@ check "an intruder labeled for a DIFFERENT Epic is rejected" error
 printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/VICTIM")' >/dev/null \
   && ko "the planted pull request reached the freeze target set" \
   || ok "and it never reaches the freeze target set"
-# A repository outside the org can never be a member: the live label search is org-scoped, so a marker
-# naming one would let its author corroborate in a repository they control.
+# A repository outside the org can never be a member: the live label search is org-scoped, and naming
+# one lets the marker's author corroborate in a repository they control.
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"attacker/anything","number":1}]')
 FX_REHYDRATE=$(rehydrate "$B" "$(node attacker/anything 1 OPEN)")
 check "a member outside the org is rejected outright" clear live 1/0/1
@@ -304,8 +296,8 @@ FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/repo-c 3 OPEN '' label)")
 check "a member still carrying the label is corroborated" frozen live+snapshot 1/1/1
 FX_REHYDRATE=$(rehydrate "$B" "$C") # B is de-labeled: only its timeline proves membership
 check "a de-labeled member is corroborated by its timeline" frozen live+snapshot 1/1/1
-# GraphQL follows a rename and answers with the NEW name. A frozen marker is never rewritten, so
-# matching identity on the name would strand a renamed member's Epic at `error` forever.
+# GraphQL follows a rename and answers with the new name, while a frozen marker is never rewritten, so
+# identity is matched on the alias index and the number.
 FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/repo-b-renamed#2":"closed false"}')
 FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b-renamed 2 CLOSED)" "$C")
 check "a member whose repository was renamed still resolves" frozen live+snapshot 1/1/1
@@ -314,8 +306,8 @@ reset_fixtures
 echo
 echo "the roll-forward target set, on BOTH membership paths"
 # Every node must carry liveMember whichever path built it. jq reads a missing key as null, so an
-# untagged node silently drops out of the roll-forward filter and into its skip-warning — disabling
-# recovery for exactly the Epics that have no snapshot yet, which is all of them before activation.
+# untagged node drops out of the roll-forward filter and into its skip-warning, disabling recovery for
+# the Epics that have no snapshot yet.
 reset_fixtures
 FX_QUEUE='[]' # repo-c left its queue: a stray, still labeled, within grace
 FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO5")]"
@@ -344,9 +336,9 @@ for want in 'owner:"a-novel-kit", name:"repo-b"' 'number:2' 'owner:"a-novel-kit"
     *) ko "the re-read query is missing: $want" ;;
   esac
 done
-# `2.0` is a valid integer to the guard (it equals its own floor) but jq preserves the literal a body
-# was written with, and `number:2.0` is an Int! violation that rejects the WHOLE document — no retry
-# clears it, so the Epic would wedge forever. It has to render canonically.
+# `2.0` passes the guard (it equals its own floor) but jq preserves the literal a body was written
+# with, and `number:2.0` is an Int! violation that rejects the whole document. No retry clears it, so
+# the number has to render canonically.
 reset_fixtures
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2.0}]')
 FX_REHYDRATE=$(rehydrate "$B")
@@ -406,7 +398,7 @@ reset_fixtures
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
 for want in 'label:"epic:900"' 'org:a-novel-kit'; do
-  # All THREE searches, not merely one: a grep over the file would pass while two of them ran unscoped.
+  # All three searches: a grep over the whole file passes while two of them run unscoped.
   [ "$(grep -cF -- "$want" "$WORK/searches")" = 3 ] \
     && ok "all three member searches are scoped by $want" \
     || ko "a member search is missing $want — the set would be every open pull request"
@@ -462,10 +454,10 @@ reset_fixtures
 echo
 echo "the wave boundary: history is scoped to the wave, membership is not"
 # The regression that makes a second wave impossible. A merged pull request keeps its epic:<N> label, so
-# an unbounded is:merged search reports the PREVIOUS wave forever: merged>=1 stays true, grace runs from
-# the first merge EVER, and the first sibling of the next wave is a stray past grace on the very pass it
-# appears — frozen by a required check, re-frozen every sweep, with nothing the author can do about it.
-FX_QUEUE='[]'                                                   # the new sibling is labelled, not queued
+# an unbounded is:merged search reports the previous wave forever: merged>=1 stays true, grace runs from
+# the first merge ever, and the first sibling of the next wave is a stray past grace on the pass it
+# appears — frozen by a required check, re-frozen every sweep.
+FX_QUEUE='[]'                                                   # the new sibling is labeled and out of the queue
 FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO40")]" # the previous wave: landed, past grace
 check "without a boundary, a new sibling is frozen on the last wave" frozen live 1/0/1
 FX_BODY=$(marker retired '[]' "$AGO20")
@@ -480,7 +472,7 @@ FX_LIVE_CLOSED="[$(node a-novel-kit/repo-b 2 CLOSED "$AGO5")]"
 check "a member closed after the boundary is this wave's abandonment" frozen live 1/1/1
 [ "$EV_REASON" = "a member was closed without merging" ] \
   && ok "and for the right reason" || ko "wrong reason: $EV_REASON"
-# The closed bucket carries the identical disease and is scoped identically: an abandonment a human has
+# The closed bucket carries the same hazard and is scoped identically: an abandonment a human has
 # already dealt with must not re-freeze every wave that follows it.
 FX_LIVE_CLOSED="[$(node a-novel-kit/repo-b 2 CLOSED "$AGO40")]"
 check "the same member closed before it belongs to the retired wave" clear live 1/0/1
@@ -499,8 +491,8 @@ reset_fixtures
 echo
 echo "the boundary is read from every marker status, not only the tombstone"
 # merge-gate splices the whole region, so the tombstone is destroyed the moment the next wave captures a
-# marker of its own. A boundary that is not carried forward onto that marker dies with it, and the
-# permanent freeze returns one pass later — which is why the reader takes it from any status.
+# marker of its own. A boundary that is not carried forward onto that marker dies with it and the
+# permanent freeze returns one pass later, so the reader takes it from any status.
 FX_BODY=$(marker frozen "$BC")
 FX_REHYDRATE=$(rehydrate "$B" "$C")
 check "a frozen marker with no boundary reads the whole history" frozen live+snapshot 1/1/1
@@ -513,9 +505,9 @@ reset_fixtures
 
 echo
 echo "the boundary bounds HISTORY, never the frozen set"
-# The frozen set IS the current wave: retirement is what writes a boundary, and it removes the set it
-# retires. Time-filtering it here would let the boundary shrink MEMBERSHIP — the one thing the union
-# exists to prevent — and would drop exactly the abandoned member the snapshot is kept for.
+# The frozen set is the current wave: retirement is what writes a boundary, and it removes the set it
+# retires. The boundary bounds history alone, so it never shrinks membership or drops the abandoned
+# member the snapshot is kept for.
 FX_LIVE_MERGED='[]'
 FX_BODY=$(marker frozen "$BC" "$AGO20")
 FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 MERGED "$AGO40")" "$C")
@@ -539,11 +531,11 @@ reset_fixtures
 
 echo
 echo "an unusable boundary is ignored, and never reaches a query"
-# The dangerous input is not an obviously broken one. GitHub answers a malformed time qualifier — and a
-# well-shaped impossible date — with ZERO rows and NO errors array, indistinguishable from a genuinely
-# empty bucket. That bucket gates every decision, and an empty one reads as "nothing has landed" →
-# `clear` → which POSTS success and lifts a standing freeze. Falling back to unbounded history is the
-# safe direction: it errs toward freezing. fd 6 keeps this loop's input clear of evaluate_epic's own.
+# GitHub answers a malformed time qualifier — and a well-shaped impossible date — with zero rows and no
+# errors array, indistinguishable from a genuinely empty bucket. That bucket gates every decision, and
+# an empty one reads as "nothing has landed" → `clear`, which posts success and lifts a standing freeze.
+# Falling back to unbounded history errs toward freezing. fd 6 keeps this loop's input clear of
+# evaluate_epic's own.
 FX_QUEUE='[]'
 FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO40")]"
 while IFS='|' read -r why bad <&6; do
@@ -562,9 +554,8 @@ an instant in the future|$AHEAD
 a trailing search qualifier|2026-07-01T00:00:00Z org:attacker
 a quote that would close the qualifier|2026-07-01T00:00:00Z"
 EOF
-# Not merely "no floor": the injected text must be nowhere in the grammar. `org:` is the scope that
-# bounds membership to this org, so a second one would widen the member set to a repository the marker's
-# author controls.
+# The injected text must be nowhere in the grammar. `org:` is the scope that bounds membership to this
+# org, and a second one widens the member set to a repository the marker's author controls.
 FX_BODY=$(marker retired '[]' '2026-07-01T00:00:00Z org:attacker')
 : > "$WORK/searches"
 evaluate_epic 900 >/dev/null 2>&1
@@ -572,9 +563,9 @@ evaluate_epic 900 >/dev/null 2>&1
 grep -q 'attacker' "$WORK/searches" \
   && ko "an injected qualifier reached the search grammar" \
   || ok "an injected qualifier never reaches the search grammar"
-# Rejecting a value is not enough if REPORTING it is itself the vector. The marker lives in an issue
-# body, jq -r turns an embedded \n into a real newline, and GitHub reads workflow commands line by line
-# — so an unsanitized warning would let the boundary forge a command on the path that rejects it.
+# Reporting a rejected value is itself a vector. The marker lives in an issue body, jq -r turns an
+# embedded \n into a real newline, and GitHub reads workflow commands line by line, so an unsanitized
+# warning lets the boundary forge a command on the path that rejects it.
 # Captured in `$( )`, so EV_* never reach this shell: only the log is under test here.
 FX_BODY=$(marker retired '[]' "$(printf '2026-07-01T00:00:00Z\n::error::forged')")
 check "a boundary carrying a newline is rejected" frozen live 1/0/1
@@ -587,10 +578,9 @@ reset_fixtures
 
 echo
 echo "the boundary is compared against a clock that is already minutes old"
-# now_epoch is read when the STEP starts; a sweep is often minutes into it by the time it reaches an
-# Epic. Without a skew allowance a tombstone merge-gate wrote moments ago reads as "the future" and is
-# thrown away — costing a pass of unbounded history, which re-freezes the next wave until the sweep
-# after. The guard exists for a boundary far enough ahead to hide real history, not for that race.
+# now_epoch is read when the step starts, and a sweep is often minutes into it by the time it reaches
+# an Epic, so the skew allowance keeps a tombstone merge-gate wrote moments ago from reading as "the
+# future". The guard catches a boundary far enough ahead to hide real history.
 FX_QUEUE='[]'
 FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO40")]"
 FX_BODY=$(marker retired '[]' "$(date -u -d '+2 minutes' +%Y-%m-%dT%H:%M:%SZ)")
@@ -618,8 +608,8 @@ echo
 echo "a degraded marker falls back to the live floor — never a crash, never a freeze on garbage"
 FX_BODY=$(marker pending "$BC")
 check "a pending marker (the set has not settled)" clear live 1/0/1
-# A tombstone is the one marker whose whole purpose is the boundary; carrying none it says nothing, and
-# saying nothing must mean the Epic's whole history, not an empty one.
+# A tombstone exists to carry the boundary; carrying none it says nothing, and saying nothing means the
+# Epic's whole history.
 FX_BODY=$(marker retired '[]')
 check "a tombstone carrying no boundary" clear live 1/0/1
 FX_BODY='<!-- epic-membership:snapshot:start -->
@@ -650,28 +640,27 @@ FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/x\"){pullRequest(number:1){number
 check "a member repo carrying a GraphQL injection" clear live 1/0/1
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo\nEVIL: rateLimit{cost}","number":1}]')
 check "a member repo carrying a newline" clear live 1/0/1
-# The case the whole-string anchors exist for: jq's `$` matches BEFORE a final newline, so a bare
-# trailing one passes `^…$`. It emits a raw line break inside a GraphQL string literal — a
+# The case the whole-string anchors exist for: jq's `$` matches before a final newline, so a bare
+# trailing one passes `^…$`. It emits a raw line break inside a GraphQL string literal, a
 # document-level error that no retry clears, wedging the Epic forever.
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b\n","number":2}]')
 check "a member repo with a bare trailing newline" clear live 1/0/1
-# One bad member must poison the whole set: validating with `any` instead of `all` would let the
-# injection through alongside a legitimate member.
+# One bad member poisons the whole set, so an injection cannot ride in alongside a legitimate member.
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/x\"){evil","number":1}]')
 check "one evil member among valid ones" clear live 1/0/1
-# The repo pattern must be anchored at BOTH ends: a payload in the prefix still ends in a valid name.
+# The repo pattern is anchored at both ends: a payload in the prefix still ends in a valid name.
 FX_BODY=$(marker frozen '[{"repo":"evil\"){x} a-novel-kit/repo-b","number":2}]')
 check "a member repo with an injected prefix" clear live 1/0/1
 FX_BODY=$(marker frozen '[]')
 check "an empty frozen set" clear live 1/0/1
 FX_BODY=FAIL404
 check "the Epic issue is absent" clear live 1/0/1
-# An unreadable body is IGNORANCE, not an answer: we cannot tell whether a snapshot exists, and a
-# `clear` would post success and lift a freeze an earlier pass set. Only a 404 is an answer.
+# An unreadable body leaves it unknown whether a snapshot exists, and a `clear` posts success and lifts
+# a freeze an earlier pass set. Only a 404 is an answer.
 FX_BODY=FAIL500
 check "the body read fails outright — decide nothing" error
-# A benign notice on stderr must not corrupt the payload — it costs a whole pass now that an
-# unreadable body no longer falls back to the live floor.
+# A benign notice on stderr must not corrupt the payload: an unreadable body does not fall back to the
+# live floor, so it costs a whole pass.
 FX_MARKER_BODY=$(marker frozen "$BC")
 FX_REHYDRATE=$(rehydrate "$B" "$C")
 FX_BODY=NOISE
@@ -680,9 +669,9 @@ FX_REHYDRATE=""
 
 echo
 echo "a pseudo-fence cannot shadow the real marker"
-# Readers once matched the fence as a SUBSTRING while merge-gate's splice matches whole lines, so a
-# decoy fence inside an HTML comment was read as the marker yet was invisible to the writer — a tamper
-# that survived every self-heal pass.
+# merge-gate's splice matches the fence as a whole line, so every reader does too. A substring match
+# reads a decoy fence inside an HTML comment as the marker while the writer stays blind to it, and the
+# tamper survives every self-heal pass.
 FX_BODY=$(printf '%s\n%s\n%s\n\n%s' \
   '<!--- <!-- epic-membership:snapshot:start --> --->' \
   '{"status":"frozen","members":[{"repo":"a-novel-kit/DECOY","number":4242}]}' \
@@ -704,8 +693,8 @@ FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-no
 check "a duplicated member is de-duplicated, not double-counted" frozen live+snapshot 1/1/1
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-B","number":2},{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-c","number":3}]')
 check "a case-variant duplicate is one member, not two" frozen live+snapshot 1/1/1
-# Two DISTINCT members in one repository: cross-repo Epics reuse numbers, so the dedup key has to be
-# the pair. Keyed on repo alone these would collapse and the set would silently lose a member.
+# Two distinct members in one repository: cross-repo Epics reuse numbers, so the dedup key is the pair.
+# Keyed on repo alone these collapse and the set loses a member.
 FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/repo-b#4":"open false"}')
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-b","number":4}]')
 FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/repo-b 4 OPEN)")
@@ -723,8 +712,8 @@ evaluate_epic 900 2>&1 >/dev/null | grep -q 'could not re-read all 2 frozen memb
 : > "$GITHUB_STEP_SUMMARY"
 FX_REHYDRATE=$(jq -cn '{data:{m0:null,m1:null}, errors:[{message:"NOT_FOUND"}]}')
 check "every alias nulled (data has keys, but no members)" error
-# GitHub answers a pullRequest(number:) that does not exist with a null and NO errors array, so the
-# member count is the only thing standing between a short answer and a silent clear.
+# GitHub answers a pullRequest(number:) that does not exist with a null and no errors array, so the
+# member count is what stands between a short answer and a silent clear.
 FX_REHYDRATE=$(jq -cn --argjson b "$B" '{data:{m0:{pullRequest:$b}, m1:{pullRequest:null}}}')
 check "a short answer carrying no errors array" error
 FX_REHYDRATE=$(jq -cn --argjson b "$B" '{data:{m0:{pullRequest:$b}, m1:{pullRequest:null}}, errors:[{message:"timeout"}]}')
@@ -732,8 +721,8 @@ check "one alias nulled — a short answer is not a clean set" error
 FX_REHYDRATE=$(rehydrate "$B" "$C" | jq -c '. + {errors:[{message:"something went wrong"}]}')
 check "a complete answer that still reports errors is not trusted" error
 FX_REHYDRATE=$(rehydrate "$B" "$(node a-novel-kit/UNRELATED 4242 OPEN)")
-# Give the intruder full REST + queue backing, so `error` can only come from the identity check
-# rejecting it — not from the harness running out of fixtures for a PR it never expected.
+# Give the intruder full REST + queue backing, so `error` comes from the identity check rejecting it
+# and not from the harness running out of fixtures for a PR it never expected.
 FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/UNRELATED#4242":"open false"}')
 FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"},{"number":4242,"state":"QUEUED","headOid":"sha4242"}]'
 check "a node for a pull request nobody asked about" error
@@ -786,12 +775,11 @@ check "an Epic with no snapshot sees none of the previous one's" clear live 1/0/
 
 echo
 printf '%d passed, %d failed\n' "$pass" "$fail"
-# A floor on the count, not just on failures: a suite that runs no assertions at all exits 0 and reads
-# as green, which is the one way a test file can protect nothing while looking like it protects
-# everything. Raise this when assertions are added; never lower it to make a run pass.
-# Report failures first: they are the useful diagnosis. The floor below is about assertions that never
-# RAN, so it counts executions (pass + fail) — counting passes alone would make any ordinary failure
-# masquerade as a truncated suite.
+# A floor on the count as well as on failures: a suite that runs no assertions exits 0 and reads as
+# green. Raise this when assertions are added; never lower it to make a run pass.
+# Failures are reported first, since they are the useful diagnosis. The floor covers assertions that
+# never ran, so it counts executions (pass + fail); counting passes alone turns an ordinary failure
+# into a truncated-suite report.
 ran=$((pass + fail))
 if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -1,23 +1,21 @@
 #!/usr/bin/env bash
 # Regression tests for merge-gate's activation-snapshot write path.
 #
-# Same approach as tests/detect-partial-landing.sh: the functions under test are EXTRACTED verbatim
-# from the action manifest and sourced, so the shipped code is what runs here. Only `gh` is stubbed.
+# Same approach as tests/detect-partial-landing.sh: the functions under test are extracted verbatim
+# from the action manifest and sourced. Only `gh` is stubbed.
 #
 # What this covers is the lost-update race. The reconcile sweep runs merge-gate as a matrix over
 # every open member pull request with no concurrency bound, and render-epic-status edits the same
-# issue body from a job that does not wait for it — so writers overlap by design, against an API with
+# issue body from a job that does not wait for it, so writers overlap by design against an API with
 # no conditional update.
 #
-# The subtle half is not the write, it is what the write DOES WITH a decision made earlier. `$do` and
-# `$payload` are computed from a body read before the loop; a writer that re-reads but does not
-# re-derive will freeze a member set the world has already moved past, and a retry loop makes it win.
-# Several cases below exist only to pin that.
+# The write acts on a decision made earlier: `$do` and `$payload` are computed from a body read
+# before the loop, so a writer that re-reads without re-deriving freezes a member set the world has
+# already moved past, and a retry loop makes it win. Several cases below exist to pin that.
 #
-# Scope: this drives `write_marker` and its helpers. The decision step that PRODUCES `$do`/`$payload`
-# (the `do=` jq, and the MEMBERS normalization above it) is not extracted and is not covered here —
-# the fixtures set those as inputs. Their reachable range was checked by hand against that jq; adding
-# a decision-step suite is the obvious next increment.
+# Scope: this drives `write_marker` and its helpers. The decision step that produces `$do`/`$payload`
+# (the `do=` jq, and the member normalization above it) is not extracted; the fixtures set those as
+# inputs.
 set -euo pipefail
 
 TOP_PID=$$
@@ -49,14 +47,14 @@ if ! bash -n "$WORK/lib.sh"; then
 fi
 
 export ORG=a-novel-kit PLANNING_REPO=.github EPIC=900
-# The re-derive guard re-checks AGE, so the harness must supply the same clock the step does.
+# The re-derive guard re-checks age, so the harness supplies the same clock the step does.
 export STABILIZE_SECONDS=120
 now=2026-07-22T10:00:00Z
 export GITHUB_STEP_SUMMARY="$WORK/summary.md"
-# Fences and region layout, read OUT OF THE MANIFEST. The fence literal is shared by merge-gate,
-# epic-membership and detect-partial-landing, so a restated copy here could not see the writer drift
-# away from both readers; and the ORDER inside the region matters — put the payload above the note
-# and `current_marker` reads every marker as absent.
+# Fences and region layout are read out of the manifest. The fence literal is shared by merge-gate,
+# epic-membership and detect-partial-landing, so a copy restated here could not catch the writer
+# drifting away from both readers. The order inside the region matters: put the payload above the
+# note and `current_marker` reads every marker as absent.
 START=$(sed -n "s/^ *START='\(.*\)'\$/\1/p" "$ACTION" | head -1)
 END=$(sed -n "s/^ *END='\(.*\)'\$/\1/p" "$ACTION" | head -1)
 [ -n "$START" ] && [ -n "$END" ] || die "could not read the fence literals from $ACTION"
@@ -70,10 +68,9 @@ sleep() { :; }
 
 # ---- the stubbed body store ---------------------------------------------------------------
 # $WORK/body is the issue body on the server. $WORK/steal, when non-empty, is a peer write that lands
-# immediately AFTER ours, once — the case an exit-code check calls a win. It models what the real peer
-# (render-epic-status) does: keep what it found and add its own section OUTSIDE our region. A stub
-# that replaced the whole body would delete that prose, and then no assertion could observe a lost
-# update at all — which is the one thing this suite exists to see.
+# immediately after ours, once — the case an exit-code check calls a win. It models what render-epic-
+# status does: keep what it found and add its own section outside our region, so a lost update shows
+# up as that section disappearing.
 gh() {
   case "$*" in
     *"issues/${EPIC}"*)
@@ -83,25 +80,25 @@ gh() {
         printf '%s' "$(($(< "$WORK/read_fails") - 1))" > "$WORK/read_fails"
         return 1
       fi
-      # Fail every read from the Nth onward — lets a read failure follow an edit failure, which is
-      # the only order in which the per-attempt `err` reset is observable.
+      # Fail every read from the Nth onward, so a read failure can follow an edit failure — the only
+      # order in which the per-attempt `err` reset is observable.
       if [ -s "$WORK/read_fail_from" ] && [ "$(wc -c < "$WORK/reads")" -ge "$(< "$WORK/read_fail_from")" ]; then
         return 1
       fi
-      # GitHub stores bodies with CRLF. Serving LF would leave every `tr -d '\r'` in the action
-      # untested while its comments assert the strip is load-bearing.
+      # GitHub stores bodies with CRLF, so the stub serves them that way and the action's
+      # `tr -d '\r'` is exercised.
       sed 's/$/\r/' "$WORK/body"
       ;;
     *"issue edit"*)
       [ -s "$WORK/edit_fails" ] && { printf 'x' >> "$WORK/writes"; echo "gh: HTTP 422" >&2; return 1; }
-      # NOTE: ${*##pattern} strips per-positional-parameter and rejoins — join first, then strip.
+      # ${*##pattern} strips per positional parameter and rejoins, so join first and strip after.
       local all="$*" f
       f="${all##*--body-file }"; f="${f%% *}"
       printf 'x' >> "$WORK/writes"
       # A write that silently does not land — the API returned success but the body is unchanged.
       [ -s "$WORK/noop" ] || cp "$f" "$WORK/body"
-      # Real `gh issue edit` prints the issue URL on success. Without it, capturing the command's
-      # stdout into the error variable is invisible.
+      # Real `gh issue edit` prints the issue URL on success, so a run that captures its stdout into
+      # the error variable is visible here.
       echo "https://github.com/${ORG}/${PLANNING_REPO}/issues/${EPIC}"
       # File-backed for the same reason as read_fails: the write runs inside $( ), so clearing a
       # shell variable here would never reach the parent and the peer would strike on every attempt.
@@ -111,23 +108,21 @@ gh() {
   esac
 }
 
-# repo-a carries the HIGHER number on purpose: sorting by repo and sorting by number then give
-# different answers, so a guard using the wrong key is observable.
+# repo-a carries the higher number, so sorting by repo and sorting by number give different answers
+# and a guard using the wrong key is observable.
 M1='[{"repo":"a-novel-kit/repo-a","number":5}]'
 M2='[{"repo":"a-novel-kit/repo-a","number":5},{"repo":"a-novel-kit/repo-b","number":2}]'
-# Same size as M2, different members: without this, every "members differ" case also differs in
-# COUNT, and comparing lengths would be indistinguishable from comparing sets.
+# Same size as M2, different members, so comparing lengths is distinguishable from comparing sets.
 M2B='[{"repo":"a-novel-kit/repo-a","number":5},{"repo":"a-novel-kit/repo-c","number":3}]'
-# Two members in ONE repo, numbers out of input order: sorting by repo alone is stable and leaves them
-# as given, so only the composite (repo, number) key produces the canonical order.
+# Two members in one repo, numbers out of input order: sorting by repo alone is stable and leaves
+# them as given, so the canonical order needs the composite (repo, number) key.
 M2S='[{"repo":"a-novel-kit/repo-a","number":2},{"repo":"a-novel-kit/repo-a","number":9}]'
 
 pending_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --argjson m "$1" '{status:"pending", at:$at, members:$m}'; }
 frozen_json() { jq -cn --argjson m "$1" '{status:"frozen", members:$m}'; }
 
-# The note the action actually writes, read OUT OF THE MANIFEST. Restating it here is how a fixture
-# comes to encode a belief instead of the format: a note that ever began with `[` or `{` would make
-# current_marker latch onto it and read every marker as absent, and a paraphrase could never show it.
+# The note the action writes, read out of the manifest: a note beginning with `[` or `{` would make
+# current_marker latch onto it and read every marker as absent, which a restated copy could not show.
 note_of() { # frozen|pending
   local key=FROZEN
   [ "$1" = frozen ] || key=PENDING
@@ -139,9 +134,8 @@ region_file() { # $1 = payload json, $2 = frozen|pending -> the region the actio
   [ -n "$note" ] || die "could not read the note text from $ACTION"
   payload="$1"
   f=$(mktemp -p "$WORK"); regionf="$f"
-  # Run the manifest's own assembly rather than a copy of it.
-  # `$( )` strips the trailing newline, so the closing brace needs its own separator or bash
-  # reads it as an argument to the last command.
+  # Run the manifest's own assembly. `$( )` strips the trailing newline, so the closing brace needs
+  # its own separator or bash reads it as an argument to the last command.
   eval "{ $REGION_BLOCK
 } > \"\$regionf\""
   printf '%s' "$f"
@@ -170,13 +164,13 @@ reset() {
   : > "$WORK/edit_fails"; : > "$WORK/read_fail_from"; : > "$WORK/reads"
   : > "$GITHUB_STEP_SUMMARY"; server_body ""
 }
-# Capture the function's own output so it cannot be mistaken for the exit code, and so both tee'd
-# and plain log lines can be asserted from one place.
+# Capture the function's output so it cannot be mistaken for the exit code, and so tee'd and plain
+# log lines are asserted from one place.
 run() { write_marker "$(region_file "$payload" "$do")" > "$WORK/out" 2>&1 && echo 0 || echo $?; }
 said() { grep -q "$1" "$WORK/out"; }
 
-# The MEMBERS normalization, lifted from the manifest. It decides what `$cur` IS, so the
-# members-moved branch and both re-derive guards all rest on it — and it had no coverage.
+# The member normalization, lifted from the manifest. It decides what `$cur` is, so the
+# members-moved branch and both re-derive guards rest on it.
 NORMALIZE_JQ=$(awk '/^ *cur=\$\(printf/{f=1;next} f{print} f&&/\)$/{exit}' "$ACTION" \
   | sed "s/^[[:space:]]*'//; s/')$//")
 [ -n "$NORMALIZE_JQ" ] || die "could not read the member normalization from $ACTION"
@@ -185,7 +179,7 @@ normalize() { printf '%s' "$1" | jq -c "$NORMALIZE_JQ" 2>/dev/null || echo '[]';
 echo "the member set is canonical, whatever casing GitHub answers with"
 # GitHub resolves repository names case-insensitively and may answer with either spelling. If the
 # normalized set differs between passes the decision reads "members moved", resets the stabilization
-# clock, and the Epic never freezes — silently, forever.
+# clock, and the Epic never freezes.
 mixed='[{"repo":"A-Novel-Kit/repo-b","number":2},{"repo":"a-novel-kit/repo-a","number":1}]'
 lower='[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"a-novel-kit/repo-a","number":1}]'
 eq "two casings of one set normalize identically" "$(normalize "$mixed")" "$(normalize "$lower")"
@@ -197,8 +191,8 @@ eq "a case-variant duplicate is one member" \
   "$(normalize '[{"repo":"a-novel-kit/R","number":1},{"repo":"a-novel-kit/r","number":1}]' | jq 'length')" 1
 
 echo "the marker contract is shared by three actions"
-# A derived fixture follows merge-gate's fences rather than catching a change in them; what it cannot
-# see is the writer drifting away from the two READERS. Assert the contract across all three.
+# A fixture derived from the manifest follows merge-gate's fences wherever they move, so the writer
+# drifting away from its two readers is asserted separately.
 for d in epic-membership detect-partial-landing; do
   f="$ROOT/generic-actions/$d/action.yaml"
   if [ ! -f "$f" ]; then ko "$d/action.yaml is missing"; continue; fi
@@ -220,8 +214,8 @@ echo
 echo "a peer that writes after us"
 reset
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
-# The peer reverts the body, discarding our write. Nothing about that invalidates a pending decision,
-# so we should notice and retry rather than trust the edit's exit code.
+# The peer reverts the body, discarding our write. A pending decision survives that, so the pass
+# notices and retries instead of trusting the edit's exit code.
 { cat "$WORK/body"; printf '\n<!-- rendered by the peer -->\n'; } > "$WORK/steal"
 eq "we retry until our write survives" "$(run)" 0
 eq "and our marker is what finally stands" "$(marker_now | jq -r '.members | length')" 2
@@ -233,7 +227,7 @@ grep -q 'rendered by the peer' "$WORK/body" \
 echo
 echo "a wiped marker invalidates a freeze in flight"
 # A freeze means "the set held still since this pending marker". If the marker is gone, that premise
-# cannot be re-established, so the pass abandons rather than freezing on faith.
+# cannot be re-established, so the pass abandons.
 reset
 server_body "$(pending_json "$M2" 2026-07-22T09:00:00Z)"
 do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
@@ -253,9 +247,9 @@ said 'already frozen' && ok "and it says so in the run log" || ko "the yield is 
 
 echo
 echo "a stale freeze must not become permanent"
-# THE case this rewrite exists for. Our pass decided `frozen` against members=M2. A peer has since
-# seen the set change to M1 and reset the clock. Freezing M2 now would make a superseded set
-# terminal — and the member it drops is then held forever by the gate.
+# Our pass decided `frozen` against members=M2, and a peer has since seen the set change to M1 and
+# reset the clock. Freezing M2 now would make a superseded set terminal, and the gate would hold the
+# member it drops forever.
 reset
 server_body "$(pending_json "$M1" 2026-07-22T10:05:00Z)"
 do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
@@ -267,8 +261,8 @@ said 'member set moved' && ok "and the abandonment is explained" || ko "abandoni
 
 echo
 echo "equivalent writers agree instead of fighting"
-# Two writers with the same member set differ only in `at`. Byte-equality would leave neither able to
-# satisfy the other: they would ping-pong to exhaustion and both report a failure that never happened.
+# Two writers with the same member set differ only in `at`. Under byte-equality neither could satisfy
+# the other, and both would ping-pong to exhaustion reporting a failure that never happened.
 reset
 server_body "$(pending_json "$M2" 2026-07-22T09:59:00Z)"
 do=pending; cur="$M2"; payload=$(pending_json "$M2" 2026-07-22T10:00:00Z)
@@ -281,9 +275,8 @@ echo "an orphaned payload line does not satisfy the verify"
 # would match that orphan and report success while the region says something else.
 reset
 orphan=$(frozen_json "$M2")
-# The body carries our exact payload as loose prose (what splice's recovery path leaves behind) plus
-# a region saying something else. The write does not land, so a correct verify must fail — a
-# whole-body grep would match the orphan and report success.
+# The body carries our exact payload as loose prose plus a region saying something else, and the
+# write does not land.
 printf 'Some prose.\n%s\n\n%s\n%s\n%s\n%s\n' "$orphan" "$START" "$(note_of pending)" \
   "$(pending_json "$M2" 2026-07-22T09:00:00Z)" "$END" > "$WORK/body"
 printf 'x' > "$WORK/noop"
@@ -292,9 +285,8 @@ eq "a write that never landed is not masked by the orphan" "$(run)" 1
 eq "and the region still says what it did" "$(marker_now | jq -r .status)" pending
 
 echo "a marker that cannot age must be repaired, not accepted"
-# The decision step routes a corrupt or missing `at` here on purpose: a timestamp that cannot be read
-# can never age, so the marker would sit pending forever and the Epic would keep live membership —
-# with a success line every sweep. An equivalence test that ignores `at` must not swallow that.
+# The decision step routes a corrupt or missing `at` here: a timestamp that cannot be read never
+# ages, so the marker would sit pending forever while every sweep logged success.
 for bad in '"not-a-date"' 'null'; do
   reset
   server_body "$(jq -cn --argjson m "$M2" --argjson at "$bad" '{status:"pending", at:$at, members:$m}')"
@@ -315,9 +307,9 @@ eq "and the marker is frozen" "$(marker_now | jq -r .status)" frozen
 
 echo
 echo "a freeze must not skip the stabilization window"
-# The decision step only says `frozen` once the marker has held still past STABILIZE_SECONDS. If the
-# guard does not re-check age, a peer's clock reset can be overtaken seconds later — freezing before
-# the lagging label index has had its window to surface a missing member.
+# The decision step says `frozen` only once the marker has held still past STABILIZE_SECONDS. Without
+# an age re-check in the guard, a peer's clock reset is overtaken seconds later and the freeze lands
+# before the lagging label index can surface a missing member.
 reset
 server_body "$(pending_json "$M2" 2026-07-22T09:59:30Z)"   # 30s old, threshold is 120s
 do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
@@ -327,8 +319,8 @@ eq "and the marker stays pending" "$(marker_now | jq -r .status)" pending
 
 echo
 echo "member order is not a reason to abandon"
-# The decision step compares members sorted; the re-derive guard must too, or a marker the decision
-# calls stable is judged moved and the freeze is refused on every sweep forever.
+# The decision step compares members sorted, and so does the re-derive guard; otherwise a marker the
+# decision calls stable is judged moved and the freeze is refused on every sweep.
 reset
 server_body "$(jq -cn --argjson m "$M2" '{status:"pending", at:"2026-07-22T09:00:00Z", members:($m | reverse)}')"
 do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
@@ -338,8 +330,7 @@ eq "and the marker is frozen" "$(marker_now | jq -r .status)" frozen
 echo
 echo "splice, on its own"
 # Driven directly, because the retry loop hides it: a broken splice writes a body with no fences, the
-# next attempt takes the fallback branch, appends a correct region, and the verify passes. Every
-# splice defect therefore reads as a green suite unless it is exercised on its own.
+# next attempt takes the fallback branch, appends a correct region, and the verify passes.
 sp() { # $1 = body text, $2 = payload -> the spliced result
   local b r
   b=$(mktemp -p "$WORK"); r=$(region_file "$2" frozen)
@@ -355,8 +346,8 @@ eq "an existing region is replaced in place" "$(inner "$out" | jq -r .status)" f
 one_region "$out" && ok "leaving exactly one region" || ko "region count wrong"
 grep -q '^top$' <<< "$out" && grep -q '^bottom$' <<< "$out" \
   && ok "with the prose either side intact" || ko "prose was dropped by the in-place branch"
-# The replaced payload must be GONE, not merely out of the region: a stale copy left loose in the
-# body is what lets a whole-body match report a marker that is not there.
+# The replaced payload leaves the body entirely: a stale copy left loose in it is what lets a
+# whole-body match report a marker that is not there.
 grep -qF -- "$(pending_json "$M1")" <<< "$out" \
   && ko "the replaced payload is still in the body" \
   || ok "and the payload it replaced is gone entirely"
@@ -370,9 +361,9 @@ one_region "$out" && ok "duplicate fences are healed to one region" || ko "dupli
 grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
   && ok "without dropping the prose around them" || ko "prose was destroyed healing duplicate fences"
 
-# Prose BETWEEN a stray fence and the end is the shape that discriminates: an in-place replace spans
+# Prose between a stray fence and the end discriminates the two branches: an in-place replace spans
 # from the first START to the END and discards everything inside, while the recovery path strips the
-# fence lines and keeps it. A malformed region must take the recovery path.
+# fence lines and keeps it. A malformed region takes the recovery path.
 out=$(sp "$(printf '%s\nHUMAN-A\n%s\nHUMAN-B\n%s\n' "$START" "$START" "$END")" "$P")
 one_region "$out" && ok "an unbalanced fence pair is healed to one region" || ko "unbalanced fences survived"
 grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
@@ -384,8 +375,8 @@ grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
 
 echo
 echo "same status, different members of the same size"
-# Without this, every members-differ case also differs in COUNT, so comparing lengths would pass for
-# comparing sets — in both the equivalence check and the re-derive guard.
+# Every other members-differ case also differs in count, so comparing lengths would pass for
+# comparing sets in both the equivalence check and the re-derive guard.
 reset
 server_body "$(pending_json "$M2B" 2026-07-22T09:00:00Z)"
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
@@ -400,8 +391,7 @@ eq "writing nothing" "$(writes)" 0
 
 echo
 echo "a shorter peer set is a difference, not a match"
-# The index-lag shape: a peer wrote a strict subset. If the comparison is a subset test rather than
-# equality, no writer ever corrects it.
+# The index-lag shape: a peer wrote a strict subset. Under a subset test no writer ever corrects it.
 reset
 server_body "$(pending_json "$M1" 2026-07-22T09:00:00Z)"
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
@@ -413,7 +403,7 @@ echo "a region holding more than one value"
 # jq -s '.[0]' takes the first. If a hand-edit leaves two, the first wins — including an empty frozen
 # set, which would pin the Epic to no members at all.
 reset
-# BOTH values sit inside the fences — that is what makes "first" meaningful.
+# Both values sit inside the fences, which is what makes "first" meaningful.
 printf 'prose\n%s\n%s\n%s\n%s\n%s\n' "$START" "$(note_of pending)" \
   "$(pending_json "$M1")" "$(jq -cn '{status:"frozen",members:[]}')" "$END" > "$WORK/body"
 eq "the first value in the region is the one read" "$(marker_now | jq -r '.status')" pending
@@ -422,9 +412,8 @@ eq "not the last" "$(marker_now | jq -r '.members | length')" 1
 echo
 
 echo "a clobbered repair is retried, not reported as done"
-# The entry check knows an unreadable `at` is not equivalent; the VERIFY must know it too. If it
-# falls back to a plain equivalence test, a repair that a peer immediately undid reads as landed —
-# the marker never ages, and the log says success.
+# The verify applies the same unreadable-`at` test as the entry check. Under a plain equivalence test
+# a repair a peer immediately undid reads as landed, the marker never ages, and the log says success.
 reset
 bad=$(jq -cn --argjson m "$M2" '{status:"pending", at:"not-a-date", members:$m}')
 server_body "$bad"
@@ -455,8 +444,8 @@ said 'HTTP 422' && ok "and the API's own error text is surfaced, not swallowed" 
 
 echo
 echo "a give-up after mixed failures names a real cause"
-# err is cleared each attempt so a give-up cannot quote an earlier attempt's error. That reset is
-# only observable when the LAST attempts fail somewhere that sets no error of its own.
+# `err` is cleared each attempt so a give-up cannot quote an earlier attempt's error. The reset is
+# only observable when the last attempts fail somewhere that sets no error of its own.
 reset
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
 printf 'x' > "$WORK/edit_fails"

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -121,8 +121,8 @@ M2S='[{"repo":"a-novel-kit/repo-a","number":2},{"repo":"a-novel-kit/repo-a","num
 pending_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --argjson m "$1" '{status:"pending", at:$at, members:$m}'; }
 frozen_json() { jq -cn --argjson m "$1" '{status:"frozen", members:$m}'; }
 
-# The note the action writes, read out of the manifest: a note beginning with `[` or `{` would make
-# current_marker latch onto it and read every marker as absent, which a restated copy could not show.
+# The note the action writes, read out of the manifest: a note beginning with `[` or `{` makes
+# current_marker latch onto it and read every marker as absent, which a restated copy cannot show.
 note_of() { # frozen|pending
   local key=FROZEN
   [ "$1" = frozen ] || key=PENDING
@@ -215,7 +215,7 @@ echo "a peer that writes after us"
 reset
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
 # The peer reverts the body, discarding our write. A pending decision survives that, so the pass
-# notices and retries instead of trusting the edit's exit code.
+# notices the loss and retries; the edit's exit code says nothing about it.
 { cat "$WORK/body"; printf '\n<!-- rendered by the peer -->\n'; } > "$WORK/steal"
 eq "we retry until our write survives" "$(run)" 0
 eq "and our marker is what finally stands" "$(marker_now | jq -r '.members | length')" 2
@@ -248,8 +248,8 @@ said 'already frozen' && ok "and it says so in the run log" || ko "the yield is 
 echo
 echo "a stale freeze must not become permanent"
 # Our pass decided `frozen` against members=M2, and a peer has since seen the set change to M1 and
-# reset the clock. Freezing M2 now would make a superseded set terminal, and the gate would hold the
-# member it drops forever.
+# reset the clock. Freezing M2 now makes a superseded set terminal, and the gate then holds the member
+# it drops forever.
 reset
 server_body "$(pending_json "$M1" 2026-07-22T10:05:00Z)"
 do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
@@ -261,8 +261,8 @@ said 'member set moved' && ok "and the abandonment is explained" || ko "abandoni
 
 echo
 echo "equivalent writers agree instead of fighting"
-# Two writers with the same member set differ only in `at`. Under byte-equality neither could satisfy
-# the other, and both would ping-pong to exhaustion reporting a failure that never happened.
+# Two writers with the same member set differ only in `at`. Under byte equality neither satisfies the
+# other, and both ping-pong to exhaustion reporting a failure that never happened.
 reset
 server_body "$(pending_json "$M2" 2026-07-22T09:59:00Z)"
 do=pending; cur="$M2"; payload=$(pending_json "$M2" 2026-07-22T10:00:00Z)
@@ -286,7 +286,7 @@ eq "and the region still says what it did" "$(marker_now | jq -r .status)" pendi
 
 echo "a marker that cannot age must be repaired, not accepted"
 # The decision step routes a corrupt or missing `at` here: a timestamp that cannot be read never
-# ages, so the marker would sit pending forever while every sweep logged success.
+# ages, leaving the marker pending forever while every sweep logs success.
 for bad in '"not-a-date"' 'null'; do
   reset
   server_body "$(jq -cn --argjson m "$M2" --argjson at "$bad" '{status:"pending", at:$at, members:$m}')"
@@ -375,8 +375,8 @@ grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
 
 echo
 echo "same status, different members of the same size"
-# Every other members-differ case also differs in count, so comparing lengths would pass for
-# comparing sets in both the equivalence check and the re-derive guard.
+# Every other members-differ case also differs in count, so a length compare passes for a set compare
+# in both the equivalence check and the re-derive guard. This case tells the two apart.
 reset
 server_body "$(pending_json "$M2B" 2026-07-22T09:00:00Z)"
 do=pending; cur="$M2"; payload=$(pending_json "$M2")

--- a/tests/release-train.sh
+++ b/tests/release-train.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 # Regression tests for release-train's fail-closed reads.
 #
-# Same discipline as detect-partial-landing.sh: the functions under test are EXTRACTED verbatim from
-# the manifest and sourced, so what runs here is what ships. Only `gh` is stubbed, and it can fail on
-# demand — the whole point being that a read failure must not be readable as a benign outcome.
+# Same discipline as detect-partial-landing.sh: the functions under test are extracted verbatim from
+# the manifest and sourced. Only `gh` is stubbed, and it can fail on demand, since the point is that
+# a read failure must not read as a benign outcome.
 #
-# Two defects are covered, and they share a shape. derive_bump mapped a failed commit-range read onto
-# the same value as an empty range ("none"), so a transient API error skipped a repo, recorded it as
-# nochange, and left the run green — and since nothing marked a failure, a re-dispatch recomputed the
-# same skip forever. splice_body is the other end of it: fed the empty body a failed read produced, it
-# returns a body holding only the receipt block, which the PATCH would then write over the Epic's
-# prose and its frozen activation snapshot.
+# Two paths share that shape. derive_bump distinguishes a failed commit-range read from an empty
+# range: mapping both onto "none" skips a repo, records it as nochange, and leaves the run green,
+# and with nothing marking a failure a re-dispatch recomputes the same skip. splice_body is the other
+# end — fed the empty body a failed read produces, it returns a body holding only the receipt block,
+# which the PATCH would write over the Epic's prose and its frozen activation snapshot.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -34,8 +33,7 @@ for fn in commit_messages derive_bump splice_body; do
   fi
   printf '%s\n' "$out" >> "$WORK/lib.sh"
 done
-# Extraction stops at the first 8-space `}`. If that ever lands mid-function the result is invalid
-# bash, and without this check the suite fails later with a confusing unbound-variable abort.
+# Extraction stops at the first 8-space `}`; if that lands mid-function the result is invalid bash.
 if ! bash -n "$WORK/lib.sh"; then
   echo "::error::extracted functions do not parse — extraction truncated a definition"
   exit 1
@@ -44,7 +42,7 @@ fi
 sleep() { :; } # the retry loop's wall-clock delay is not useful here
 
 # ---- stubbed leaf -----------------------------------------------------------------------
-# GH_FAIL=1 makes every read fail, which is the condition both defects hid behind.
+# GH_FAIL=1 makes every read fail, the condition both paths turn on.
 # GH_SUBJECTS holds the commit messages a successful read returns.
 GH_FAIL=0
 GH_SUBJECTS=""
@@ -104,16 +102,15 @@ BLOCK='<!-- release-train:receipts:start -->
 ### receipts
 <!-- release-train:receipts:end -->'
 
-# This is what the PATCH used to write when the read failed. The assertion is not that splice_body is
-# wrong — given an empty body it can only produce this — but that the result is destructive, which is
-# why the caller has to refuse to reach it.
+# Given an empty body, splice_body can only return a block-only body. The assertion pins that result
+# as destructive, which is why the caller refuses to reach it.
 spliced=$(splice_body "" "$BLOCK")
 case "$spliced" in
   *"human prose"*) check "empty input keeps prose" "impossible" "kept" ;;
   *) echo "  ok   an empty body yields a block-only body (the destructive case the caller must avoid)" ;;
 esac
 
-# The healthy paths still behave: prose survives, and the region is replaced rather than appended.
+# The healthy paths: prose survives, and an existing region is replaced in place.
 BODY='Some human prose.
 
 <!-- release-train:receipts:start -->

--- a/tests/release-train.sh
+++ b/tests/release-train.sh
@@ -9,7 +9,7 @@
 # range: mapping both onto "none" skips a repo, records it as nochange, and leaves the run green,
 # and with nothing marking a failure a re-dispatch recomputes the same skip. splice_body is the other
 # end — fed the empty body a failed read produces, it returns a body holding only the receipt block,
-# which the PATCH would write over the Epic's prose and its frozen activation snapshot.
+# and the PATCH then writes that over the Epic's prose and its frozen activation snapshot.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)


### PR DESCRIPTION
## Summary

- Comment-only sweep across the actions, reusable workflows and bash test harnesses: cut verbosity, state the positive claim instead of the contrast, and drop justification of designs nobody wrote.
- 39 files, roughly 180 comment lines removed net. All 27 shouted words in `detect-partial-landing` are gone; the acronyms and GraphQL enum values (`REST`, `JSON`, `MERGED`/`CLOSED`/`OPEN`, `CRLF`, `ISO`) stay.
- This repo was the densest in the sweep, and its comments are the ones most likely to be load-bearing. Every named constraint survives.

## What a reviewer should scrutinise

- **`detect-partial-landing` was swept twice.** Its first sweep was discarded during the rebase onto `d89661b`, which rewrote both files, and it was then swept fresh from the merged content — so the wave-boundary logic is `master`'s, unmerged with any earlier prose. `action.yaml` 376 → 342 comment lines, `tests/detect-partial-landing.sh` 151 → 139.
- **The `snapshot_buckets` corroboration block** argued why two rejected paths are both wrong. It now states the fail-safe rule once — an untrustworthy marker decides nothing (rc 1), leaving any prior freeze in place — with the attacker-chosen-subset and blind-spot facts as supporting statements.
- **The `AGENT_KILL_SWITCH` mint-vs-halt paragraph** appeared verbatim in four actions (`enable-auto-merge`, `board-write`, `rollup-board`, `render-epic-status`), each time defending why the token is minted before the halt guard. Deleted in all four; the fail-safe semantics and the per-action consequence stay.
- **One comment was wrong.** `standalone_sweep`'s doc said the backstop runs "after the epic loop". `sweep_main` calls it *before* the loop, deliberately — the next comment block explains why ("backstop first, so the epic pass posts last and wins on a contested head"). Corrected.

## Constraints kept, argument cut

Bash 3.x (`${VAR,,}` is 4+, macOS runners), `jq`'s `$` matching before a final newline, GitHub answering a malformed time qualifier with zero rows and no `errors` array, `--paginate`'s 30-ref page, GH013 "without workflows permission", `./` in a composite action resolving against the consumer, the composite-action `vars` context trap, fd-3/5/7/8 stdin isolation, the newline-to-workflow-command injection vector, and the 300-second skew allowance on the boundary clock.

Conditionals were kept wherever the condition genuinely occurs: a leftover ephemeral branch blocking a fresh cut, a repo outside the enqueue token's scope 403-ing mid-wave, `gh` coercing an all-digit option id passed via `-F`, `pnpm 11`'s verify-deps pre-hook aborting with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

## Not touched

Action `description:` fields. They are YAML values rather than comments, and they are mirrored by hand into the README catalog, so sweeping them desyncs the catalog. Several of the repo's worst preambles live there — worth a follow-up that does both together.

## Non-comment changes

One: a trailing comment on `FX_QUEUE='[]'` in a test fixture (the code and its column padding are byte-identical), plus a stray double blank line inside a `run:` block in `merge-gate/action.yaml` collapsed to one, between two comment paragraphs.

## Breaking changes

None. No action input, output, or behaviour changed.

## Test plan

- [x] Every changed YAML parses under `yaml.safe_load`; `bash -n` clean on all three `.sh` files
- [x] All three extraction-based suites pass as `main.yaml` runs them (132 / 76 / release-train green) — these lift functions verbatim out of the `run:` blocks, so a broken indent surfaces here
- [x] `prettier@3.9.2 --check` clean on all 36 changed YAML files
- [ ] CI green