### PR TITLE
fix(derive-status): derive every closing issue, not the lowest-numbered

### DIFF
--- a/generic-actions/board-write/action.yaml
+++ b/generic-actions/board-write/action.yaml
@@ -26,9 +26,13 @@ inputs:
   content_id:
     required: true
     description: >
-      Node id of the issue or PR whose board item to write. The caller resolves what to
-      write (e.g. a PR's linked issue); board-write finds that content's item in the
-      project.
+      Node id of the issue or PR whose board item to write, or SEVERAL such ids separated
+      by newlines or spaces. The caller resolves what to write (e.g. a PR's linked
+      issues); board-write finds each content's item in the project and applies the same
+      field and value to all of them. Several ids are handled here rather than by the
+      caller because a composite action cannot loop a `uses:` step, so a caller that
+      needed to write more than one item would have to reimplement this action — which is
+      how a PR closing two issues came to update only one of them.
   field:
     required: true
     description: Name of the field to set, e.g. "Status" or "Start date".
@@ -67,10 +71,12 @@ inputs:
 
 outputs:
   item_id:
-    description: Node id of the board item that was resolved (or added).
+    description: >
+      Node id of the board item that was resolved (or added). With several content ids,
+      the last one — the outputs describe the run, not any single item.
     value: ${{ steps.write.outputs.item_id }}
   changed:
-    description: '"true" if the field was mutated, "false" if it already held the value.'
+    description: '"true" if ANY item was mutated, "false" if every one already held the value.'
     value: ${{ steps.write.outputs.changed }}
 
 runs:
@@ -178,83 +184,88 @@ runs:
             ;;
         esac
 
-        # 2. Resolve the content's item in this project, adding it if missing so a derived
-        #    write on an un-boarded Task boards it. Page through projectItems so a content
-        #    sitting on many projects still matches when the target board is not on the
-        #    first page.
-        item_q='query($c:ID!,$cursor:String){ node(id:$c){
-          ... on Issue{ projectItems(first:100, after:$cursor){
-            pageInfo{ hasNextPage endCursor } nodes{ id project{ id } } } }
-          ... on PullRequest{ projectItems(first:100, after:$cursor){
-            pageInfo{ hasNextPage endCursor } nodes{ id project{ id } } } } } }'
-        item_id=""
-        cursor=""
-        while :; do
-          args=(-F c="$CONTENT_ID")
-          [ -n "$cursor" ] && args+=(-F cursor="$cursor")
-          iresp=$(gh api graphql -f query="$item_q" "${args[@]}")
-          item_id=$(echo "$iresp" | jq -r --arg p "$PROJECT_ID" \
-            '[.data.node.projectItems.nodes[] | select(.project.id==$p) | .id][0] // empty')
-          [ -n "$item_id" ] && break
-          [ "$(echo "$iresp" | jq -r '.data.node.projectItems.pageInfo.hasNextPage')" = "true" ] || break
-          cursor=$(echo "$iresp" | jq -r '.data.node.projectItems.pageInfo.endCursor')
+        # content_id may name SEVERAL contents, newline- or space-separated. A pull request can
+        # close more than one issue, and a composite action cannot loop a `uses:` step — so the
+        # fan-out belongs inside the single privileged writer rather than around it, which is what
+        # keeps that claim true.
+        read -r -a content_ids <<<"$(printf '%s' "$CONTENT_ID" | tr '\n' ' ')"
+
+        any_changed=false
+        last_item=""
+
+        for content_id in "${content_ids[@]}"; do
+          [ -n "$content_id" ] || continue
+
+          # 2. Resolve the content's item in this project, adding it if missing so a derived
+          #    write on an un-boarded Task boards it. Page through projectItems so a content
+          #    sitting on many projects still matches when the target board is not on the
+          #    first page.
+          item_q='query($c:ID!,$cursor:String){ node(id:$c){
+            ... on Issue{ projectItems(first:100, after:$cursor){
+              pageInfo{ hasNextPage endCursor } nodes{ id project{ id } } } }
+            ... on PullRequest{ projectItems(first:100, after:$cursor){
+              pageInfo{ hasNextPage endCursor } nodes{ id project{ id } } } } } }'
+          item_id=""
+          cursor=""
+          while :; do
+            args=(-F c="$content_id")
+            [ -n "$cursor" ] && args+=(-F cursor="$cursor")
+            iresp=$(gh api graphql -f query="$item_q" "${args[@]}")
+            item_id=$(echo "$iresp" | jq -r --arg p "$PROJECT_ID" \
+              '[.data.node.projectItems.nodes[] | select(.project.id==$p) | .id][0] // empty')
+            [ -n "$item_id" ] && break
+            [ "$(echo "$iresp" | jq -r '.data.node.projectItems.pageInfo.hasNextPage')" = "true" ] || break
+            cursor=$(echo "$iresp" | jq -r '.data.node.projectItems.pageInfo.endCursor')
+          done
+
+          if [ -z "$item_id" ]; then
+            if [ "$ADD_IF_MISSING" != "true" ]; then
+              echo "::error::content $content_id is not on the board and add_if_missing=false"
+              exit 1
+            fi
+            add_m='mutation($proj:ID!,$c:ID!){
+              addProjectV2ItemById(input:{projectId:$proj,contentId:$c}){ item{ id } } }'
+            item_id=$(gh api graphql -f query="$add_m" -F proj="$PROJECT_ID" -F c="$content_id" \
+              | jq -r '.data.addProjectV2ItemById.item.id')
+            echo "Added content to the board (item $item_id)." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+          last_item="$item_id"
+
+          # 3. Compare-before-write: read the item's current value for this field. An equal
+          #    value means a re-run or an overlapping trigger, so nothing is mutated.
+          cur_q="query(\$item:ID!,\$field:String!){ node(id:\$item){ ... on ProjectV2Item{
+            fieldValueByName(name:\$field){ $cur_frag } } } }"
+          cur=$(gh api graphql -f query="$cur_q" -F item="$item_id" -F field="$FIELD" \
+            | jq -r '.data.node.fieldValueByName.current // empty')
+
+          # A set-once field such as Start date keeps whatever it already holds, so a re-run
+          # or the sweep cannot overwrite the original stamp.
+          if [ "$ONLY_IF_EMPTY" = "true" ] && [ -n "$cur" ]; then
+            echo "No change — \"$FIELD\" already set (\"$cur\") on item $item_id and only_if_empty." | tee -a "$GITHUB_STEP_SUMMARY"
+            continue
+          fi
+
+          if [ "$cur" = "$VALUE" ]; then
+            echo "No change — \"$FIELD\" already \"$VALUE\" on item $item_id." | tee -a "$GITHUB_STEP_SUMMARY"
+            continue
+          fi
+
+          # 4. Write it (or, under dry-run, just report).
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "- [dry-run] would set \"$FIELD\" = \"$VALUE\" on item $item_id (was \"${cur:-<unset>}\")." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            continue
+          fi
+
+          write_m="mutation(\$proj:ID!,\$item:ID!,\$field:ID!){ updateProjectV2ItemFieldValue(input:{
+            projectId:\$proj, itemId:\$item, fieldId:\$field, value: $value_frag }){ projectV2Item{ id } } }"
+          gh api graphql -f query="$write_m" -F proj="$PROJECT_ID" -F item="$item_id" -F field="$field_id" >/dev/null
+          echo "Set \"$FIELD\" = \"$VALUE\" on item $item_id (was \"${cur:-<unset>}\")." | tee -a "$GITHUB_STEP_SUMMARY"
+          any_changed=true
         done
 
