### PR TITLE
fix(token-expiry): tell a rejected credential apart from one with no expiry

### DIFF
--- a/generic-actions/token-expiry-notify/action.yaml
+++ b/generic-actions/token-expiry-notify/action.yaml
@@ -67,14 +67,85 @@ runs:
       run: |
         set -euo pipefail
 
+        # Post one embed to the webhook, retrying a failed delivery. Returns non-zero once the
+        # attempts are spent, so a caller decides whether an undelivered notice fails the job.
+        post_embed() { # $1=embed description  $2=decimal embed color
+          local payload code attempt
+          # allowed_mentions parse:[] keeps a maintenance nudge from pinging a role or @everyone.
+          payload=$(jq -n --arg d "$1" --argjson c "$2" \
+            '{embeds: [{description: $d, color: $c}], allowed_mentions: {parse: []}}')
+
+          if [ "$DRY_RUN" = "true" ]; then
+            { echo "[dry-run] would post the ${TOKEN_NAME} embed (color $2):"; printf '%s\n' "$1"; } \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            return 0
+          fi
+
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::warning::no webhook configured — can't post the \"${TOKEN_NAME}\" notice."
+            return 1
+          fi
+
+          code=000
+          for attempt in 1 2 3; do
+            code=$(curl -sS --connect-timeout 5 --max-time 15 -o "$RUNNER_TEMP/tok_resp" -w '%{http_code}' \
+              -X POST -H 'Content-Type: application/json' --data "$payload" "$WEBHOOK") || code=000
+            if [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
+              echo "Posted the ${TOKEN_NAME} notice (HTTP $code)." | tee -a "$GITHUB_STEP_SUMMARY"
+              return 0
+            fi
+            echo "::warning::notice post attempt $attempt/3 failed (HTTP $code)."
+            [ "$attempt" -lt 3 ] && sleep "$((attempt * attempt * 2))"
+          done
+
+          echo "::error::couldn't post the ${TOKEN_NAME} notice after 3 attempts (last HTTP $code)."
+          return 1
+        }
+
+        # Classify what the credential check found. A transport failure, a credential GitHub rejects,
+        # and a credential that carries no expiry are three outcomes, and only the last is benign.
+        token_state() { # $1=curl exit status  $2=HTTP status  $3=expiry header value
+          if [ "$1" -ne 0 ]; then printf 'unreachable'
+          elif [ "$2" != "200" ]; then printf 'rejected'
+          elif [ -z "$3" ]; then printf 'non-expiring'
+          else printf 'expiring'
+          fi
+        }
+
         # A fine-grained PAT's expiry rides on the response header of any authenticated request. A
         # non-expiring credential, such as a classic PAT or an App token, sends no such header.
-        exp=$(curl -sfS -o /dev/null -D - -H "Authorization: Bearer ${TOKEN}" https://api.github.com/ 2>/dev/null \
-          | grep -i '^github-authentication-token-expiration:' | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' || true)
-        if [ -z "$exp" ]; then
-          echo "Token \"${TOKEN_NAME}\" has no expiration header (non-expiring / not a fine-grained PAT) — nothing to remind." | tee -a "$GITHUB_STEP_SUMMARY"
-          exit 0
-        fi
+        #
+        # curl runs without -f so a rejected credential still returns its status line, which is what
+        # separates an expired token from a network fault and from a token that has no expiry.
+        headers="$RUNNER_TEMP/tok_headers"
+        curl_err="$RUNNER_TEMP/tok_curl_err"
+        curl_status=0
+        http_code=$(curl -sS -o /dev/null -D "$headers" -w '%{http_code}' \
+          -H "Authorization: Bearer ${TOKEN}" https://api.github.com/ 2>"$curl_err") || curl_status=$?
+        exp=$(grep -i '^github-authentication-token-expiration:' "$headers" 2>/dev/null \
+          | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' || true)
+
+        case "$(token_state "$curl_status" "${http_code:-000}" "$exp")" in
+          unreachable)
+            echo "::error::could not reach GitHub to check \"${TOKEN_NAME}\": $(tr -d '\n' <"$curl_err")"
+            exit 1
+            ;;
+          rejected)
+            # The credential the automation depends on is already gone. This is the outcome the
+            # reminder exists for, so it alerts and fails.
+            alert="## 🚨 [Token] ${TOKEN_NAME} - rejected by GitHub"$'\n'"-# HTTP ${http_code} — expired, revoked, or without the access it needs. Rotate it."
+            if [ -n "${REGEN_MD:-}" ]; then
+              alert="${alert}"$'\n\n'"${REGEN_MD}"
+            fi
+            post_embed "$alert" 15158332 || true
+            echo "::error::GitHub rejected \"${TOKEN_NAME}\" with HTTP ${http_code} — expired, revoked, or without the access it needs."
+            exit 1
+            ;;
+          non-expiring)
+            echo "Token \"${TOKEN_NAME}\" carries no expiry (classic PAT or App token) — nothing to remind." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+            ;;
+        esac
         exp_ts=$(date -u -d "$exp" +%s 2>/dev/null || echo 0)
         if [ "$exp_ts" -eq 0 ]; then
           echo "::warning::couldn't parse the expiry \"${exp}\" for \"${TOKEN_NAME}\" — skipping."
@@ -116,29 +187,5 @@ runs:
         fi
         desc=$(printf '%s' "$desc" | head -c 3900)
         desc=$(printf '%s' "$desc" | iconv -f UTF-8 -t UTF-8 -c 2>/dev/null) || true
-        # allowed_mentions parse:[] keeps a maintenance nudge from pinging a role or @everyone.
-        payload=$(jq -n --arg d "$desc" --argjson c "$color" \
-          '{embeds: [{description: $d, color: $c}], allowed_mentions: {parse: []}}')
 
-        if [ "$DRY_RUN" = "true" ]; then
-          { echo "[dry-run] would post the ${TOKEN_NAME} expiry embed (color ${color}, ${days}d left):"; printf '%s\n' "$desc"; } | tee -a "$GITHUB_STEP_SUMMARY"
-          exit 0
-        fi
-        if [ -z "${WEBHOOK:-}" ]; then
-          echo "::warning::no webhook configured — can't post the \"${TOKEN_NAME}\" expiry reminder (${days}d left)."
-          exit 0
-        fi
-
-        max=3; code=000
-        for attempt in $(seq 1 "$max"); do
-          code=$(curl -sS --connect-timeout 5 --max-time 15 -o "$RUNNER_TEMP/tok_resp" -w '%{http_code}' \
-            -X POST -H 'Content-Type: application/json' --data "$payload" "$WEBHOOK") || code=000
-          if [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
-            echo "Posted the ${TOKEN_NAME} expiry reminder (HTTP $code, ${days}d left)." | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          echo "::warning::reminder post attempt $attempt/$max failed (HTTP $code)."
-          [ "$attempt" -lt "$max" ] && sleep "$((attempt * attempt * 2))"
-        done
-        echo "::error::couldn't post the ${TOKEN_NAME} expiry reminder after $max attempts (last HTTP $code)."
-        exit 1
+        post_embed "$desc" "$color"

--- a/tests/token-expiry-notify.sh
+++ b/tests/token-expiry-notify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Regression tests for token-expiry-notify's credential check.
+#
+# token_state is extracted verbatim from the manifest and driven directly, so the assertions are on
+# the shipped classifier.
+#
+# The action reminds a maintainer before a fine-grained PAT expires. An expired or revoked token
+# returns no expiry header, so collapsing the check onto "is the header empty" reported the one
+# outcome the job exists to catch as the benign one, and exited 0. A daily run then printed a
+# reassuring line forever.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION="${1:-$ROOT/generic-actions/token-expiry-notify/action.yaml}"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+extract() { # $1 = function name — lift it out of the run: block and de-indent
+  awk -v n="$1" '
+    $0 ~ "^        "n"\\(\\) \\{" {f=1}
+    f {print}
+    f && /^        \}$/ {exit}
+  ' "$ACTION" | sed 's/^        //'
+}
+
+out=$(extract token_state)
+if [ -z "$out" ]; then
+  echo "::error::could not extract token_state from $ACTION — did its definition move or change indent?"
+  exit 1
+fi
+printf '%s\n' "$out" >"$WORK/lib.sh"
+
+if ! bash -n "$WORK/lib.sh"; then
+  echo "::error::the extracted function does not parse — extraction truncated a definition"
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+. "$WORK/lib.sh"
+
+fails=0
+check() { # $1=label $2=expected $3=actual
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected [$2], got [$3]"
+    fails=$((fails + 1))
+  fi
+}
+
+echo "== the three outcomes an empty expiry header can mean =="
+
+# An expired or revoked PAT: GitHub answers 401 and sends no expiry header. The header is empty for
+# the same reason a non-expiring credential's is, which is what made the two indistinguishable.
+check "a rejected token" "rejected" "$(token_state 0 401 '')"
+check "a token without the access it needs" "rejected" "$(token_state 0 403 '')"
+check "a server fault" "rejected" "$(token_state 0 500 '')"
+
+# curl could not complete the request at all: DNS, TLS, a connect timeout.
+check "an unreachable API" "unreachable" "$(token_state 6 000 '')"
+check "an unreachable API reporting a status too" "unreachable" "$(token_state 28 000 '')"
+
+# The benign case: a classic PAT or an App token authenticates and carries no expiry.
+check "a credential with no expiry" "non-expiring" "$(token_state 0 200 '')"
+
+echo "== the reminder path is unchanged =="
+
+check "a fine-grained PAT with an expiry" "expiring" "$(token_state 0 200 'Mon, 01 Jan 2027 00:00:00 UTC')"
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "::error::$fails assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
Closes #336

