### PR TITLE
feat(merge-gate): retire a snapshot once its wave has landed

### DIFF
--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -23,6 +23,14 @@ description: >
   `{repo, number}`; each member's live state (open/merged/closed, draft, review) is re-read on
   every resolve — the set is frozen, the state is not.
 
+  The next wave begins when the previous one is RETIRED. Once every member of a frozen set has
+  merged, merge-gate replaces the marker with a `retired` tombstone carrying the wave boundary, and
+  the next set to hold merge-ready captures its own snapshot. A wave that did NOT land — a member
+  closed unmerged — is never retired: the snapshot is the only durable record that those pull
+  requests were members, so it stands until a human resolves it (see epic-rollback). This reader
+  selects on `status == "frozen"` alone, so a `retired` marker resolves here exactly as no marker
+  would, falling back to the live label search.
+
 inputs:
   epic_number:
     required: true

--- a/generic-actions/epic-membership/action.yaml
+++ b/generic-actions/epic-membership/action.yaml
@@ -23,13 +23,12 @@ description: >
   `{repo, number}`; each member's live state (open/merged/closed, draft, review) is re-read on
   every resolve — the set is frozen, the state is not.
 
-  The next wave begins when the previous one is RETIRED. Once every member of a frozen set has
+  The next wave begins when the previous one is retired. Once every member of a frozen set has
   merged, merge-gate replaces the marker with a `retired` tombstone carrying the wave boundary, and
-  the next set to hold merge-ready captures its own snapshot. A wave that did NOT land — a member
-  closed unmerged — is never retired: the snapshot is the only durable record that those pull
-  requests were members, so it stands until a human resolves it (see epic-rollback). This reader
-  selects on `status == "frozen"` alone, so a `retired` marker resolves here exactly as no marker
-  would, falling back to the live label search.
+  the next set to hold merge-ready captures its own snapshot. A wave with a member closed unmerged
+  did not land and is never retired: the snapshot is the only durable record that those pull requests
+  were members, so it stands until a human resolves it through epic-rollback. This reader selects on
+  `status == "frozen"` alone, so a `retired` marker falls through to the live label search.
 
 inputs:
   epic_number:

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -31,14 +31,13 @@ description: >
   group — if the set regressed since enqueue (a member went back to draft, or lost its
   approval). A standalone PR in the queue re-affirms `success` (it was gated at enqueue).
 
-  This action is the ONLY writer of the activation-snapshot marker in the Epic body, which both
-  epic-membership and detect-partial-landing read. It captures the set (pending, then frozen) when
-  the Epic first holds merge-ready, and RETIRES it — to a `retired` tombstone carrying the wave
-  boundary — once every member has merged, so the next set can freeze and a pull request labeled
-  after the freeze is held for one wave rather than forever. A wave with a member closed unmerged
-  did not land and is never retired; the gate names it after 72h instead. A PR waiting on the next
-  wave is what triggers the retirement, since a fully merged wave has no open member left to run
-  the gate.
+  This action is the only writer of the activation-snapshot marker in the Epic body, which both
+  epic-membership and detect-partial-landing read. It captures the set — pending, then frozen — when
+  the Epic first holds merge-ready, and retires it to a `retired` tombstone carrying the wave
+  boundary once every member has merged. Retirement frees the next set to freeze, so a PR labeled
+  after the freeze is held for one wave. A wave with a member closed unmerged did not land and stays
+  frozen; the gate names it after 72h. The PR waiting on the next wave is what triggers retirement,
+  since a fully merged wave has no open member left to run the gate.
 
 inputs:
   client_id:
@@ -385,11 +384,11 @@ runs:
         # wave's verdict says nothing about its own readiness. Pre-snapshot the live set is
         # the PR's own set, so this is a no-op, and a
         # merge_group event gates the whole group.
-        # This hold is also the only pass positioned to END the previous wave, so it enables the
+        # This hold is also the only pass positioned to end the previous wave, so it enables the
         # capture step in retire-only mode before returning. Retirement needs a frozen wave that has
-        # fully landed AND a pass that reaches the capture step; a wave with every member merged has
-        # no open member left to run the gate, so the pull request waiting on the next wave is the
-        # only trigger there is. Returning here without it is what held that PR forever.
+        # fully landed and a pass that reaches the capture step, and a wave with every member merged
+        # has no open member left to run the gate. The pull request waiting here is the only trigger
+        # there is.
         if [ -z "${IN_QUEUE:-}" ] && [ -n "${PR_NUMBER:-}" ]; then
           if [ "$(printf '%s' "$MEMBERS" | jq --arg r "$REPO_FULL" --argjson n "${PR_NUMBER}" \
                 'any(.[]; .repo == $r and .number == $n)')" != "true" ]; then
@@ -451,14 +450,13 @@ runs:
         EPIC: ${{ steps.discover.outputs.epic_number }}
         MEMBERS: ${{ steps.membership.outputs.members }}
         STABILIZE_SECONDS: "120"
-        # Set when this pass arrived from the not-in-set hold rather than from an all-ready set. Such
-        # a pass is not a member of the set it just read, so it has no standing to capture one; it may
-        # only retire the wave that is holding it.
+        # Set when this pass arrived from the not-in-set hold. Such a pass is not a member of the set
+        # it just read, so it has no standing to capture one; it may only retire the wave holding it.
         RETIRE_ONLY: ${{ steps.evaluate.outputs.retire_only }}
-        # How long a frozen wave may sit unfinished before the gate names what it is waiting on. It
-        # only warns: expiring a snapshot on a clock would un-freeze membership mid-landing, the
-        # failure the snapshot exists to prevent, and would fire exactly when an Epic is already
-        # unhealthy. A human closes the stray, or labels the Epic `automation:paused`.
+        # How long a frozen wave may sit unfinished before the gate names what it is waiting on. The
+        # warning is the whole action: a snapshot that expired on a clock would un-freeze membership
+        # mid-landing, which is the failure it exists to prevent. Resolution stays with a human, who
+        # closes the stray or labels the Epic `automation:paused`.
         STUCK_WAVE_HOURS: "72"
       run: |
         set -euo pipefail
@@ -470,18 +468,17 @@ runs:
             | jq -s -c '.[0] // empty' 2>/dev/null || true
         }
 
-        # The wave boundary carried by a marker: the instant before which a terminal pull request
-        # belongs to a retired wave, which detect-partial-landing appends to its `merged:` and
-        # `closed:` searches so one wave's history is not read as the next one's.
+        # The wave boundary a marker carries: the instant before which a terminal pull request belongs
+        # to a retired wave. detect-partial-landing appends it to its `merged:` and `closed:` searches
+        # so one wave's history is not read as the next one's.
         #