-        if [ -z "$item_id" ]; then
-          if [ "$ADD_IF_MISSING" != "true" ]; then
-            echo "::error::content is not on the board and add_if_missing=false"
-            exit 1
-          fi
-          add_m='mutation($proj:ID!,$c:ID!){
-            addProjectV2ItemById(input:{projectId:$proj,contentId:$c}){ item{ id } } }'
-          item_id=$(gh api graphql -f query="$add_m" -F proj="$PROJECT_ID" -F c="$CONTENT_ID" \
-            | jq -r '.data.addProjectV2ItemById.item.id')
-          echo "Added content to the board (item $item_id)." | tee -a "$GITHUB_STEP_SUMMARY"
-        fi
-
-        # 3. Compare-before-write: read the item's current value for this field. An equal
-        #    value means a re-run or an overlapping trigger, so nothing is mutated.
-        cur_q="query(\$item:ID!,\$field:String!){ node(id:\$item){ ... on ProjectV2Item{
-          fieldValueByName(name:\$field){ $cur_frag } } } }"
-        cur=$(gh api graphql -f query="$cur_q" -F item="$item_id" -F field="$FIELD" \
-          | jq -r '.data.node.fieldValueByName.current // empty')
-
-        # A set-once field such as Start date keeps whatever it already holds, so a re-run
-        # or the sweep cannot overwrite the original stamp.
-        if [ "$ONLY_IF_EMPTY" = "true" ] && [ -n "$cur" ]; then
-          echo "No change — \"$FIELD\" already set (\"$cur\") and only_if_empty." | tee -a "$GITHUB_STEP_SUMMARY"
-          {
-            echo "item_id=$item_id"
-            echo "changed=false"
-          } >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        if [ "$cur" = "$VALUE" ]; then
-          echo "No change — \"$FIELD\" already \"$VALUE\" on item $item_id." | tee -a "$GITHUB_STEP_SUMMARY"
-          {
-            echo "item_id=$item_id"
-            echo "changed=false"
-          } >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        # 4. Write it (or, under dry-run, just report).
-        if [ "$DRY_RUN" = "true" ]; then
-          echo "- [dry-run] would set \"$FIELD\" = \"$VALUE\" on item $item_id (was \"${cur:-<unset>}\")." \
-            | tee -a "$GITHUB_STEP_SUMMARY"
-          {
-            echo "item_id=$item_id"
-            echo "changed=false"
-          } >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        write_m="mutation(\$proj:ID!,\$item:ID!,\$field:ID!){ updateProjectV2ItemFieldValue(input:{
-          projectId:\$proj, itemId:\$item, fieldId:\$field, value: $value_frag }){ projectV2Item{ id } } }"
-        gh api graphql -f query="$write_m" -F proj="$PROJECT_ID" -F item="$item_id" -F field="$field_id" >/dev/null
-        echo "Set \"$FIELD\" = \"$VALUE\" on item $item_id (was \"${cur:-<unset>}\")." | tee -a "$GITHUB_STEP_SUMMARY"
         {
-          echo "item_id=$item_id"
-          echo "changed=true"
+          echo "item_id=$last_item"
+          echo "changed=$any_changed"
         } >> "$GITHUB_OUTPUT"

