### PR TITLE
fix(ci): detect composite-illegal contexts anywhere in an expression

### DIFF
--- a/.github/scripts/lint-action-manifests.sh
+++ b/.github/scripts/lint-action-manifests.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Reject expression contexts that do not exist for a composite action.
+#
+# GitHub expression-evaluates a composite action's WHOLE manifest when it loads it — input
+# descriptions, run: strings, bash comments inside them. vars, secrets, needs, matrix and strategy
+# are not available there, so one such reference anywhere in the file makes the action fail to LOAD
+# for every consumer. That took merge-gate offline across both orgs until v1.12.1.
+#
+# The manifests document caller syntax by writing those names as PLAIN TEXT (`vars.AGENT_KILL_SWITCH`
+# with no ${{ }} around it), which is legal and deliberate. So the check cannot simply grep for the
+# names: it has to know whether an occurrence sits inside an expression.
+#
+# That distinction is the whole difficulty, and why two simpler versions of this check were wrong:
+#
+#   ${{ vars.X }}                        caught by anchoring to the start of the expression
+#   ${{ inputs.a || vars.X }}            NOT caught — the context is not the first token
+#   ${{ format('{0}', secrets.X) }}      NOT caught by ${{[^}]*}} either — [^}]* stops at the } in '{0}'
+#
+# So the scan walks each line tracking whether it is inside a ${{ … }} region, and reports only the
+# occurrences that are. Expressions are treated as line-local, which is what they are in these
+# manifests; a context split across a block scalar would be missed.
+set -euo pipefail
+
+ROOT="${1:-.}"
+
+fail=0
+
+while IFS= read -r file; do
+  # Only composite actions are affected. A reusable workflow may use these contexts freely.
+  grep -qE 'using:[[:space:]]*"?composite' "$file" || continue
+
+  hits=$(awk '
+    {
+      line = $0
+      len = length(line)
+      inside = 0
+      i = 1
+
+      while (i <= len) {
+        if (substr(line, i, 3) == "${{") { inside = 1; i += 3; continue }
+        if (inside && substr(line, i, 2) == "}}") { inside = 0; i += 2; continue }
+
+        if (inside) {
+          rest = substr(line, i)
+          prev = (i > 1) ? substr(line, i - 1, 1) : " "
+
+          # A leading word character means this is the tail of a longer name (myvars.x), not the
+          # context itself.
+          if (prev !~ /[A-Za-z0-9_.]/ && rest ~ /^(vars|secrets|needs|matrix|strategy)\./) {
+            match(rest, /^(vars|secrets|needs|matrix|strategy)\.[A-Za-z0-9_.-]*/)
+            printf "%d:%s\n", NR, substr(rest, 1, RLENGTH)
+          }
+        }
+
+        i++
+      }
+    }
+  ' "$file")
+
+  if [ -n "$hits" ]; then
+    while IFS= read -r hit; do
+      echo "::error file=${file},line=${hit%%:*}::\`${hit#*:}\` is inside a \${{ }} expression, and that context does not exist for a composite action — the action will fail to LOAD for every consumer. Write the context as plain text to document it, or thread the value in as an input. See the v1.12.1 load-failure incident."
+    done <<<"$hits"
+
+    fail=1
+  fi
+done < <(find "$ROOT" -type f \( -name action.yaml -o -name action.yml \) -not -path '*/node_modules/*')
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+echo "✓ no composite-illegal expression contexts in any action manifest."

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,21 +42,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+      # The detector lives in a script rather than inline so tests/lint-action-manifests.sh can run
+      # the shipped code against fixtures. The previous inline version anchored the context to the
+      # start of its expression and so missed every compound one — a gate nobody had proven caught
+      # anything, because it had no negative case.
       - name: No composite-illegal expression contexts in action manifests
         shell: bash
-        run: |
-          set -euo pipefail
-          fail=0
-          while IFS= read -r f; do
-            # Only composite actions are affected; a reusable workflow is not one.
-            grep -qE 'using:[[:space:]]*"?composite' "$f" || continue
-            if grep -nE '\$\{\{[[:space:]]*(vars|secrets|needs|matrix|strategy)\.' "$f"; then
-              echo "::error file=$f::references a context unavailable to composite actions (vars/secrets/needs/matrix/strategy) — deliteralize it: write the context as plain text (e.g. \`vars.X\`), never inside a template expression. See the v1.12.1 load-failure incident."
-              fail=1
-            fi
-          done < <(find . -type f -name action.yaml -not -path './node_modules/*')
-          if [ "$fail" -ne 0 ]; then exit 1; fi
-          echo "✓ no composite-illegal expression contexts in any action manifest."
+        run: bash .github/scripts/lint-action-manifests.sh .
 
   # The landing-saga actions are bash, and their freeze, clear and hold decisions are too costly to
   # get wrong to leave unexercised. Each suite in tests/ extracts the functions it covers straight out

--- a/tests/lint-action-manifests.sh
+++ b/tests/lint-action-manifests.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Regression tests for the composite-manifest context lint.
+#
+# A gate with no negative case is a gate nobody has proven catches anything, which is exactly how the
+# previous version of this check stayed vacuous: it ran on every PR, printed a tick, and would have
+# missed the reference that took merge-gate offline org-wide had it been written as anything other
+# than the first token of its expression.
+#
+# So every case below is a manifest the linter is run against for real, and the two halves matter
+# equally: the violations must fail, and the deliberate plain-text prose must not.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+LINTER="$ROOT/.github/scripts/lint-action-manifests.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+fails=0
+
+# writes a composite manifest whose run: step is $2, into its own directory
+fixture() { # $1=name $2=run body
+  mkdir -p "$WORK/$1"
+  cat >"$WORK/$1/action.yaml" <<EOF
+name: $1
+description: fixture
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        $2
+EOF
+  printf '%s' "$WORK/$1"
+}
+
+check() { # $1=label $2=expected(pass|fail) $3=dir
+  if bash "$LINTER" "$3" >/dev/null 2>&1; then
+    got=pass
+  else
+    got=fail
+  fi
+
+  if [ "$got" = "$2" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected the linter to $2, it did $got"
+    fails=$((fails + 1))
+  fi
+}
+
+echo "== violations the linter must catch =="
+
+check "context as the first token" fail \
+  "$(fixture first-token 'echo "${{ vars.AGENT_KILL_SWITCH }}"')"
+
+# The case the anchored version missed. This is what a contributor writes when making an input
+# self-defaulting, and it is indistinguishable to GitHub from the one above.
+check "context after an operator" fail \
+  "$(fixture after-operator 'echo "${{ inputs.kill_switch || vars.AGENT_KILL_SWITCH }}"')"
+
+# The case a widened ${{[^}]*}} pattern would still miss: [^}]* stops at the } inside '{0}'.
+check "context inside a function call with braces" fail \
+  "$(fixture inside-format "echo \"\${{ format('{0}', secrets.TOKEN) }}\"")"
+
+check "needs context" fail \
+  "$(fixture needs-ctx 'echo "${{ toJSON(needs.build.outputs.x) }}"')"
+
+check "matrix context" fail \
+  "$(fixture matrix-ctx 'echo "${{ matrix.os }}"')"
+
+check "strategy context" fail \
+  "$(fixture strategy-ctx 'echo "${{ strategy.job-index }}"')"
+
+echo "== what the linter must NOT flag =="
+
+# The deliberate convention: these names appear as prose in ten manifests, documenting the syntax a
+# CALLER uses. Flagging them would force the documentation out of the actions.
+check "plain-text prose outside an expression" pass \
+  "$(fixture prose '# threaded from the caller as kill_switch: vars.AGENT_KILL_SWITCH')"
+
+check "a legal context in an expression" pass \
+  "$(fixture legal-ctx 'echo "${{ inputs.client_id }} ${{ github.repository }} ${{ env.FOO }}"')"
+
+# The name is a substring of a longer identifier, not the context.
+check "a longer identifier ending in a context name" pass \
+  "$(fixture substring 'echo "${{ inputs.myvars.thing }}"')"
+
+# A reusable workflow may use these contexts freely; only composite actions cannot.
+mkdir -p "$WORK/reusable"
+cat >"$WORK/reusable/action.yaml" <<'EOF'
+name: reusable
+description: not a composite action
+runs:
+  using: node20
+  main: index.js
+EOF
+check "a non-composite action is out of scope" pass "$WORK/reusable"
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "::error::$fails assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
Closes #334

The job that exists to prevent the v1.12.0 org-wide outage anchored the context to the **start** of
its expression:

```bash
grep -nE '\$\{\{[[:space:]]*(vars|secrets|needs|matrix|strategy)\.' "$f"
```

GitHub does not care about position — the reference fails to load the action wherever it sits. So the
guard passed the first thing a contributor would realistically write:

```yaml
run: echo "${{ inputs.kill_switch || vars.AGENT_KILL_SWITCH }}"
```

Ten manifests currently carry `vars.AGENT_KILL_SWITCH` as deliberate prose. Making any one of them
self-defaulting would have shipped past a green required check and taken `merge-gate` down in every
governed repo, exactly as before.

## Why not actionlint

I recommended it on the issue. **I was wrong, and I checked before building on it.** actionlint parses
`action.yaml` as a *workflow* file and emits only syntax noise:

```
generic-actions/board-write/action.yaml:1:1: "jobs" section is missing in workflow [syntax-check]
generic-actions/board-write/action.yaml:2:1: unexpected key "description" for "workflow" section
```

It does not lint composite action manifests, so adopting it would have replaced a weak check with no
check.

## Why not just widen the pattern

The obvious widening is also incomplete:

```
${{ format('{0}', secrets.TOKEN) }}      # ${{[^}]*}} stops at the } inside '{0}'
```

The rule is genuinely "inside a `${{ … }}` region", so the detector has to track that rather than
pattern-match around it. It now walks each line with that state and reports only occurrences that are
inside one — which is what keeps the deliberate plain-text prose legal, since flagging it would push
the documentation out of the actions.

Line-local, which is what these expressions are; a context split across a block scalar would be
missed, and the script says so.

## Test plan

The check had **no negative case** — which is how it stayed vacuous while running green on every PR.
`tests/lint-action-manifests.sh` runs the real linter against real manifests:

- [x] **6 violations must fail** — first-token, after an operator, inside `format('{0}', …)`, `needs`,
      `matrix`, `strategy`
- [x] **4 legal shapes must pass** — plain-text prose, a legal context (`inputs`/`github`/`env`), a
      longer identifier ending in a context name, and a non-composite action
- [x] **3 of the 6 pass against the previous check** (verified by restoring it) — after-an-operator,
      inside-`format`, and `needs`
- [x] The real repo still lints clean
- [x] `test-actions` globs `tests/*.sh`, so the suite wires itself in
- [x] `prettier --check` passes

The detector moved from inline YAML into `.github/scripts/` for one reason: so the tests run **the
shipped code** rather than a copy of it.