### PR TITLE
fix(reconcile): select epic members by label, not the Closes walk

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -138,6 +138,7 @@ jobs:
           q='query($q:String!,$cursor:String){ search(query:$q, type:ISSUE, first:100, after:$cursor){
             pageInfo{ hasNextPage endCursor }
             nodes{ ... on PullRequest{ number headRefOid repository{ name }
+              labels(first:20){ nodes{ name } }
               closingIssuesReferences(first:5){ nodes{ parent{ number } } } } } } }'
           # Page every open PR: a fail-safe cannot stop at the first 100.
           nodes='[]'
@@ -150,13 +151,22 @@ jobs:
             [ "$(echo "$page" | jq -r '.data.search.pageInfo.hasNextPage')" = "true" ] || break
             cursor=$(echo "$page" | jq -r '.data.search.pageInfo.endCursor')
           done
-          # tasks holds the open PRs that close an issue, whose Status is re-derived.
-          # epic_prs holds those whose closing issue has a parent Epic, which get merge-gate re-posted.
+          # tasks holds the open PRs that close an issue, whose Status is re-derived. Status derivation
+          # reads the closing reference, so the Closes walk is the right selector for this half.
           tasks=$(echo "$nodes" | jq -c '[.[]
             | select(.number and (.closingIssuesReferences.nodes | length > 0))
             | {repo: .repository.name, number, sha: .headRefOid}]')
+          # epic_prs holds the PRs merge-gate is re-posted on. Membership is the `epic:<N>` LABEL,
+          # which is what merge-gate holds against — a label needs >= triage to apply, while a Closes
+          # keyword is author-controlled. This selector used to be the Closes walk, so a member
+          # carrying the label but no Closes line (an infra or re-pin PR pulled into a wave) was never
+          # re-evaluated. It stayed held at `failure` until someone pushed to it, and since a held PR
+          # is released only by this sweep, the whole wave blocked on one permanently-red check.
+          #
+          # Dropping the Closes-derived set loses nothing: merge-gate classifies an unlabeled PR as
+          # standalone and always passes it, so re-posting on those never changed an outcome.
           epic_prs=$(echo "$nodes" | jq -c '[.[]
-            | select(.number and (([.closingIssuesReferences.nodes[].parent] | map(select(. != null)) | length) > 0))
+            | select(.number and ([.labels.nodes[].name | select(startswith("epic:"))] | length > 0))
             | {repo: .repository.name, number, sha: .headRefOid}]')
           {
             echo "tasks=$tasks"

--- a/tests/reconcile-selector.sh
+++ b/tests/reconcile-selector.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regression tests for the reconcile sweep's membership selectors.
+#
+# Same discipline as the other suites: the jq programs are EXTRACTED verbatim from the workflow and
+# run against fixture nodes, so what is asserted here is what ships. There is nothing to stub — the
+# selectors are pure functions of the GraphQL result.
+#
+# The case that matters: a PR carrying the `epic:<N>` label but no `Closes` line. merge-gate holds
+# every member of an unready set at `failure`, and a held PR is released only by this sweep — so a
+# member the sweep cannot see stays red until someone pushes to it, and the whole wave blocks behind
+# one permanently-red required check. That is the shape of a cross-repo re-pin or infra PR pulled
+# into a wave, which is ordinary rather than exotic.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+WORKFLOW="${1:-$ROOT/.github/workflows/reconcile-board.yaml}"
+
+extract_jq() { # $1 = the shell variable the filter is assigned to
+  sed -n "/^          $1=\$(echo/,/\]')\$/p" "$WORKFLOW" | sed -e "1s/^[^']*'//" -e "\$s/')\$//"
+}
+
+TASKS_FILTER=$(extract_jq tasks)
+EPIC_FILTER=$(extract_jq epic_prs)
+
+for name in TASKS_FILTER EPIC_FILTER; do
+  if [ -z "${!name}" ]; then
+    echo "::error::could not extract the $name from $WORKFLOW — did the assignment move or change indent?"
+    exit 1
+  fi
+done
+
+# Four PRs covering every combination that matters.
+NODES=$(
+  cat <<'EOF'
+[
+  { "number": 1, "headRefOid": "sha1", "repository": {"name": "repo-a"},
+    "labels": {"nodes": [{"name": "epic:417"}]},
+    "closingIssuesReferences": {"nodes": [{"parent": {"number": 417}}]} },
+
+  { "number": 2, "headRefOid": "sha2", "repository": {"name": "repo-b"},
+    "labels": {"nodes": [{"name": "epic:417"}]},
+    "closingIssuesReferences": {"nodes": []} },
+
+  { "number": 3, "headRefOid": "sha3", "repository": {"name": "repo-c"},
+    "labels": {"nodes": [{"name": "dependencies"}]},
+    "closingIssuesReferences": {"nodes": [{"parent": {"number": 417}}]} },
+
+  { "number": 4, "headRefOid": "sha4", "repository": {"name": "repo-d"},
+    "labels": {"nodes": []},
+    "closingIssuesReferences": {"nodes": [{"parent": null}]} }
+]
+EOF
+)
+
+fails=0
+check() { # $1=label $2=expected $3=actual
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected [$2], got [$3]"
+    fails=$((fails + 1))
+  fi
+}
+
+selected() { printf '%s' "$NODES" | jq -c "$1" | jq -c '[.[].number]'; }
+
+echo "== epic_prs: membership is the label, not the Closes walk =="
+
+got=$(selected "$EPIC_FILTER")
+
+# PR 2 is the regression: labelled, no Closes. Under the previous Closes-walk selector it was invisible
+# to the sweep, so merge-gate never got re-posted and it stayed held forever.
+check "a labelled PR with no Closes is selected" "[1,2]" "$got"
+
+case "$got" in
+  *3*) echo "  FAIL an unlabelled PR was selected"; fails=$((fails + 1)) ;;
+  *) echo "  ok   an unlabelled PR with a parented Closes is not selected" ;;
+esac
+
+echo "== tasks: status re-derivation still follows the Closes walk =="
+
+# derive-status reads the closing reference, so this half is correctly Closes-driven and must not have
+# been changed along with the other.
+check "every PR closing an issue is re-derived" "[1,3,4]" "$(selected "$TASKS_FILTER")"
+
+echo "== the previous selector, for contrast =="
+
+OLD_FILTER='[.[]
+  | select(.number and (([.closingIssuesReferences.nodes[].parent] | map(select(. != null)) | length) > 0))
+  | {repo: .repository.name, number, sha: .headRefOid}]'
+
+old=$(selected "$OLD_FILTER")
+check "it missed the labelled PR and swept an unlabelled one" "[1,3]" "$old"
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "::error::$fails assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
Closes #335