--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -113,18 +113,22 @@ runs:
           exit 1
         fi
 
-        # A Task pairs with exactly one PR, so there is normally one closing ref. A PR that
-        # closes several resolves to the lowest-numbered one, which is deterministic across
-        # re-runs; the reconcile sweep derives the others from their own PRs.
+        # Every closing issue is derived, not just one. This used to take the lowest-numbered ref
+        # and leave the rest in whatever status they already held, on the stated grounds that "the
+        # reconcile sweep covers the rest" — but the sweep re-derives an issue from ITS OWN pull
+        # request, and an issue closed by a sibling's PR has none. So the others were never picked
+        # up by anything: not a race that resolves on the next pass, but a state nothing reaches.
+        # A Task left reading `Triage` while its fix is in review is invisible, because the run
+        # that stranded it succeeds.
         refs=$(echo "$pr" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes')
         ref_count=$(echo "$refs" | jq 'length')
-        issue_id=$(echo "$refs" | jq -r 'sort_by(.number) | .[0].id // empty')
-        # Labels of the selected closing issue: a hotfix cleanup Task carries `hotfix-reconcile`,
-        # which makes Done its terminal MERGED status.
-        issue_labels=$(echo "$refs" | jq -c 'sort_by(.number) | (.[0].labels.nodes // []) | map(.name)')
-        if [ "$ref_count" -gt 1 ]; then
-          echo "::warning::PR #$PR closes $ref_count issues; deriving the lowest-numbered. The reconcile sweep covers the rest."
-        fi
+        # Newline-separated: board-write takes several ids and applies the same field and value to
+        # each, so the fan-out lives in the one privileged writer instead of here.
+        issue_ids=$(echo "$refs" | jq -r 'sort_by(.number) | .[].id')
+        # Labels drive one branch below — a hotfix cleanup Task carries `hotfix-reconcile`, which
+        # makes Done its terminal MERGED status — so they are collected across every closing issue
+        # and checked for agreement rather than sampled from one.
+        labelled=$(echo "$refs" | jq -c '[.[] | (.labels.nodes // []) | map(.name) | index("hotfix-reconcile") != null]')
 
         # A pure function of the PR's current state: the reconcile sweep re-runs it and has
         # to reach the same answer whatever event fired.
@@ -132,10 +136,17 @@ runs:
           MERGED)
             # A hotfix-reconcile cleanup Task is terminal on merge: the forward-port landed and a
             # hotfix cuts its own tag off the reconcile's baseline, so nothing else ships it.