A fine-grained PAT's expiry rides on a response header. An expired or revoked token sends none — the
same empty header a classic PAT or an App token sends. The check read only the header, so the outcome
the job exists to catch was reported as the benign one:

```bash
exp=$(curl -sfS … 2>/dev/null | grep -i '^github-authentication-token-expiration:' … || true)
if [ -z "$exp" ]; then
  echo "Token \"${TOKEN_NAME}\" has no expiration header (non-expiring / not a fine-grained PAT) — nothing to remind."
  exit 0
fi
```

Three suppressors on one line — `-f` discards the response on a 4xx, `2>/dev/null` hides curl's
stderr, `|| true` swallows the exit — and the empty result maps onto a message asserting health. A
daily scheduled run then printed that line forever, green, while the automation had no credential.

The same silence covered a DNS or TLS fault, so the reminder could go quiet for a day with nothing to
show for it.

## What changed

`curl` runs without `-f`, so a rejected credential returns its status line. The check then separates
three outcomes that were one:

| curl | HTTP | header | outcome |
|---|---|---|---|
| fails | — | — | `unreachable` — error and fail |
| ok | not 200 | — | `rejected` — alert and fail |
| ok | 200 | empty | `non-expiring` — nothing to remind |
| ok | 200 | set | `expiring` — the existing reminder path |