`merge-gate` is unambiguous about what membership is:

> a PR is a member of Epic N **iff it carries the `epic:<N>` label** — a label needs >= triage to
> apply, so it is a permission-gated assertion of membership, whereas a `Closes` keyword is
> author-controlled and cannot be trusted to define the set. **The `Closes` walk survives only as a
> discovery HINT.**

The reconcile sweep enumerated by the hint. Its GraphQL query did not even fetch labels.

## Why that strands a wave

Two more lines from `merge-gate` close the loop:

> Holds are posted as `conclusion: failure` … **a held PR only waits — the reconcile sweep re-runs and
> flips it to `success` once the set is ready**

> A PR with no `epic:<N>` label is standalone and **always passes**.

So the sweep is the *only* thing that releases a held member — and it could not see a member carrying
the label without a `Closes` line. That is exactly the shape of a `go.mod` re-pin or an infra PR
pulled into a wave, which is ordinary in the staged cross-repo rollouts `manage-versions` describes.
That PR stayed red until someone pushed to it, and because a set lands atomically, the whole wave
blocked behind one permanently-red required check.

Diagnosed as a coordination problem, because a held PR showing `merge-gate: failure` is the *designed,
healthy* state while siblings are unready — visually identical to the stuck state. And the sweep run
itself was green: it did everything it was asked.

## Dropping the Closes-derived set rather than unioning

The issue offered a union as a transitional option. It isn't needed, and the reason is the
"always passes" line above: an unlabeled PR is standalone, so re-posting `merge-gate` on it never
changed an outcome. Label-only is both more correct **and** cheaper — the sweep stops re-gating every
open PR that happens to close a parented issue, every 15 minutes, to no effect.

The `tasks` half is untouched and stays `Closes`-driven, because status derivation reads the closing
reference. The two selectors answer different questions and only one was wrong.

## Test plan

- [x] `tests/reconcile-selector.sh` extracts **both jq filters from the workflow** and runs them
      against fixture nodes, so the assertions are on the shipped selectors
- [x] A labelled PR with no `Closes` is selected — the regression
- [x] An unlabelled PR with a parented `Closes` is *not* selected
- [x] `tasks` still selects every PR closing an issue
- [x] The suite also runs the **previous** filter for contrast and asserts it returned `[1,3]` where
      the new one returns `[1,2]` — it missed the labelled member and swept an unlabelled bystander.
      That keeps the defect on the record rather than relying on a one-off manual check.
- [x] All five suites pass; `prettier --check` passes
- [ ] CI green

## Note

`labels(first:20)` — a PR carrying more than twenty labels would have its `epic:` label missed. That
is far outside anything in these orgs, and the alternative (a per-PR search qualifier) costs a request
per PR on a sweep that already pages every open PR in the org.