-            if printf '%s' "$issue_labels" | jq -e 'index("hotfix-reconcile")' >/dev/null 2>&1; then
+            # One status is written to every closing issue, so they have to agree on this. A PR
+            # closing both a hotfix cleanup Task and an ordinary one has no single right answer —
+            # it fails rather than silently picking one, which is the mistake this change is about.
+            hotfix_count=$(printf '%s' "$labelled" | jq '[.[] | select(.)] | length')
+            if [ "$hotfix_count" = "0" ]; then
+              status="Awaiting release"
+            elif [ "$hotfix_count" = "$ref_count" ]; then
               status="Done"
             else
-              status="Awaiting release"
+              echo "::error::PR #$PR closes both hotfix-reconcile and ordinary Tasks, which derive different terminal statuses. Split the PR so each lands with its own."
+              exit 1
             fi
             ;;
           CLOSED) status="Ready" ;; # closed unmerged → the attempt was abandoned; back to actionable
@@ -154,7 +165,7 @@ runs:
             ;;
         esac
 
-        if [ -z "$issue_id" ]; then
+        if [ -z "$issue_ids" ]; then
           echo "PR #$PR closes no issue — nothing to derive." | tee -a "$GITHUB_STEP_SUMMARY"
           echo "has_issue=false" >> "$GITHUB_OUTPUT"
           exit 0
@@ -170,12 +181,15 @@ runs:
 
         {
           echo "has_issue=true"
-          echo "issue_id=$issue_id"
+          # Multi-line, so it needs the delimiter form; board-write splits on whitespace.
+          echo "issue_ids<<EOF_ISSUE_IDS"
+          printf '%s\n' "$issue_ids"
+          echo "EOF_ISSUE_IDS"
           echo "status=$status"
           echo "activated=$activated"
           echo "today=$(date -u +%Y-%m-%d)"
         } >> "$GITHUB_OUTPUT"
-        echo "PR #$PR ($state, draft=$draft, review=${review:-none}) → \"$status\" on issue $issue_id." \
+        echo "PR #$PR ($state, draft=$draft, review=${review:-none}) → \"$status\" on $ref_count issue(s)." \
           | tee -a "$GITHUB_STEP_SUMMARY"
 
     # Write the derived Status. board-write mints the [Agent] token, resolves the item,
@@ -190,7 +204,7 @@ runs:
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         project_id: ${{ inputs.project_id }}
-        content_id: ${{ steps.derive.outputs.issue_id }}
+        content_id: ${{ steps.derive.outputs.issue_ids }}
         field: Status
         value: ${{ steps.derive.outputs.status }}
         kill_switch: ${{ inputs.kill_switch }}