-        # Extracted AND validated here, in one place, because this value is used both to BUILD a
-        # payload and to GUARD a write. Read it twice with two different notions of well-formed and
-        # the two disagree: a guard comparing a raw boundary against a validated one never matches,
-        # and the pass yields on every attempt forever. Accepting exactly the form this step emits —
-        # which is also the only form detect-partial-landing will put in a query — makes a
-        # hand-edited or corrupt boundary drop out here, so the next write repairs it instead of
-        # carrying it forward. Dropping it scopes the next wave to unbounded history, which
-        # over-freezes; a bogus one silently reads as "nothing landed" and clears.
+        # Extraction and validation live together here because callers both build payloads from this
+        # value and compare writes against it. A second reading with a looser notion of well-formed
+        # would never match this one, and the write would yield on every attempt. The accepted form is
+        # the one this step emits, which is also the only form detect-partial-landing puts in a query,
+        # so a hand-edited boundary drops out here and the next write replaces it. An absent boundary
+        # scopes the next wave to unbounded history, which over-freezes; a bogus one reads as "nothing
+        # landed" and clears.
         since_of() { # $1 = marker json -> the boundary, or empty
           printf '%s' "${1:-}" | jq -r '
             if type == "object" and (.since | type == "string")
@@ -501,14 +498,15 @@ runs:
         # passes reach here. GitHub stores bodies with CRLF; strip \r so the marker lines match.
         body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' | tr -d '\r')
 
-        # Has the frozen wave fully LANDED? Only MERGED counts, and "terminal" is deliberately not the
-        # test: a member that was de-labeled and closed unmerged is exactly what the snapshot exists to
-        # remember, so counting it as done would retire the only durable record of a wave that FAILED,
-        # and flip the partial-landing detector from `frozen` to `clear` — which posts success. Such a
-        # wave stays frozen until a human resolves it, which is what epic-rollback is for.
+        # Whether the frozen wave has fully landed. Only a merged member counts. A member de-labeled
+        # and closed unmerged is what the snapshot exists to remember, so treating it as done would
+        # retire the only record that the wave failed, and flip the partial-landing detector from
+        # `frozen` to `clear`, which posts success. Such a wave stays frozen until a human resolves it
+        # through epic-rollback.
+        #
         # Under a frozen marker epic-membership returns that set with each member's state re-read
-        # live, so this costs no extra call. Before activation every state is OPEN, and a version skew
-        # that omits `state` yields false, so neither retires prematurely.
+        # live, so this costs no extra call. Every state is OPEN before activation, and a version skew
+        # omitting `state` yields false. Neither retires early.
         all_landed=$(printf '%s' "$MEMBERS" | jq -c \
           '(length > 0) and all(.[]; .state == "MERGED")' 2>/dev/null || echo false)
 
@@ -541,10 +539,10 @@ runs:
         if [ -z "$marker" ] || ! printf '%s' "$marker" | jq empty 2>/dev/null; then marker=null; fi
         now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-        # The boundary this pass inherits. splice replaces the WHOLE fenced region, so a boundary
-        # survives only by being written again: without this the retirement tombstone is destroyed by
-        # the very next capture, the live `merged:` search hands the new wave the old one's merges
-        # back, and that wave freezes one pass after it captures — the bug #340 fixed, undone.
+        # The boundary this pass inherits. splice replaces the whole fenced region, so a boundary
+        # survives only by being written again: the first capture after a retirement carries the
+        # tombstone's instant forward, which keeps the retired wave's merges out of the new wave's
+        # history.
         inherited_since=$(since_of "$marker")
 
         # A frozen marker is retired once its wave has landed, and otherwise skipped. A valid pending
@@ -554,11 +552,10 @@ runs:
         do=$(jq -rn --argjson cur "$cur" --argjson mk "$marker" --arg now "$now" \
           --argjson landed "$all_landed" --argjson thr "${STABILIZE_SECONDS}" '
           if ($mk | type) != "object" then "pending"
-          # A frozen wave whose every member has merged has discharged its purpose: the set it was
-          # frozen to remember is landed, and until it is retired the gate holds every pull request
-          # labeled afterwards forever, with a message promising a next wave that can never begin.
-          # Retiring it draws the boundary and lets the next ready set capture its own, which is the
-          # "joins the next wave" behavior epic-membership already documents.
+          # A frozen wave whose members have all merged has discharged its purpose. Retiring it draws
+          # the wave boundary and frees the next ready set to capture its own, which is the "joins the
+          # next wave" behavior epic-membership documents. A marker left in place holds every pull
+          # request labeled after it.
           elif $mk.status == "frozen" then (if $landed then "retire" else "skip" end)
           elif ($mk.status == "pending" and ($mk.members | type == "array") and ($mk.at | type == "string"))
             then (
@@ -575,10 +572,9 @@ runs:
 
         if [ "$do" = "skip" ]; then
           # A frozen wave that cannot finish is otherwise invisible: it holds every pull request
-          # labeled after it, and retirement needs every member merged, so nothing ever says why. Name
-          # what it is waiting on once the wait is long enough to be a fault rather than a landing in
-          # progress. The two cases need different words: an open member is late, while a member
-          # closed unmerged means the wave did not land and CANNOT retire by design.
+          # labeled after it, retirement needs every member merged, and nothing says why. Name what it
+          # is waiting on once the wait is long enough to be a fault. An open member is late; a member
+          # closed unmerged means the wave did not land and never retires.
           if [ "$(printf '%s' "$marker" | jq -r 'if type == "object" then (.status // "") else "" end' 2>/dev/null || true)" = "frozen" ] \
             && printf '%s' "$marker" | jq -e --arg now "$now" --argjson hrs "${STUCK_WAVE_HOURS}" \
                  '(.at | try (fromdateiso8601 | true) catch false)
@@ -592,7 +588,7 @@ runs:
                 | tee -a "$GITHUB_STEP_SUMMARY"
             fi
             if [ -n "$abandoned" ]; then
-              echo "::warning::Epic #${EPIC}: the frozen wave cannot retire — ${abandoned} closed without merging, so it did not land. It stays frozen deliberately, because the snapshot is the only record that those were members; resolve it with epic-rollback." \
+              echo "::warning::Epic #${EPIC}: the frozen wave cannot retire — ${abandoned} closed without merging, so it did not land. It stays frozen because the snapshot is the only record that those were members; resolve it with epic-rollback." \
                 | tee -a "$GITHUB_STEP_SUMMARY"
             fi
           fi
@@ -601,8 +597,8 @@ runs:
           exit 0
         fi
 
-        # A retire-only pass reached here from the not-in-set hold: it read a set it is not part of,
-        # so capturing one would freeze a wave on the authority of a pull request the wave excludes.
+        # A retire-only pass reached here from the not-in-set hold, so it read a set it is not part
+        # of. Capturing one would freeze a wave on the authority of a pull request that wave excludes.
         # It may end the previous wave and nothing else.
         if [ "${RETIRE_ONLY:-}" = "true" ] && [ "$do" != "retire" ]; then
           echo "Epic #${EPIC}: held for a later wave, and the current snapshot is not retirable this pass (${do}) — leaving it." \
@@ -611,19 +607,18 @@ runs:
         fi
 
         if [ "$do" = "retire" ]; then
-          # A TOMBSTONE, not a deletion. The marker is the only record of where this wave ended, and
-          # the live `merged:` search keeps returning the wave's merges for the rest of the Epic's
-          # life, so removing the region hands the next wave the previous one's history back. `since`
-          # is `now` rather than inherited: retirement is what DRAWS the boundary, superseding the one
-          # before it. Nothing merged between the wave's last merge and this pass — the gate holds
-          # every non-member — so no history is hidden by it. The tombstone names no members, and
-          # both membership readers select on `status == "frozen"`, so they fall through to the live
-          # floor exactly as they would with no marker at all.
+          # A tombstone. The marker is the only record of where this wave ended, and the live
+          # `merged:` search keeps returning the wave's merges for the rest of the Epic's life, so an
+          # empty region would hand the next wave the previous one's history back. `since` is `now`:
+          # retirement draws the boundary, superseding whatever came before. Nothing merges between
+          # the wave's last merge and this pass, because the gate holds every non-member, so the
+          # boundary hides no history. The tombstone names no members, and both membership readers
+          # select on `status == "frozen"`, so it resolves there as an absent marker does.
           payload=$(jq -cn --arg since "$now" '{status: "retired", since: $since}')
           note="_Epic membership, RETIRED — the wave frozen here has fully landed. The instant below separates its history from the next wave's; the next ready set captures its own. Do not edit._"
         elif [ "$do" = "frozen" ]; then
-          # `at` records when the status last changed. A frozen marker never ages into anything, but
-          # a wave that cannot finish has to be measurable to be reported, which is what it is for.
+          # `at` records when the status last changed. A frozen marker never ages into another status;
+          # the timestamp is there so a wave that cannot finish can be measured and reported.
           payload=$(printf '%s' "$cur" | jq -c --arg at "$now" --arg since "$inherited_since" \
             '{status: "frozen", at: $at, members: .} + (if $since == "" then {} else {since: $since} end)')
           note="_Epic membership, FROZEN at activation by the merge-gate. The authoritative set for this landing — a later de-label, close, or relabel does not change it. Do not edit._"
@@ -684,17 +679,16 @@ runs:
         # it win. So each attempt re-checks the decision against what is actually there.
 
         # The marker says what we intend and can still make progress: same status, same member set,
-        # same wave boundary. `at` is per-writer and ignored: under byte equality two writers with an
-        # identical set never satisfy each other, ping-ponging until both give up on a failure that
-        # never happened. `since` is not per-writer — it is inherited content, and ignoring it would
-        # let a write that dropped the boundary read as equivalent to one that kept it. Both the entry
+        # same wave boundary. `at` is per-writer and ignored, since under byte equality two writers
+        # with an identical set never satisfy each other and both give up on a failure that never
+        # happened. `since` is inherited content, so it counts toward equality. Both the entry
         # short-circuit and the post-write verify call this, so a repair that was clobbered cannot
         # read as a repair that landed.
         marker_settled() { # $1 = live marker json, $2 = our payload json
           same_marker "$1" "$2" || return 1
-          # Only `pending` ages. `frozen` and `retired` are terminal marker states carrying no aging
-          # clock, so equality is the whole test for them — demanding a parseable `at` from a
-          # tombstone would leave it permanently unsettled and retry every retirement to exhaustion.
+          # Only `pending` ages. `frozen` and `retired` are terminal states carrying no aging clock,
+          # so equality is the whole test for them. A tombstone has no `at` to parse, and demanding
+          # one leaves it permanently unsettled while the retirement retries to exhaustion.
           case "$(printf '%s' "$1" | jq -r '.status // ""' 2>/dev/null || true)" in
             frozen | retired) return 0 ;;
           esac
@@ -734,12 +728,11 @@ runs:
             fi
 
             if [ "$do" = "retire" ]; then
-              # Re-derive the retirement: only the frozen set THIS pass judged landed may be ended.
-              # If the marker is no longer frozen, or its members moved, a peer has already opened the
-              # next wave and a tombstone written now would discard it and re-draw the boundary at the
+              # Re-derive the retirement: only the frozen set this pass judged landed may be ended. A
+              # marker that is no longer frozen, or whose members moved, means a peer has opened the
+              # next wave, and a tombstone written now would discard it and redraw the boundary at the
               # wrong instant. The member comparison is character-for-character the one the freeze
-              # guard below makes; two spellings of "this marker names the set this pass computed" is
-              # how one guard comes to accept what the other rejects.
+              # guard below makes, so neither guard can accept what the other rejects.
               if ! jq -e -n --argjson m "${marker:-null}" --argjson cur "$cur" \
                    '($m | type == "object") and $m.status == "frozen"
                     and (($m.members // []) | sort_by((.repo | ascii_downcase), .number)) == $cur' >/dev/null 2>&1; then
@@ -759,12 +752,11 @@ runs:
               break
             fi
 
-            # The boundary is carried, not derived: the payload took it from the marker this pass read
-            # at the start, so a peer that has since drawn a different one would be overwritten and the
-            # next wave's history un-scoped. Retirement is exempt — it draws the boundary rather than
-            # inheriting it, and the re-derive above already pins which set it may end. Both sides read
-            # through since_of, so a corrupt boundary compares equal to the empty one that replaces it
-            # and the repairing write goes through instead of yielding forever.
+            # The payload took its boundary from the marker this pass read at the start, so a peer
+            # that has since drawn a different one must survive. Retirement is exempt: it draws the
+            # boundary, and the re-derive above already pins which set it may end. Both sides read
+            # through since_of, so a corrupt boundary compares equal to the empty one replacing it and
+            # the repairing write goes through.
             if [ "$do" != "retire" ] && [ "$(since_of "$marker")" != "${inherited_since:-}" ]; then
               echo "Epic #${EPIC}: the wave boundary moved while this pass was deciding — not overwriting it; the next pass inherits what is actually there." \
                 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -31,6 +31,15 @@ description: >
   group — if the set regressed since enqueue (a member went back to draft, or lost its
   approval). A standalone PR in the queue re-affirms `success` (it was gated at enqueue).
 
+  This action is the ONLY writer of the activation-snapshot marker in the Epic body, which both
+  epic-membership and detect-partial-landing read. It captures the set (pending, then frozen) when
+  the Epic first holds merge-ready, and RETIRES it — to a `retired` tombstone carrying the wave
+  boundary — once every member has merged, so the next set can freeze and a pull request labeled
+  after the freeze is held for one wave rather than forever. A wave with a member closed unmerged
+  did not land and is never retired; the gate names it after 72h instead. A PR waiting on the next
+  wave is what triggers the retirement, since a fully merged wave has no open member left to run
+  the gate.
+
 inputs:
   client_id:
     required: true
@@ -376,10 +385,16 @@ runs:
         # wave's verdict says nothing about its own readiness. Pre-snapshot the live set is
         # the PR's own set, so this is a no-op, and a
         # merge_group event gates the whole group.
+        # This hold is also the only pass positioned to END the previous wave, so it enables the
+        # capture step in retire-only mode before returning. Retirement needs a frozen wave that has
+        # fully landed AND a pass that reaches the capture step; a wave with every member merged has
+        # no open member left to run the gate, so the pull request waiting on the next wave is the
+        # only trigger there is. Returning here without it is what held that PR forever.
         if [ -z "${IN_QUEUE:-}" ] && [ -n "${PR_NUMBER:-}" ]; then
           if [ "$(printf '%s' "$MEMBERS" | jq --arg r "$REPO_FULL" --argjson n "${PR_NUMBER}" \
                 'any(.[]; .repo == $r and .number == $n)')" != "true" ]; then
             post_check failure "Epic #${EPIC} — this PR carries the label but is not in the member set ${where}; holding (it belongs to a later wave, not this landing)."
+            echo "retire_only=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
         fi
@@ -409,7 +424,7 @@ runs:
     # gate's own token stays read-only on issues and the write capability lives in this step alone.
     - name: Mint snapshot-write token
       id: snap_token
-      if: ${{ steps.evaluate.outputs.capture == 'true' }}
+      if: ${{ steps.evaluate.outputs.capture == 'true' || steps.evaluate.outputs.retire_only == 'true' }}
       # Best-effort with its capture step: a token-mint hiccup must not fail the gate.
       continue-on-error: true
       uses: actions/create-github-app-token@v3
@@ -424,7 +439,7 @@ runs:
         permission-issues: write
 
     - name: Capture activation snapshot
-      if: ${{ steps.evaluate.outputs.capture == 'true' }}
+      if: ${{ steps.evaluate.outputs.capture == 'true' || steps.evaluate.outputs.retire_only == 'true' }}
       # Best-effort: the merge-gate check is already posted success, so a failed capture never fails
       # the gate. Membership stays live-derived until the next ready pass writes the marker.
       continue-on-error: true
@@ -436,6 +451,15 @@ runs:
         EPIC: ${{ steps.discover.outputs.epic_number }}
         MEMBERS: ${{ steps.membership.outputs.members }}
         STABILIZE_SECONDS: "120"
+        # Set when this pass arrived from the not-in-set hold rather than from an all-ready set. Such
+        # a pass is not a member of the set it just read, so it has no standing to capture one; it may
+        # only retire the wave that is holding it.
+        RETIRE_ONLY: ${{ steps.evaluate.outputs.retire_only }}
+        # How long a frozen wave may sit unfinished before the gate names what it is waiting on. It
+        # only warns: expiring a snapshot on a clock would un-freeze membership mid-landing, the
+        # failure the snapshot exists to prevent, and would fire exactly when an Epic is already
+        # unhealthy. A human closes the stray, or labels the Epic `automation:paused`.
+        STUCK_WAVE_HOURS: "72"
       run: |
         set -euo pipefail
         # The marker currently in the body, as JSON; empty when there is none or it is unusable.
@@ -444,6 +468,25 @@ runs:
             | awk -v s="$START" -v e="$END" '$0 == s {f=1;next} $0 == e {f=0} f' \
             | sed -n '/^[[:space:]]*[{[]/,$p' \
             | jq -s -c '.[0] // empty' 2>/dev/null || true
+        }
+
+        # The wave boundary carried by a marker: the instant before which a terminal pull request
+        # belongs to a retired wave, which detect-partial-landing appends to its `merged:` and
+        # `closed:` searches so one wave's history is not read as the next one's.
+        #
+        # Extracted AND validated here, in one place, because this value is used both to BUILD a
+        # payload and to GUARD a write. Read it twice with two different notions of well-formed and
+        # the two disagree: a guard comparing a raw boundary against a validated one never matches,
+        # and the pass yields on every attempt forever. Accepting exactly the form this step emits —
+        # which is also the only form detect-partial-landing will put in a query — makes a
+        # hand-edited or corrupt boundary drop out here, so the next write repairs it instead of
+        # carrying it forward. Dropping it scopes the next wave to unbounded history, which
+        # over-freezes; a bogus one silently reads as "nothing landed" and clears.
+        since_of() { # $1 = marker json -> the boundary, or empty
+          printf '%s' "${1:-}" | jq -r '
+            if type == "object" and (.since | type == "string")
+              and (.since | test("\\A[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\\z"))
+            then .since else empty end' 2>/dev/null || true
         }
 
         START='<!-- epic-membership:snapshot:start -->'
@@ -457,6 +500,17 @@ runs:
         # `frozen` as the set and reads `pending` as no snapshot. This runs per member PR, so several
         # passes reach here. GitHub stores bodies with CRLF; strip \r so the marker lines match.
         body=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/${EPIC}" --jq '.body // ""' | tr -d '\r')
+
+        # Has the frozen wave fully LANDED? Only MERGED counts, and "terminal" is deliberately not the
+        # test: a member that was de-labeled and closed unmerged is exactly what the snapshot exists to
+        # remember, so counting it as done would retire the only durable record of a wave that FAILED,
+        # and flip the partial-landing detector from `frozen` to `clear` — which posts success. Such a
+        # wave stays frozen until a human resolves it, which is what epic-rollback is for.
+        # Under a frozen marker epic-membership returns that set with each member's state re-read
+        # live, so this costs no extra call. Before activation every state is OPEN, and a version skew
+        # that omits `state` yields false, so neither retires prematurely.
+        all_landed=$(printf '%s' "$MEMBERS" | jq -c \
+          '(length > 0) and all(.[]; .state == "MERGED")' 2>/dev/null || echo false)
 
         # Repository names are canonicalized to lower case, so every pass computes a byte-identical
         # set for the same members. GitHub resolves names case-insensitively and answers with either
@@ -487,13 +541,25 @@ runs:
         if [ -z "$marker" ] || ! printf '%s' "$marker" | jq empty 2>/dev/null; then marker=null; fi
         now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-        # A frozen marker is skipped. A valid pending one resets when the members changed, promotes
-        # when it is unchanged and aged, and otherwise waits. Anything else — missing, malformed, or
-        # carrying another status — gets a fresh pending.
+        # The boundary this pass inherits. splice replaces the WHOLE fenced region, so a boundary
+        # survives only by being written again: without this the retirement tombstone is destroyed by
+        # the very next capture, the live `merged:` search hands the new wave the old one's merges
+        # back, and that wave freezes one pass after it captures — the bug #340 fixed, undone.
+        inherited_since=$(since_of "$marker")
+
+        # A frozen marker is retired once its wave has landed, and otherwise skipped. A valid pending
+        # one resets when the members changed, promotes when it is unchanged and aged, and otherwise
+        # waits. Anything else — missing, malformed, or carrying another status, which includes a
+        # `retired` tombstone — gets a fresh pending.
         do=$(jq -rn --argjson cur "$cur" --argjson mk "$marker" --arg now "$now" \
-          --argjson thr "${STABILIZE_SECONDS}" '
+          --argjson landed "$all_landed" --argjson thr "${STABILIZE_SECONDS}" '
           if ($mk | type) != "object" then "pending"
-          elif $mk.status == "frozen" then "skip"
+          # A frozen wave whose every member has merged has discharged its purpose: the set it was
+          # frozen to remember is landed, and until it is retired the gate holds every pull request
+          # labeled afterwards forever, with a message promising a next wave that can never begin.
+          # Retiring it draws the boundary and lets the next ready set capture its own, which is the
+          # "joins the next wave" behavior epic-membership already documents.
+          elif $mk.status == "frozen" then (if $landed then "retire" else "skip" end)
           elif ($mk.status == "pending" and ($mk.members | type == "array") and ($mk.at | type == "string"))
             then (
               if (($mk.members | sort_by((.repo | ascii_downcase), .number)) != $cur) then "pending"
@@ -508,16 +574,62 @@ runs:
           else "pending" end' 2>/dev/null || echo skip)
 
         if [ "$do" = "skip" ]; then
+          # A frozen wave that cannot finish is otherwise invisible: it holds every pull request
+          # labeled after it, and retirement needs every member merged, so nothing ever says why. Name
+          # what it is waiting on once the wait is long enough to be a fault rather than a landing in
+          # progress. The two cases need different words: an open member is late, while a member
+          # closed unmerged means the wave did not land and CANNOT retire by design.
+          if [ "$(printf '%s' "$marker" | jq -r 'if type == "object" then (.status // "") else "" end' 2>/dev/null || true)" = "frozen" ] \
+            && printf '%s' "$marker" | jq -e --arg now "$now" --argjson hrs "${STUCK_WAVE_HOURS}" \
+                 '(.at | try (fromdateiso8601 | true) catch false)
+                  and (($now | fromdateiso8601) - (.at | fromdateiso8601)) >= ($hrs * 3600)' >/dev/null 2>&1; then
+            late=$(printf '%s' "$MEMBERS" | jq -r '[.[] | select(.state == "OPEN" or .state == null)
+              | "\(.repo)#\(.number)"] | join(", ")' 2>/dev/null || true)
+            abandoned=$(printf '%s' "$MEMBERS" | jq -r '[.[] | select(.state == "CLOSED")
+              | "\(.repo)#\(.number)"] | join(", ")' 2>/dev/null || true)
+            if [ -n "$late" ]; then
+              echo "::warning::Epic #${EPIC}: the frozen wave has been open more than ${STUCK_WAVE_HOURS}h, still waiting on ${late}. Nothing labeled after it can land until it finishes — land those, close them, or label the Epic \`automation:paused\`." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
+            if [ -n "$abandoned" ]; then
+              echo "::warning::Epic #${EPIC}: the frozen wave cannot retire — ${abandoned} closed without merging, so it did not land. It stays frozen deliberately, because the snapshot is the only record that those were members; resolve it with epic-rollback." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
           echo "Epic #${EPIC}: snapshot already frozen, or stable but not yet aged — leaving it." \
             | tee -a "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
 
-        if [ "$do" = "frozen" ]; then
-          payload=$(printf '%s' "$cur" | jq -c '{status: "frozen", members: .}')
+        # A retire-only pass reached here from the not-in-set hold: it read a set it is not part of,
+        # so capturing one would freeze a wave on the authority of a pull request the wave excludes.
+        # It may end the previous wave and nothing else.
+        if [ "${RETIRE_ONLY:-}" = "true" ] && [ "$do" != "retire" ]; then
+          echo "Epic #${EPIC}: held for a later wave, and the current snapshot is not retirable this pass (${do}) — leaving it." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        if [ "$do" = "retire" ]; then
+          # A TOMBSTONE, not a deletion. The marker is the only record of where this wave ended, and
+          # the live `merged:` search keeps returning the wave's merges for the rest of the Epic's
+          # life, so removing the region hands the next wave the previous one's history back. `since`
+          # is `now` rather than inherited: retirement is what DRAWS the boundary, superseding the one
+          # before it. Nothing merged between the wave's last merge and this pass — the gate holds
+          # every non-member — so no history is hidden by it. The tombstone names no members, and
+          # both membership readers select on `status == "frozen"`, so they fall through to the live
+          # floor exactly as they would with no marker at all.
+          payload=$(jq -cn --arg since "$now" '{status: "retired", since: $since}')
+          note="_Epic membership, RETIRED — the wave frozen here has fully landed. The instant below separates its history from the next wave's; the next ready set captures its own. Do not edit._"
+        elif [ "$do" = "frozen" ]; then
+          # `at` records when the status last changed. A frozen marker never ages into anything, but
+          # a wave that cannot finish has to be measurable to be reported, which is what it is for.
+          payload=$(printf '%s' "$cur" | jq -c --arg at "$now" --arg since "$inherited_since" \
+            '{status: "frozen", at: $at, members: .} + (if $since == "" then {} else {since: $since} end)')
           note="_Epic membership, FROZEN at activation by the merge-gate. The authoritative set for this landing — a later de-label, close, or relabel does not change it. Do not edit._"
         else
-          payload=$(printf '%s' "$cur" | jq -c --arg at "$now" '{status: "pending", at: $at, members: .}')
+          payload=$(printf '%s' "$cur" | jq -c --arg at "$now" --arg since "$inherited_since" \
+            '{status: "pending", at: $at, members: .} + (if $since == "" then {} else {since: $since} end)')
           note="_Epic membership, PENDING — stabilizing before it freezes (the label index is eventually consistent). Do not edit._"
         fi
 
@@ -571,23 +683,31 @@ runs:
         # re-deriving freezes a member set the world has already moved past, and the retry below makes
         # it win. So each attempt re-checks the decision against what is actually there.
 
-        # The marker says what we intend and can still make progress: same status, same member set.
-        # `at` is per-writer and ignored: under byte equality two writers with an identical set never
-        # satisfy each other, ping-ponging until both give up on a failure that never happened. Both
-        # the entry short-circuit and the post-write verify call this, so a repair that
-        # was clobbered cannot read as a repair that landed.
+        # The marker says what we intend and can still make progress: same status, same member set,
+        # same wave boundary. `at` is per-writer and ignored: under byte equality two writers with an
+        # identical set never satisfy each other, ping-ponging until both give up on a failure that
+        # never happened. `since` is not per-writer — it is inherited content, and ignoring it would
+        # let a write that dropped the boundary read as equivalent to one that kept it. Both the entry
+        # short-circuit and the post-write verify call this, so a repair that was clobbered cannot
+        # read as a repair that landed.
         marker_settled() { # $1 = live marker json, $2 = our payload json
           same_marker "$1" "$2" || return 1
-          # A frozen marker is terminal, so it carries no `at` and needs none.
-          [ "$(printf '%s' "$1" | jq -r '.status // ""')" = "frozen" ] && return 0
+          # Only `pending` ages. `frozen` and `retired` are terminal marker states carrying no aging
+          # clock, so equality is the whole test for them — demanding a parseable `at` from a
+          # tombstone would leave it permanently unsettled and retry every retirement to exhaustion.
+          case "$(printf '%s' "$1" | jq -r '.status // ""' 2>/dev/null || true)" in
+            frozen | retired) return 0 ;;
+          esac
           # A pending marker whose `at` cannot be parsed can never age, so it is not settled however
           # equal its members look; the decision step routes that case to a repairing write.
           printf '%s' "$1" | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null 2>&1
         }
 
         same_marker() { # $1 = marker json, $2 = marker json
-          [ -n "$1" ] && [ -n "$2" ] && jq -e -n --argjson a "$1" --argjson b "$2" \
-            '($a.status == $b.status) and (($a.members // []) == ($b.members // []))' >/dev/null 2>&1
+          [ -n "$1" ] && [ -n "$2" ] \
+            && jq -e -n --argjson a "$1" --argjson b "$2" \
+              '($a.status == $b.status) and (($a.members // []) == ($b.members // []))' >/dev/null 2>&1 \
+            && [ "$(since_of "$1")" = "$(since_of "$2")" ]
         }
 
         write_marker() { # $1 = region file. 0 = our marker is in place, 2 = yielded, 1 = gave up
@@ -613,12 +733,40 @@ runs:
               break
             fi
 
+            if [ "$do" = "retire" ]; then
+              # Re-derive the retirement: only the frozen set THIS pass judged landed may be ended.
+              # If the marker is no longer frozen, or its members moved, a peer has already opened the
+              # next wave and a tombstone written now would discard it and re-draw the boundary at the
+              # wrong instant. The member comparison is character-for-character the one the freeze
+              # guard below makes; two spellings of "this marker names the set this pass computed" is
+              # how one guard comes to accept what the other rejects.
+              if ! jq -e -n --argjson m "${marker:-null}" --argjson cur "$cur" \
+                   '($m | type == "object") and $m.status == "frozen"
+                    and (($m.members // []) | sort_by((.repo | ascii_downcase), .number)) == $cur' >/dev/null 2>&1; then
+                echo "Epic #${EPIC}: the snapshot moved on before this pass could retire it — leaving it." \
+                  | tee -a "$GITHUB_STEP_SUMMARY"
+                rc=2
+                break
+              fi
             # A frozen marker is terminal: it is the authority every reader has been using, so yield
             # whatever this pass intended. The check narrows the window without closing it — a freeze
             # landing between here and the write below is still clobbered, and no conditional-update
             # API exists to prevent that.
-            if [ -n "$marker" ] && [ "$(printf '%s' "$marker" | jq -r '.status // ""')" = "frozen" ]; then
+            elif [ -n "$marker" ] && [ "$(printf '%s' "$marker" | jq -r '.status // ""')" = "frozen" ]; then
               echo "Epic #${EPIC}: the snapshot is already frozen (a peer got there first) — leaving it." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+              rc=2
+              break
+            fi
+
+            # The boundary is carried, not derived: the payload took it from the marker this pass read
+            # at the start, so a peer that has since drawn a different one would be overwritten and the
+            # next wave's history un-scoped. Retirement is exempt — it draws the boundary rather than
+            # inheriting it, and the re-derive above already pins which set it may end. Both sides read
+            # through since_of, so a corrupt boundary compares equal to the empty one that replaces it
+            # and the repairing write goes through instead of yielding forever.
+            if [ "$do" != "retire" ] && [ "$(since_of "$marker")" != "${inherited_since:-}" ]; then
+              echo "Epic #${EPIC}: the wave boundary moved while this pass was deciding — not overwriting it; the next pass inherits what is actually there." \
                 | tee -a "$GITHUB_STEP_SUMMARY"
               rc=2
               break
@@ -664,7 +812,10 @@ runs:
         }
 
         write_marker "$regionf" && wm=0 || wm=$?
-        if [ "$wm" = 0 ]; then
+        if [ "$wm" = 0 ] && [ "$do" = "retire" ]; then
+          echo "Epic #${EPIC}: the wave landed — activation snapshot retired at ${now}; the next ready set captures its own." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+        elif [ "$wm" = 0 ]; then
           n=$(printf '%s' "$cur" | jq 'length')
           echo "Epic #${EPIC}: ${do} activation snapshot in place — ${n} member(s)." | tee -a "$GITHUB_STEP_SUMMARY"
         elif [ "$wm" = 2 ]; then

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -13,9 +13,11 @@
 # before the loop, so a writer that re-reads without re-deriving freezes a member set the world has
 # already moved past, and a retry loop makes it win. Several cases below exist to pin that.
 #
-# Scope: this drives `write_marker` and its helpers. The decision step that produces `$do`/`$payload`
-# (the `do=` jq, and the member normalization above it) is not extracted; the fixtures set those as
-# inputs.
+# Scope: this drives `write_marker` and its helpers, plus the three things the step computes before
+# calling it — the member normalization, the decision program, and the payload assembly. All four are
+# lifted out of the manifest rather than restated, because a fixture that restates one encodes a
+# belief about the format instead of observing it: while the decision was supplied as an input, no
+# test could see the step decide anything.
 set -euo pipefail
 
 TOP_PID=$$
@@ -33,7 +35,7 @@ extract() { # $1 = function name — lift it out of the run: block and de-indent
     f && /^        \}$/ {exit}
   ' "$ACTION" | sed 's/^        //'
 }
-for fn in splice current_marker same_marker marker_settled write_marker; do
+for fn in splice current_marker since_of same_marker marker_settled write_marker; do
   out=$(extract "$fn")
   if [ -z "$out" ]; then
     echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
@@ -58,9 +60,11 @@ export GITHUB_STEP_SUMMARY="$WORK/summary.md"
 START=$(sed -n "s/^ *START='\(.*\)'\$/\1/p" "$ACTION" | head -1)
 END=$(sed -n "s/^ *END='\(.*\)'\$/\1/p" "$ACTION" | head -1)
 [ -n "$START" ] && [ -n "$END" ] || die "could not read the fence literals from $ACTION"
+# Indentation-agnostic: the block moves the moment it is wrapped in anything, and an anchor tied to a
+# fixed indent would stop matching silently — the failure this whole derivation exists to prevent.
 REGION_BLOCK=$(awk '
-  /^        \{$/ { buf=""; inb=1; next }
-  inb && /^        \} > "\$regionf"$/ { printf "%s", buf; exit }
+  /^[[:space:]]*\{$/ { buf=""; inb=1; next }
+  inb && /^[[:space:]]*\} > "\$regionf"$/ { printf "%s", buf; exit }
   inb { buf = buf $0 "\n" }
 ' "$ACTION")
 [ -n "$REGION_BLOCK" ] || die "could not read the region block from $ACTION"
@@ -118,14 +122,18 @@ M2B='[{"repo":"a-novel-kit/repo-a","number":5},{"repo":"a-novel-kit/repo-c","num
 # them as given, so the canonical order needs the composite (repo, number) key.
 M2S='[{"repo":"a-novel-kit/repo-a","number":2},{"repo":"a-novel-kit/repo-a","number":9}]'
 
-pending_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --argjson m "$1" '{status:"pending", at:$at, members:$m}'; }
-frozen_json() { jq -cn --argjson m "$1" '{status:"frozen", members:$m}'; }
+# $3, where present, is the wave boundary the marker carries forward.
+pending_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --arg s "${3:-}" --argjson m "$1" \
+  '{status:"pending", at:$at, members:$m} + (if $s == "" then {} else {since:$s} end)'; }
+frozen_json() { jq -cn --arg at "${2:-2026-07-22T10:00:00Z}" --arg s "${3:-}" --argjson m "$1" \
+  '{status:"frozen", at:$at, members:$m} + (if $s == "" then {} else {since:$s} end)'; }
+retired_json() { jq -cn --arg s "$1" '{status:"retired", since:$s}'; }
 
 # The note the action writes, read out of the manifest: a note beginning with `[` or `{` makes
 # current_marker latch onto it and read every marker as absent, which a restated copy cannot show.
-note_of() { # frozen|pending
-  local key=FROZEN
-  [ "$1" = frozen ] || key=PENDING
+note_of() { # frozen|pending|retire
+  local key
+  case "$1" in frozen) key=FROZEN ;; retire) key=RETIRED ;; *) key=PENDING ;; esac
   sed -n "s/^ *note=\"\(_Epic membership, $key.*\)\"$/\1/p" "$ACTION" | head -1
 }
 region_file() { # $1 = payload json, $2 = frozen|pending -> the region the action itself would build
@@ -175,6 +183,49 @@ NORMALIZE_JQ=$(awk '/^ *cur=\$\(printf/{f=1;next} f{print} f&&/\)$/{exit}' "$ACT
   | sed "s/^[[:space:]]*'//; s/')$//")
 [ -n "$NORMALIZE_JQ" ] || die "could not read the member normalization from $ACTION"
 normalize() { printf '%s' "$1" | jq -c "$NORMALIZE_JQ" 2>/dev/null || echo '[]'; }
+
+# The DECISION program, lifted whole. Until now the suite set `do` as an input, so nothing could
+# watch the step decide — and a wave boundary is decided before it is written.
+DECIDE_JQ=$(awk "
+  /do=\\\$\\(jq -rn/ { f=1 }
+  f && !st && /'\$/ { st=1; next }
+  st && /' 2>\\/dev\\/null \\|\\| echo skip\\)\$/ { sub(/'.*\$/, \"\"); print; exit }
+  st { print }
+" "$ACTION")
+[ -n "$DECIDE_JQ" ] || die "could not read the decision program from $ACTION"
+decide() { # $1 = marker json (or null), $2 = all_landed, $3 = cur members
+  jq -rn --argjson cur "${3:-$M2}" --argjson mk "$1" --arg now "$now" \
+    --argjson landed "$2" --argjson thr "$STABILIZE_SECONDS" "$DECIDE_JQ" 2>/dev/null || echo skip
+}
+
+# The landed test, also lifted. It is what decides a wave is over, and it lives in bash beside the
+# decision program rather than inside it, so extracting only the latter would leave it unseen.
+LANDED_JQ=$(awk '/all_landed=/{f=1;next} f{ sub(/^[[:space:]]*'"'"'/, ""); sub(/'"'"'.*$/, ""); print; exit }' "$ACTION")
+[ -n "$LANDED_JQ" ] || die "could not read the landed test from $ACTION"
+landed_of() { printf '%s' "$1" | jq -c "$LANDED_JQ" 2>/dev/null || echo false; }
+
+# The payload/note assembly, lifted whole — the last piece the suite supplied rather than observed,
+# which is why a frozen marker silently losing its timestamp, or a retirement dropping the boundary,
+# were both invisible.
+PAYLOAD_BLOCK=$(awk '/if \[ "\$do" = "retire" \]; then/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
+[ -n "$PAYLOAD_BLOCK" ] || die "could not read the payload assembly from $ACTION"
+# The retire-only bail, lifted the same way: it is inline step logic rather than a function, and it
+# is the whole reason a held pull request may run the capture step at all.
+BAIL_BLOCK=$(awk '/RETIRE_ONLY:-/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
+[ -n "$BAIL_BLOCK" ] || die "could not read the retire-only bail from $ACTION"
+bails() { # $1 = RETIRE_ONLY, $2 = do -> "bailed" (the step returned) or "went-on"
+  local out
+  out=$( RETIRE_ONLY="$1"; do="$2"; eval "$BAIL_BLOCK" >/dev/null 2>&1; printf 'went-on' )
+  [ -n "$out" ] && echo went-on || echo bailed
+}
+
+payload_for() { # $1 = do, $2 = cur, $3 = inherited since -> echoes the payload, sets NOTE_OUT
+  local do cur inherited_since payload note
+  do="$1"; cur="$2"; inherited_since="${3:-}"
+  eval "$PAYLOAD_BLOCK"
+  NOTE_OUT="$note"
+  printf '%s' "$payload"
+}
 
 echo "the member set is canonical, whatever casing GitHub answers with"
 # GitHub resolves repository names case-insensitively and may answer with either spelling. If the
@@ -327,6 +378,182 @@ do=frozen; cur="$M2"; payload=$(frozen_json "$M2")
 eq "a reordered member array still freezes" "$(run)" 0
 eq "and the marker is frozen" "$(marker_now | jq -r .status)" frozen
 
+# ---- the wave boundary ---------------------------------------------------------------------
+# A frozen set is the set FOREVER until something retires it, so a pull request labelled after the
+# freeze is held by the gate with a message promising a next wave that can never begin.
+
+W=2026-07-20T08:00:00Z
+
+echo
+echo "a landed wave is retired so the next one can freeze"
+reset
+server_body "$(frozen_json "$M2")"
+do=retire; cur="$M2"; inherited_since=""; payload=$(retired_json "$now")
+eq "the tombstone is written" "$(run)" 0
+eq "leaving a retired marker" "$(marker_now | jq -r .status)" retired
+eq "carrying the boundary it drew" "$(marker_now | jq -r .since)" "$now"
+eq "and naming no members" "$(marker_now | jq -r '.members // "none"')" none
+grep -q 'Some prose' "$WORK/body" && ok "with the human prose untouched" || ko "prose was dropped retiring"
+grep -qF -- "$START" "$WORK/body" && ok "and the region still standing" \
+  || ko "the fences went with it, so the boundary has nowhere to live"
+
+echo
+echo "retirement re-derives like every other write"
+# Only the frozen set this pass judged landed may be ended. If a peer has opened the next wave, a
+# tombstone written now discards it and redraws the boundary at the wrong instant.
+reset
+server_body "$(pending_json "$M2" 2026-07-22T09:59:00Z)"
+do=retire; cur="$M2"; inherited_since=""; payload=$(retired_json "$now")
+eq "a marker that is no longer frozen is left alone" "$(run)" 2
+eq "and it still stands" "$(marker_now | jq -r .status)" pending
+eq "with nothing written" "$(writes)" 0
+reset
+server_body "$(frozen_json "$M2B")"
+do=retire; cur="$M2"; inherited_since=""; payload=$(retired_json "$now")
+eq "a frozen set this pass did not judge is left alone" "$(run)" 2
+eq "and nothing is written" "$(writes)" 0
+
+echo
+echo "a retirement a peer undoes is retried"
+reset
+server_body "$(frozen_json "$M2")"
+printf 'Some prose.\n\n%s\n%s\n%s\n%s\n\nMore prose.\n' "$START" "$(note_of frozen)" \
+  "$(frozen_json "$M2")" "$END" > "$WORK/steal"
+do=retire; cur="$M2"; inherited_since=""; payload=$(retired_json "$now")
+eq "the retirement is retried until it sticks" "$(run)" 0
+eq "which takes two writes" "$(writes)" 2
+eq "and the tombstone is what stands" "$(marker_now | jq -r .status)" retired
+
+echo
+echo "the boundary is carried forward, not written once"
+# splice replaces the WHOLE region, so a boundary survives only by being written again. Without this
+# the tombstone dies with the next capture, the live `merged:` search hands the new wave the old
+# one's merges back, and that wave freezes one pass after it captures.
+reset
+server_body "$(retired_json "$W")"
+inherited_since=$(since_of "$(retired_json "$W")")
+do=pending; cur="$M1"; payload=$(payload_for pending "$M1" "$inherited_since")
+eq "it is inherited from the tombstone being replaced" "$inherited_since" "$W"
+eq "a fresh pending is written over it" "$(run)" 0
+eq "and keeps the boundary" "$(marker_now | jq -r .since)" "$W"
+reset
+server_body "$(pending_json "$M1" 2026-07-22T09:00:00Z "$W")"
+inherited_since=$(since_of "$(pending_json "$M1" 2026-07-22T09:00:00Z "$W")")
+do=frozen; cur="$M1"; payload=$(payload_for frozen "$M1" "$inherited_since")
+eq "the promotion to frozen goes through" "$(run)" 0
+eq "and keeps it too" "$(marker_now | jq -r .since)" "$W"
+
+echo
+echo "only an instant is a boundary"
+# detect-partial-landing appends this to a search qualifier, and GitHub answers a malformed one with
+# zero rows and no error — indistinguishable from "nothing landed", which clears a standing freeze.
+for bad in '"garbage"' '"2026-07-20"' '"2026-07-20T08:00:00+02:00"' '1234' 'null'; do
+  eq "since=$bad is not one" \
+    "$(since_of "$(jq -cn --argjson s "$bad" '{status:"retired", since:$s}')")" ""
+done
+eq "the form this step emits is" "$(since_of "$(retired_json "$W")")" "$W"
+
+echo
+echo "a boundary a peer redrew is not overwritten"
+reset
+server_body "$(pending_json "$M2" 2026-07-22T09:00:00Z 2026-07-21T00:00:00Z)"
+do=pending; cur="$M2"; inherited_since="$W"
+payload=$(payload_for pending "$M2" "$inherited_since")
+eq "the pass yields rather than un-scoping the next wave" "$(run)" 2
+eq "and the peer's boundary stands" "$(marker_now | jq -r .since)" 2026-07-21T00:00:00Z
+eq "with nothing written" "$(writes)" 0
+
+echo
+echo "a corrupt boundary is repaired, not deadlocked on"
+# The guard compares what since_of reads on both sides. Read the live marker raw and the payload
+# validated, and a corrupt boundary never compares equal to the empty one replacing it: the pass
+# yields on every attempt, forever, while the log calls it a deliberate yield.
+reset
+server_body "$(jq -cn --argjson m "$M2" \
+  '{status:"pending", at:"2026-07-22T09:00:00Z", since:"garbage", members:$m}')"
+do=frozen; cur="$M2"; inherited_since=""
+payload=$(payload_for frozen "$M2" "$inherited_since")
+eq "the write goes through" "$(run)" 0
+eq "and the unusable boundary is dropped" "$(marker_now | jq -r '.since // "none"')" none
+
+echo
+echo "a terminal marker is settled by equality alone"
+# frozen and retired carry no aging clock. Demand a parseable `at` from one and it is permanently
+# unsettled: every retirement retries to exhaustion and reports a failure that did not happen.
+marker_settled "$(retired_json "$W")" "$(retired_json "$W")" \
+  && ok "a tombstone matching our payload counts as settled" \
+  || ko "a tombstone can never settle, so retirement never converges"
+marker_settled "$(frozen_json "$M2")" "$(frozen_json "$M2")" \
+  && ok "and so does a frozen marker" || ko "a frozen marker cannot settle"
+marker_settled "$(retired_json "$W")" "$(retired_json 2026-07-01T00:00:00Z)" \
+  && ko "two different boundaries read as one marker" || ok "but two boundaries apart do not"
+
+echo
+echo "what counts as a landed wave"
+# TERMINAL is not the test. A member de-labelled and closed unmerged is exactly what the snapshot
+# exists to remember: retiring on it destroys the only record that the wave FAILED, and flips the
+# partial-landing detector from `frozen` to `clear`, which posts success.
+st() { jq -cn --argjson s "$1" '[$s[] | {repo:"o/r", number:1, state:.}]'; }
+eq "every member merged is landed"     "$(landed_of "$(st '["MERGED","MERGED"]')")" true
+eq "one closed unmerged is NOT"        "$(landed_of "$(st '["MERGED","CLOSED"]')")" false
+eq "one still open is not"             "$(landed_of "$(st '["MERGED","OPEN"]')")" false
+eq "an empty set is not a wave at all" "$(landed_of '[]')" false
+eq "and a set carrying no state is not" "$(landed_of '[{"repo":"o/r","number":1}]')" false
+
+echo
+echo "the decision the step actually computes"
+# Driven through the manifest's own jq, so the retire rule is pinned where it is written rather than
+# assumed by fixtures that set `do` by hand.
+eq "no marker at all -> pending"       "$(decide null false)" pending
+eq "pending, aged -> frozen"           "$(decide "$(pending_json "$M2" 2026-07-22T09:00:00Z)" false)" frozen
+eq "pending, fresh -> skip"            "$(decide "$(pending_json "$M2" 2026-07-22T09:59:30Z)" false)" skip
+eq "pending, members moved -> pending" "$(decide "$(pending_json "$M2B" 2026-07-22T09:00:00Z)" false)" pending
+eq "frozen, wave not landed -> skip"   "$(decide "$(frozen_json "$M2")" false)" skip
+eq "frozen, wave landed -> retire"     "$(decide "$(frozen_json "$M2")" true)" retire
+eq "a tombstone -> pending"            "$(decide "$(retired_json "$W")" false)" pending
+eq "garbage marker -> pending"         "$(decide '"nonsense"' false)" pending
+
+echo
+echo "a held pull request may end the previous wave and nothing else"
+# Retirement is reachable only because the not-in-set hold enables this step: a wave with every
+# member merged has no open member left to run the gate, so the pull request waiting on the next wave
+# is the only trigger there is. But that pass read a set it is NOT part of, so letting it capture
+# would freeze a wave on the authority of a pull request the wave excludes.
+eq "a held pass may retire"                 "$(bails true retire)" went-on
+eq "but may not capture a fresh pending"    "$(bails true pending)" bailed
+eq "nor promote one to frozen"              "$(bails true frozen)" bailed
+eq "while an ordinary pass is unaffected"   "$(bails "" pending)" went-on
+
+echo
+echo "and it is reachable from that hold"
+# The wiring is a step output plus two Actions expressions, so it cannot be driven here — but it is
+# the only path by which a completed wave is ever retired, and one deleted line restores the forever-
+# hold this work exists to end. Assert it structurally, as the fence agreement above is.
+hold_block=$(awk '/is not in the member set/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
+grep -q 'retire_only=true' <<< "$hold_block" \
+  && ok "the not-in-set hold enables the capture step before it returns" \
+  || ko "the hold returns without enabling retirement — a pull request held there is held forever"
+for step in "Mint snapshot-write token" "Capture activation snapshot"; do
+  if awk -v s="$step" '$0 ~ "name: " s {f=1;next} f && /^ *if:/ {print; exit}' "$ACTION" \
+    | grep -q 'retire_only'; then
+    ok "\"$step\" runs for a retire-only pass"
+  else
+    ko "\"$step\" is gated on capture alone, so a retire-only pass never reaches it"
+  fi
+done
+
+echo
+echo "the payload the step builds"
+eq "a frozen payload records when it froze" "$(payload_for frozen "$M2" | jq -r 'has("at")')" true
+eq "and the members it froze"               "$(payload_for frozen "$M2" | jq -c .members)" "$M2"
+eq "a pending payload records its clock"    "$(payload_for pending "$M2" | jq -r 'has("at")')" true
+eq "neither invents a boundary"             "$(payload_for pending "$M2" | jq -r 'has("since")')" false
+eq "both carry one they inherited"          "$(payload_for frozen "$M2" "$W" | jq -r .since)" "$W"
+eq "a retirement names no members"          "$(payload_for retire "$M2" | jq -r 'has("members")')" false
+eq "drawing the boundary at now"            "$(payload_for retire "$M2" | jq -r .since)" "$now"
+eq "not the one it inherited"               "$(payload_for retire "$M2" "$W" | jq -r .since)" "$now"
+eq "and it carries a note of its own"       "$(payload_for retire "$M2" >/dev/null; [ -n "$NOTE_OUT" ] && echo yes)" yes
+
 echo
 echo "splice, on its own"
 # Driven directly, because the retry loop hides it: a broken splice writes a body with no fences, the
@@ -476,7 +703,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -ne 76 ]; then
-  echo "::error::$ran assertion(s) ran, expected exactly 76 — the suite did not execute fully (or an assertion was added without raising this)"
+if [ "$ran" -ne 138 ]; then
+  echo "::error::$ran assertion(s) ran, expected exactly 138 — the suite did not execute fully (or an assertion was added without raising this)"
   exit 1
 fi

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -13,11 +13,9 @@
 # before the loop, so a writer that re-reads without re-deriving freezes a member set the world has
 # already moved past, and a retry loop makes it win. Several cases below exist to pin that.
 #
-# Scope: this drives `write_marker` and its helpers, plus the three things the step computes before
-# calling it — the member normalization, the decision program, and the payload assembly. All four are
-# lifted out of the manifest rather than restated, because a fixture that restates one encodes a
-# belief about the format instead of observing it: while the decision was supplied as an input, no
-# test could see the step decide anything.
+# Scope: this drives `write_marker` and its helpers, plus the decision the step makes before calling
+# it and the payload it assembles. Both are lifted out of the manifest rather than restated, so a
+# fixture cannot encode a belief about the format in place of observing it.
 set -euo pipefail
 
 TOP_PID=$$
@@ -60,8 +58,8 @@ export GITHUB_STEP_SUMMARY="$WORK/summary.md"
 START=$(sed -n "s/^ *START='\(.*\)'\$/\1/p" "$ACTION" | head -1)
 END=$(sed -n "s/^ *END='\(.*\)'\$/\1/p" "$ACTION" | head -1)
 [ -n "$START" ] && [ -n "$END" ] || die "could not read the fence literals from $ACTION"
-# Indentation-agnostic: the block moves the moment it is wrapped in anything, and an anchor tied to a
-# fixed indent would stop matching silently — the failure this whole derivation exists to prevent.
+# Matched without regard to indentation, so wrapping the block in a conditional does not silently
+# stop the anchor from matching.
 REGION_BLOCK=$(awk '
   /^[[:space:]]*\{$/ { buf=""; inb=1; next }
   inb && /^[[:space:]]*\} > "\$regionf"$/ { printf "%s", buf; exit }
@@ -184,8 +182,8 @@ NORMALIZE_JQ=$(awk '/^ *cur=\$\(printf/{f=1;next} f{print} f&&/\)$/{exit}' "$ACT
 [ -n "$NORMALIZE_JQ" ] || die "could not read the member normalization from $ACTION"
 normalize() { printf '%s' "$1" | jq -c "$NORMALIZE_JQ" 2>/dev/null || echo '[]'; }
 
-# The DECISION program, lifted whole. Until now the suite set `do` as an input, so nothing could
-# watch the step decide — and a wave boundary is decided before it is written.
+# The decision program, lifted whole, so the suite watches the step decide instead of being handed
+# `do` as an input.
 DECIDE_JQ=$(awk "
   /do=\\\$\\(jq -rn/ { f=1 }
   f && !st && /'\$/ { st=1; next }
@@ -198,19 +196,18 @@ decide() { # $1 = marker json (or null), $2 = all_landed, $3 = cur members
     --argjson landed "$2" --argjson thr "$STABILIZE_SECONDS" "$DECIDE_JQ" 2>/dev/null || echo skip
 }
 
-# The landed test, also lifted. It is what decides a wave is over, and it lives in bash beside the
-# decision program rather than inside it, so extracting only the latter would leave it unseen.
+# The landed test, also lifted. It decides a wave is over, and it sits in bash beside the decision
+# program rather than inside it, so it needs its own anchor.
 LANDED_JQ=$(awk '/all_landed=/{f=1;next} f{ sub(/^[[:space:]]*'"'"'/, ""); sub(/'"'"'.*$/, ""); print; exit }' "$ACTION")
 [ -n "$LANDED_JQ" ] || die "could not read the landed test from $ACTION"
 landed_of() { printf '%s' "$1" | jq -c "$LANDED_JQ" 2>/dev/null || echo false; }
 
-# The payload/note assembly, lifted whole — the last piece the suite supplied rather than observed,
-# which is why a frozen marker silently losing its timestamp, or a retirement dropping the boundary,
-# were both invisible.
+# The payload and note assembly, lifted whole, so a payload losing its timestamp or its boundary is
+# observable here.
 PAYLOAD_BLOCK=$(awk '/if \[ "\$do" = "retire" \]; then/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
 [ -n "$PAYLOAD_BLOCK" ] || die "could not read the payload assembly from $ACTION"
-# The retire-only bail, lifted the same way: it is inline step logic rather than a function, and it
-# is the whole reason a held pull request may run the capture step at all.
+# The retire-only bail, lifted the same way. It is inline step logic rather than a function, and it
+# bounds what a held pull request may do once it reaches the capture step.
 BAIL_BLOCK=$(awk '/RETIRE_ONLY:-/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
 [ -n "$BAIL_BLOCK" ] || die "could not read the retire-only bail from $ACTION"
 bails() { # $1 = RETIRE_ONLY, $2 = do -> "bailed" (the step returned) or "went-on"
@@ -379,8 +376,8 @@ eq "a reordered member array still freezes" "$(run)" 0
 eq "and the marker is frozen" "$(marker_now | jq -r .status)" frozen
 
 # ---- the wave boundary ---------------------------------------------------------------------
-# A frozen set is the set FOREVER until something retires it, so a pull request labelled after the
-# freeze is held by the gate with a message promising a next wave that can never begin.
+# A frozen set stays the set until something retires it, so a pull request labeled after the freeze
+# is held by the gate until the wave it is waiting on ends.
 
 W=2026-07-20T08:00:00Z
 
@@ -399,8 +396,8 @@ grep -qF -- "$START" "$WORK/body" && ok "and the region still standing" \
 
 echo
 echo "retirement re-derives like every other write"
-# Only the frozen set this pass judged landed may be ended. If a peer has opened the next wave, a
-# tombstone written now discards it and redraws the boundary at the wrong instant.
+# Only the frozen set this pass judged landed may be ended. A peer that has opened the next wave
+# loses it to a tombstone written now, which also redraws the boundary at the wrong instant.
 reset
 server_body "$(pending_json "$M2" 2026-07-22T09:59:00Z)"
 do=retire; cur="$M2"; inherited_since=""; payload=$(retired_json "$now")
@@ -426,9 +423,9 @@ eq "and the tombstone is what stands" "$(marker_now | jq -r .status)" retired
 
 echo
 echo "the boundary is carried forward, not written once"
-# splice replaces the WHOLE region, so a boundary survives only by being written again. Without this
-# the tombstone dies with the next capture, the live `merged:` search hands the new wave the old
-# one's merges back, and that wave freezes one pass after it captures.
+# splice replaces the whole region, so a boundary survives only by being written again. The capture
+# after a retirement carries the tombstone's instant forward, which keeps the retired wave's merges
+# out of the new wave's history.
 reset
 server_body "$(retired_json "$W")"
 inherited_since=$(since_of "$(retired_json "$W")")
@@ -465,9 +462,8 @@ eq "with nothing written" "$(writes)" 0
 
 echo
 echo "a corrupt boundary is repaired, not deadlocked on"
-# The guard compares what since_of reads on both sides. Read the live marker raw and the payload
-# validated, and a corrupt boundary never compares equal to the empty one replacing it: the pass
-# yields on every attempt, forever, while the log calls it a deliberate yield.
+# The guard reads both sides through since_of. A second reading that skipped validation would never
+# match, and the pass would yield on every attempt while the log called it a deliberate yield.
 reset
 server_body "$(jq -cn --argjson m "$M2" \
   '{status:"pending", at:"2026-07-22T09:00:00Z", since:"garbage", members:$m}')"
@@ -478,8 +474,8 @@ eq "and the unusable boundary is dropped" "$(marker_now | jq -r '.since // "none
 
 echo
 echo "a terminal marker is settled by equality alone"
-# frozen and retired carry no aging clock. Demand a parseable `at` from one and it is permanently
-# unsettled: every retirement retries to exhaustion and reports a failure that did not happen.
+# frozen and retired carry no aging clock, so equality settles them. A tombstone asked for a
+# parseable `at` is never settled, and the retirement retries to exhaustion.
 marker_settled "$(retired_json "$W")" "$(retired_json "$W")" \
   && ok "a tombstone matching our payload counts as settled" \
   || ko "a tombstone can never settle, so retirement never converges"
@@ -490,8 +486,8 @@ marker_settled "$(retired_json "$W")" "$(retired_json 2026-07-01T00:00:00Z)" \
 
 echo
 echo "what counts as a landed wave"
-# TERMINAL is not the test. A member de-labelled and closed unmerged is exactly what the snapshot
-# exists to remember: retiring on it destroys the only record that the wave FAILED, and flips the
+# Only a merged member counts. A member de-labeled and closed unmerged is what the snapshot exists
+# to remember, so retiring on it destroys the only record that the wave failed and flips the
 # partial-landing detector from `frozen` to `clear`, which posts success.
 st() { jq -cn --argjson s "$1" '[$s[] | {repo:"o/r", number:1, state:.}]'; }
 eq "every member merged is landed"     "$(landed_of "$(st '["MERGED","MERGED"]')")" true
@@ -502,8 +498,7 @@ eq "and a set carrying no state is not" "$(landed_of '[{"repo":"o/r","number":1}
 
 echo
 echo "the decision the step actually computes"
-# Driven through the manifest's own jq, so the retire rule is pinned where it is written rather than
-# assumed by fixtures that set `do` by hand.
+# Driven through the manifest's own jq, so the retire rule is pinned where it is written.
 eq "no marker at all -> pending"       "$(decide null false)" pending
 eq "pending, aged -> frozen"           "$(decide "$(pending_json "$M2" 2026-07-22T09:00:00Z)" false)" frozen
 eq "pending, fresh -> skip"            "$(decide "$(pending_json "$M2" 2026-07-22T09:59:30Z)" false)" skip
@@ -517,8 +512,8 @@ echo
 echo "a held pull request may end the previous wave and nothing else"
 # Retirement is reachable only because the not-in-set hold enables this step: a wave with every
 # member merged has no open member left to run the gate, so the pull request waiting on the next wave
-# is the only trigger there is. But that pass read a set it is NOT part of, so letting it capture
-# would freeze a wave on the authority of a pull request the wave excludes.
+# is the only trigger there is. That pass read a set it is not part of, and letting it capture would
+# freeze a wave on the authority of a pull request that wave excludes.
 eq "a held pass may retire"                 "$(bails true retire)" went-on
 eq "but may not capture a fresh pending"    "$(bails true pending)" bailed
 eq "nor promote one to frozen"              "$(bails true frozen)" bailed
@@ -526,9 +521,9 @@ eq "while an ordinary pass is unaffected"   "$(bails "" pending)" went-on
 
 echo
 echo "and it is reachable from that hold"
-# The wiring is a step output plus two Actions expressions, so it cannot be driven here — but it is
-# the only path by which a completed wave is ever retired, and one deleted line restores the forever-
-# hold this work exists to end. Assert it structurally, as the fence agreement above is.
+# The wiring is a step output plus two Actions expressions, so the harness cannot drive it. It is the
+# only path by which a completed wave is retired, so assert it structurally, as the fence agreement
+# above is.
 hold_block=$(awk '/is not in the member set/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
 grep -q 'retire_only=true' <<< "$hold_block" \
   && ok "the not-in-set hold enables the capture step before it returns" \


### PR DESCRIPTION
Closes #328. Part of a-novel-kit/.github#130. Sequenced after #327 (the compare-and-set) and #340 (the reader) — both merged.

Supersedes #339, which I am closing: its base predates #338/#341/#343/#344, and self-review found its core approach wrong in three ways (it deleted the marker instead of tombstoning, accepted `CLOSED` as wave-complete, and had no carry-forward). The salvageable parts — the retire branch, its re-derive guard, the stuck-wave warning, and the manifest-extraction hardening in the suite — are carried over here.

## The gap

Nothing ever cleared an activation snapshot, so the set frozen at activation was the set **forever**. A pull request labelled afterwards was held indefinitely by `merge-gate`, with a message saying it *"belongs to a later wave, not this landing"* — a wave that could never begin. `epic-membership`'s own description promised the opposite.

#340 shipped the **reader**: `detect-partial-landing` scopes its `merged:` and `closed:` searches to a wave boundary (`since`) carried on the marker. This is the **writer**.

## What ends a wave

**Every member `MERGED`.** *Terminal* is deliberately not the test. A member de-labelled and closed unmerged is exactly what the snapshot exists to remember, so retiring on it destroys the only record that the wave **failed** and flips the detector from `frozen` to `clear` — which posts success. Such a wave stays frozen; after 72h the gate names what is holding it, distinguishing a late open member from one closed unmerged.

A TTL stays rejected: expiring on a clock would un-freeze membership mid-landing, the exact failure this mechanism prevents.

## Four pieces

1. **A tombstone, not a deletion.** `{"status":"retired","since":"<now>"}` replaces the region. Deleting it destroys the only record of where the wave ended, and the live `merged:` search then hands the next wave the previous one's merges back. Both membership readers select on `status == "frozen"`, so a tombstone resolves there exactly as no marker would.
2. **Retire only a wave that fully landed** — see above.
3. **Carry `since` forward.** `splice` replaces the whole fenced region, so a boundary written once dies with the next capture and #340's fix is undone one pass later. A fresh `pending` inherits it; the `pending → frozen` promotion keeps it; retirement *draws* it rather than inheriting.
4. **Make retirement reachable.** A fully merged wave has no open member left to run the gate, so the pull request waiting on the next wave is the only trigger there is — and the not-in-set hold returned *before* enabling the capture step. It now enables it in retire-only mode. That pass read a set it is not part of, so a `RETIRE_ONLY` bail stops it capturing one.

## Two absorbing states closed on the way

Both are the shape this milestone keeps finding — two readings of one value, failing by never progressing, with a success line in the log.

- **`since_of` is the single canonicalisation.** The boundary is used both to BUILD a payload and to GUARD a write. Read it raw on one side and validated on the other and a corrupt boundary never compares equal to the empty one replacing it: the pass yields on every attempt, forever, while the log calls it a deliberate yield.
- **`marker_settled` treats `retired` as terminal alongside `frozen`.** Demanding a parseable `at` from a tombstone leaves it permanently unsettled — every retirement retries to exhaustion and reports a failure that did not happen.

The retire re-derive guard also uses the freeze guard's member comparison character-for-character, rather than a second spelling of the same question.

## Tests: 76 → 138

The suite now drives the **decision program**, the **landed test**, the **payload assembly** and the **retire-only bail** out of the manifest, instead of supplying them as inputs — which is why all of these passed before:

| Mutant | Was | Now |
| --- | --- | --- |
| `CLOSED` counts as landed | green | 1 failed |
| the retire rule never fires | green | 1 failed |
| retirement skips its re-derive | green | 5 failed |
| `pending` / `frozen` drops the inherited boundary | green | 1 / 2 failed |
| retirement deletes instead of tombstoning | green | 2 failed |
| `since_of` validates nothing | green | 5 failed |
| `same_marker` ignores the boundary | green | 2 failed |
| `marker_settled` demands an `at` from a tombstone | green | 3 failed |
| a frozen payload loses its clock | green | 1 failed |
| the hold does not enable retirement | green | 1 failed |
| the token step drops `retire_only` | green | 2 failed |

The reachability wiring is a step output plus two Actions expressions, so it cannot be driven by the harness; it is asserted structurally, the way the suite already asserts cross-action fence agreement.

`detect-partial-landing` stays 132/132 and `release-train` green. Prettier clean; no composite-illegal contexts.

## Still open under #130

#319, #325 and #329 — all three want one mechanism: a way to ask *"which Epic claims this pull request?"* without the label. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)