A rejection posts a red alert to the same webhook the reminder uses, carrying the caller's `regen_md`
so the recipient gets the rotation instructions with it. Failing the job alone would only reach
whoever reads scheduled-run mail; the webhook is where this job's audience is.

`post_embed` is factored out so both notices go through one retrying sender rather than the alert
getting a second, thinner implementation.

## Test plan

The action had no suite. `tests/token-expiry-notify.sh` extracts `token_state` from the manifest and
drives it directly.

- [x] `401`, `403` and `500` each classify as `rejected` — all three return an empty expiry header,
      which is what made them indistinguishable from a healthy classic PAT
- [x] A curl transport failure classifies as `unreachable`
- [x] `200` with no header still classifies as `non-expiring`, so the benign path is unchanged
- [x] `200` with a header still classifies as `expiring`
- [x] All seven suites pass; manifest lint and `prettier --check` pass
- [ ] CI green

**Not covered:** the webhook delivery itself, which is a network leaf with no seam the offline harness
reaches. The classifier is the decision that was wrong; `post_embed` is a read.

## Note on reach

The action is in the README catalog but has no caller in either org's checked-out repos —
`.github/workflows/token-expiry.yaml` references it only in a comment as the message-shape source of
truth. Worth confirming whether anything dispatches it before deciding how urgently this ships.