@@ -205,7 +219,7 @@ runs:
         client_id: ${{ inputs.client_id }}
         app_private_key: ${{ inputs.app_private_key }}
         project_id: ${{ inputs.project_id }}
-        content_id: ${{ steps.derive.outputs.issue_id }}
+        content_id: ${{ steps.derive.outputs.issue_ids }}
         field: Start date
         value: ${{ steps.derive.outputs.today }}
         only_if_empty: "true"

--- a/tests/derive-status.sh
+++ b/tests/derive-status.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Regression tests for derive-status' closing-issue resolution.
+#
+# The jq programs are extracted verbatim from the manifest and run against fixture refs, so the
+# assertions are on the shipped selectors. There is nothing to stub — they are pure functions of the
+# GraphQL result.
+#
+# The defect: a PR closing several issues derived exactly one of them, on the stated grounds that
+# "the reconcile sweep covers the rest". The sweep re-derives an issue from ITS OWN pull request, and
+# an issue closed by a sibling's PR has none — so the others were reached by nothing. Not a race that
+# resolves next pass, a state nothing arrives at. It read as handled because the run that stranded
+# them succeeded.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION="${1:-$ROOT/generic-actions/derive-status/action.yaml}"
+
+IDS_FILTER=$(sed -n "s/^        issue_ids=.*jq -r '\(.*\)')\$/\1/p" "$ACTION")
+LABELLED_FILTER=$(sed -n "s/^        labelled=.*jq -c '\(.*\)')\$/\1/p" "$ACTION")
+
+for name in IDS_FILTER LABELLED_FILTER; do
+  if [ -z "${!name}" ]; then
+    echo "::error::could not extract $name from $ACTION — did the assignment move or change shape?"
+    exit 1
+  fi
+done
+
+fails=0
+check() { # $1=label $2=expected $3=actual
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected [$2], got [$3]"
+    fails=$((fails + 1))
+  fi
+}
+
+# A PR closing two issues, the shape of the live instance: service-authentication#1140 closes both
+# #1111 and #1112, and #1112 sat in Triage while its fix was in review.
+TWO=$(
+  cat <<'EOF'
+[ { "number": 1112, "id": "I_kw1112", "labels": {"nodes": []} },
+  { "number": 1111, "id": "I_kw1111", "labels": {"nodes": []} } ]
+EOF
+)
+
+ONE='[ { "number": 1111, "id": "I_kw1111", "labels": {"nodes": []} } ]'
+NONE='[]'
+
+MIXED=$(
+  cat <<'EOF'
+[ { "number": 10, "id": "I_kw10", "labels": {"nodes": [{"name": "hotfix-reconcile"}]} },
+  { "number": 11, "id": "I_kw11", "labels": {"nodes": []} } ]
+EOF
+)
+
+ALL_HOTFIX='[ { "number": 10, "id": "I_kw10", "labels": {"nodes": [{"name": "hotfix-reconcile"}]} } ]'
+
+ids() { printf '%s' "$1" | jq -r "$IDS_FILTER" | tr '\n' ' ' | sed 's/ $//'; }
+hotfix_count() { printf '%s' "$1" | jq -c "$LABELLED_FILTER" | jq '[.[] | select(.)] | length'; }
+
+echo "== every closing issue is derived, not just one =="
+
+check "a PR closing two issues yields both, lowest first" "I_kw1111 I_kw1112" "$(ids "$TWO")"
+check "a PR closing one issue is unchanged" "I_kw1111" "$(ids "$ONE")"
+check "a PR closing none yields nothing" "" "$(ids "$NONE")"
+
+# The previous behaviour, kept here so the defect stays on the record rather than living only in a
+# commit message: it took the lowest-numbered ref and left the other untouched.
+OLD_FILTER='sort_by(.number) | .[0].id // empty'
+check "the previous filter returned only the lowest-numbered" "I_kw1111" \
+  "$(printf '%s' "$TWO" | jq -r "$OLD_FILTER")"
+
+echo "== the hotfix-reconcile branch is decided across all of them =="
+
+check "no closing issue is a hotfix cleanup" "0" "$(hotfix_count "$TWO")"
+check "every closing issue is a hotfix cleanup" "1" "$(hotfix_count "$ALL_HOTFIX")"
+
+# Mixed is the case with no single right answer: one status is written to every closing issue, and
+# these two want different terminal ones. The action errors rather than picking, which is the whole
+# point — sampling one issue's labels is what the old code did.
+mixed=$(hotfix_count "$MIXED")
+total=$(printf '%s' "$MIXED" | jq 'length')
+if [ "$mixed" != "0" ] && [ "$mixed" != "$total" ]; then
+  echo "  ok   a mixed set is detectable as neither all nor none ($mixed of $total)"
+else
+  echo "  FAIL a mixed set was not detectable"
+  fails=$((fails + 1))
+fi
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "::error::$fails assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
Closes #346

A pull request closing several issues derived the status of exactly one, leaving the rest in whatever
status they already held.

## Why the stated mitigation could not work

```bash
# … the reconcile sweep derives the others from their own PRs.
issue_id=$(echo "$refs" | jq -r 'sort_by(.number) | .[0].id // empty')
…
echo "::warning::PR #$PR closes $ref_count issues; deriving the lowest-numbered. The reconcile sweep covers the rest."
```

The sweep re-derives an issue **from its own pull request**. An issue closed by a *sibling's* PR does
not have one. So "the sweep covers the rest" names a mechanism that structurally cannot reach them —
not a race that resolves on the next pass, but a state nothing ever arrives at.

That is why it read as handled at every review: the comment asserts a downstream guarantee the code
never establishes, and the run that strands the issues **succeeds**, so the only trace is a
`::warning::` in a green log.

**Live instance, and it is this milestone's own work:** `a-novel/service-authentication#1140` closes
both `#1111` and `#1112`. `#1111` won the tiebreak and moved to `In review`; `#1112` sat in `Triage`
— reading as un-assessed, not-yet-started work — while the PR implementing it was open and green.

## The shape of the fix

A composite action cannot loop a `uses:` step, so `derive-status` could not fan out over
`board-write` itself. The options were to reimplement `board-write` inline — which would break the
"single privileged path that mutates the board" property its own description claims, and which the
codebase has already drifted away from twice — or to teach `board-write` to take several ids.

The second keeps the property true, so `content_id` now accepts one id or several. Field resolution
stays shared; the resolve → compare-before-write → write cycle runs per content; `changed` reports
whether **any** item was mutated.

## The one case that now fails loudly

The `hotfix-reconcile` label decides a Task's terminal MERGED status (`Done` rather than
`Awaiting release`), and the old code sampled it from the lowest-numbered issue. Since one status is
written to every closing issue, a PR closing both a hotfix cleanup Task and an ordinary one has no
single right answer — so it **errors** rather than silently picking one. Sampling one issue's labels
to decide all of them is the same mistake at a smaller scale.

## Sequencing note

`derive-status` pins `board-write@v1.20.3`, so the fan-out is not live until the release stamps the
internal refs — `prepublish:doc` rewrites `a-novel-kit/workflows/…@vX.Y.Z` across `*/*/action.yaml`,
and consumers move the whole repo to one tag. Nothing runs these from `master`, so there is no window
where `derive-status` calls an older `board-write` with a multi-id input.

## Test plan

- [x] `tests/derive-status.sh` extracts both jq filters from the manifest and runs them against
      fixture refs — a two-issue PR (the live instance's shape), a one-issue PR, and none
- [x] It also runs the **previous** filter for contrast, asserting it returned only `I_kw1111` where
      the new one returns both, so the defect stays on the record
- [x] The `hotfix-reconcile` decision is asserted across all/none/mixed
- [x] All six suites pass; manifest lint and `prettier --check` pass
- [ ] CI green

**Not covered:** that `board-write` correctly loops. Its resolve/write cycle is API calls all the way
down, with no seam the offline harness can reach — the fixtures stop at the selector.