### PR TITLE
docs(actions): sweep the comments added since the last pass

### DIFF
--- a/.github/scripts/lint-action-manifests.sh
+++ b/.github/scripts/lint-action-manifests.sh
@@ -1,24 +1,23 @@
 #!/usr/bin/env bash
 # Reject expression contexts that do not exist for a composite action.
 #
-# GitHub expression-evaluates a composite action's WHOLE manifest when it loads it — input
-# descriptions, run: strings, bash comments inside them. vars, secrets, needs, matrix and strategy
-# are not available there, so one such reference anywhere in the file makes the action fail to LOAD
-# for every consumer. That took merge-gate offline across both orgs until v1.12.1.
+# GitHub expression-evaluates a composite action's entire manifest when it loads it, including input
+# descriptions, run: strings and the bash comments inside them. vars, secrets, needs, matrix and
+# strategy are unavailable there, so one reference anywhere in the file makes the action fail to load
+# for every consumer.
 #
-# The manifests document caller syntax by writing those names as PLAIN TEXT (`vars.AGENT_KILL_SWITCH`
-# with no ${{ }} around it), which is legal and deliberate. So the check cannot simply grep for the
-# names: it has to know whether an occurrence sits inside an expression.
+# The manifests document caller syntax by writing those names as plain text —
+# `vars.AGENT_KILL_SWITCH` with no ${{ }} around it — which is legal. So the check has to know
+# whether an occurrence sits inside an expression; a grep for the names alone cannot.
 #
-# That distinction is the whole difficulty, and why two simpler versions of this check were wrong:
+# Two shapes a simpler pattern lets through, both of them what a reader reaches for first:
 #
-#   ${{ vars.X }}                        caught by anchoring to the start of the expression
-#   ${{ inputs.a || vars.X }}            NOT caught — the context is not the first token
-#   ${{ format('{0}', secrets.X) }}      NOT caught by ${{[^}]*}} either — [^}]* stops at the } in '{0}'
+#   ${{ inputs.a || vars.X }}            anchoring to the start of the expression skips it
+#   ${{ format('{0}', secrets.X) }}      ${{[^}]*}} stops at the } inside '{0}'
 #
-# So the scan walks each line tracking whether it is inside a ${{ … }} region, and reports only the
-# occurrences that are. Expressions are treated as line-local, which is what they are in these
-# manifests; a context split across a block scalar would be missed.
+# The scan walks each line tracking whether it is inside a ${{ … }} region and reports the
+# occurrences that are. Expressions are line-local here; a context split across a block scalar sits
+# outside its reach.
 set -euo pipefail
 
 ROOT="${1:-.}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,10 +42,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      # The detector lives in a script rather than inline so tests/lint-action-manifests.sh can run
-      # the shipped code against fixtures. The previous inline version anchored the context to the
-      # start of its expression and so missed every compound one — a gate nobody had proven caught
-      # anything, because it had no negative case.
+      # The detector lives in a script so tests/lint-action-manifests.sh runs the shipped code
+      # against fixtures, including the violations this gate exists to catch.
       - name: No composite-illegal expression contexts in action manifests
         shell: bash
         run: bash .github/scripts/lint-action-manifests.sh .

--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -151,20 +151,18 @@ jobs:
             [ "$(echo "$page" | jq -r '.data.search.pageInfo.hasNextPage')" = "true" ] || break
             cursor=$(echo "$page" | jq -r '.data.search.pageInfo.endCursor')
           done
-          # tasks holds the open PRs that close an issue, whose Status is re-derived. Status derivation
-          # reads the closing reference, so the Closes walk is the right selector for this half.
+          # tasks holds the open PRs that close an issue, whose Status is re-derived. Status
+          # derivation reads the closing reference, which is what this selector follows.
           tasks=$(echo "$nodes" | jq -c '[.[]
             | select(.number and (.closingIssuesReferences.nodes | length > 0))
             | {repo: .repository.name, number, sha: .headRefOid}]')
-          # epic_prs holds the PRs merge-gate is re-posted on. Membership is the `epic:<N>` LABEL,
-          # which is what merge-gate holds against — a label needs >= triage to apply, while a Closes
-          # keyword is author-controlled. This selector used to be the Closes walk, so a member
-          # carrying the label but no Closes line (an infra or re-pin PR pulled into a wave) was never
-          # re-evaluated. It stayed held at `failure` until someone pushed to it, and since a held PR
-          # is released only by this sweep, the whole wave blocked on one permanently-red check.
+          # epic_prs holds the PRs merge-gate is re-posted on, selected by the `epic:<N>` label.
+          # That label is what merge-gate holds a set against, and it needs triage permission to
+          # apply. A member carries it whether or not it closes an issue, which covers the infra and
+          # re-pin PRs pulled into a wave.
           #
-          # Dropping the Closes-derived set loses nothing: merge-gate classifies an unlabeled PR as
-          # standalone and always passes it, so re-posting on those never changed an outcome.
+          # This sweep is the only thing that releases a held member, so a member missing from here
+          # stays at `failure` until someone pushes to it, and the whole wave waits behind it.
           epic_prs=$(echo "$nodes" | jq -c '[.[]
             | select(.number and ([.labels.nodes[].name | select(startswith("epic:"))] | length > 0))
             | {repo: .repository.name, number, sha: .headRefOid}]')

--- a/generic-actions/board-write/action.yaml
+++ b/generic-actions/board-write/action.yaml
@@ -26,13 +26,12 @@ inputs:
   content_id:
     required: true
     description: >
-      Node id of the issue or PR whose board item to write, or SEVERAL such ids separated
+      Node id of the issue or PR whose board item to write, or several such ids separated
       by newlines or spaces. The caller resolves what to write (e.g. a PR's linked
       issues); board-write finds each content's item in the project and applies the same
-      field and value to all of them. Several ids are handled here rather than by the
-      caller because a composite action cannot loop a `uses:` step, so a caller that
-      needed to write more than one item would have to reimplement this action — which is
-      how a PR closing two issues came to update only one of them.
+      field and value to all of them. Several ids belong here because a composite action
+      cannot loop a `uses:` step, which leaves this the only place the fan-out can happen
+      without a second implementation of the write.
   field:
     required: true
     description: Name of the field to set, e.g. "Status" or "Start date".
@@ -72,11 +71,11 @@ inputs:
 outputs:
   item_id:
     description: >
-      Node id of the board item that was resolved (or added). With several content ids,
-      the last one — the outputs describe the run, not any single item.
+      Node id of the board item that was resolved (or added). With several content ids, the
+      last one; the outputs describe the run rather than one item.
     value: ${{ steps.write.outputs.item_id }}
   changed:
-    description: '"true" if ANY item was mutated, "false" if every one already held the value.'
+    description: '"true" if any item was mutated, "false" if every one already held the value.'
     value: ${{ steps.write.outputs.changed }}
 
 runs:
@@ -184,10 +183,9 @@ runs:
             ;;
         esac
 
-        # content_id may name SEVERAL contents, newline- or space-separated. A pull request can
-        # close more than one issue, and a composite action cannot loop a `uses:` step — so the
-        # fan-out belongs inside the single privileged writer rather than around it, which is what
-        # keeps that claim true.
+        # content_id may name several contents, newline- or space-separated: a pull request can close
+        # more than one issue. The loop lives here because a composite action cannot loop a `uses:`
+        # step, leaving this the single path that mutates the board.
         read -r -a content_ids <<<"$(printf '%s' "$CONTENT_ID" | tr '\n' ' ')"
 
         any_changed=false

--- a/generic-actions/derive-status/action.yaml
+++ b/generic-actions/derive-status/action.yaml
@@ -113,21 +113,15 @@ runs:
           exit 1
         fi
 
-        # Every closing issue is derived, not just one. This used to take the lowest-numbered ref
-        # and leave the rest in whatever status they already held, on the stated grounds that "the
-        # reconcile sweep covers the rest" — but the sweep re-derives an issue from ITS OWN pull
-        # request, and an issue closed by a sibling's PR has none. So the others were never picked
-        # up by anything: not a race that resolves on the next pass, but a state nothing reaches.
-        # A Task left reading `Triage` while its fix is in review is invisible, because the run
-        # that stranded it succeeds.
+        # Every issue the PR closes is derived. The reconcile sweep reaches an issue through its own
+        # pull request, so an issue closed by a sibling's PR is reachable only from here.
         refs=$(echo "$pr" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes')
         ref_count=$(echo "$refs" | jq 'length')
-        # Newline-separated: board-write takes several ids and applies the same field and value to
-        # each, so the fan-out lives in the one privileged writer instead of here.
+        # Newline-separated for board-write, which takes several ids and writes the same field and
+        # value to each. The fan-out lives there because a composite action cannot loop a `uses:` step.
         issue_ids=$(echo "$refs" | jq -r 'sort_by(.number) | .[].id')
-        # Labels drive one branch below — a hotfix cleanup Task carries `hotfix-reconcile`, which
-        # makes Done its terminal MERGED status — so they are collected across every closing issue
-        # and checked for agreement rather than sampled from one.
+        # A hotfix cleanup Task carries `hotfix-reconcile`, which makes Done its terminal MERGED
+        # status. Collected across every closing issue, since one status covers all of them.
         labelled=$(echo "$refs" | jq -c '[.[] | (.labels.nodes // []) | map(.name) | index("hotfix-reconcile") != null]')
 
         # A pure function of the PR's current state: the reconcile sweep re-runs it and has
@@ -136,9 +130,8 @@ runs:
           MERGED)
             # A hotfix-reconcile cleanup Task is terminal on merge: the forward-port landed and a
             # hotfix cuts its own tag off the reconcile's baseline, so nothing else ships it.
-            # One status is written to every closing issue, so they have to agree on this. A PR
-            # closing both a hotfix cleanup Task and an ordinary one has no single right answer —
-            # it fails rather than silently picking one, which is the mistake this change is about.
+            # One status covers every closing issue. A PR closing both a hotfix cleanup Task and an
+            # ordinary one has two terminal statuses and no way to choose, so it stops here.
             hotfix_count=$(printf '%s' "$labelled" | jq '[.[] | select(.)] | length')
             if [ "$hotfix_count" = "0" ]; then
               status="Awaiting release"

--- a/generic-actions/token-expiry-notify/action.yaml
+++ b/generic-actions/token-expiry-notify/action.yaml
@@ -102,8 +102,9 @@ runs:
           return 1
         }
 
-        # Classify what the credential check found. A transport failure, a credential GitHub rejects,
-        # and a credential that carries no expiry are three outcomes, and only the last is benign.
+        # Classify the credential check. A transport failure, a credential GitHub rejects, and a
+        # credential that carries no expiry all leave the expiry header empty, and only the last is
+        # a healthy token.
         token_state() { # $1=curl exit status  $2=HTTP status  $3=expiry header value
           if [ "$1" -ne 0 ]; then printf 'unreachable'
           elif [ "$2" != "200" ]; then printf 'rejected'
@@ -115,8 +116,8 @@ runs:
         # A fine-grained PAT's expiry rides on the response header of any authenticated request. A
         # non-expiring credential, such as a classic PAT or an App token, sends no such header.
         #
-        # curl runs without -f so a rejected credential still returns its status line, which is what
-        # separates an expired token from a network fault and from a token that has no expiry.
+        # curl runs without -f so a rejected credential returns its status line, which is what tells
+        # the three cases apart.
         headers="$RUNNER_TEMP/tok_headers"
         curl_err="$RUNNER_TEMP/tok_curl_err"
         curl_status=0
@@ -131,8 +132,8 @@ runs:
             exit 1
             ;;
           rejected)
-            # The credential the automation depends on is already gone. This is the outcome the
-            # reminder exists for, so it alerts and fails.
+            # The credential the automation runs on is already gone, which is what the reminder
+            # exists to catch. It alerts on the webhook and fails the job.
             alert="## 🚨 [Token] ${TOKEN_NAME} - rejected by GitHub"$'\n'"-# HTTP ${http_code} — expired, revoked, or without the access it needs. Rotate it."
             if [ -n "${REGEN_MD:-}" ]; then
               alert="${alert}"$'\n\n'"${REGEN_MD}"

--- a/tests/derive-status.sh
+++ b/tests/derive-status.sh
@@ -5,11 +5,10 @@
 # assertions are on the shipped selectors. There is nothing to stub — they are pure functions of the
 # GraphQL result.
 #
-# The defect: a PR closing several issues derived exactly one of them, on the stated grounds that
-# "the reconcile sweep covers the rest". The sweep re-derives an issue from ITS OWN pull request, and
-# an issue closed by a sibling's PR has none — so the others were reached by nothing. Not a race that
-# resolves next pass, a state nothing arrives at. It read as handled because the run that stranded
-# them succeeded.
+# The central case is a PR that closes several issues. The reconcile sweep reaches an issue through
+# its own pull request, so an issue closed by a sibling's PR is reachable only from the deriver here.
+# A Task left behind sits at whatever status it held while its fix is in review, and the run that
+# left it there succeeds.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -65,8 +64,8 @@ check "a PR closing two issues yields both, lowest first" "I_kw1111 I_kw1112" "$
 check "a PR closing one issue is unchanged" "I_kw1111" "$(ids "$ONE")"
 check "a PR closing none yields nothing" "" "$(ids "$NONE")"
 
-# The previous behaviour, kept here so the defect stays on the record rather than living only in a
-# commit message: it took the lowest-numbered ref and left the other untouched.
+# The lowest-numbered-ref selector, kept as a contrast: it resolves one issue where the shipped
+# filter resolves every closing issue.
 OLD_FILTER='sort_by(.number) | .[0].id // empty'
 check "the previous filter returned only the lowest-numbered" "I_kw1111" \
   "$(printf '%s' "$TWO" | jq -r "$OLD_FILTER")"
@@ -76,9 +75,9 @@ echo "== the hotfix-reconcile branch is decided across all of them =="
 check "no closing issue is a hotfix cleanup" "0" "$(hotfix_count "$TWO")"
 check "every closing issue is a hotfix cleanup" "1" "$(hotfix_count "$ALL_HOTFIX")"
 
-# Mixed is the case with no single right answer: one status is written to every closing issue, and
-# these two want different terminal ones. The action errors rather than picking, which is the whole
-# point — sampling one issue's labels is what the old code did.
+# A mixed set has no single right answer: one status covers every closing issue, and these two carry
+# different terminal ones. The action stops there, which is why the classifier reports the count
+# instead of sampling one issue's labels.
 mixed=$(hotfix_count "$MIXED")
 total=$(printf '%s' "$MIXED" | jq 'length')
 if [ "$mixed" != "0" ] && [ "$mixed" != "$total" ]; then

--- a/tests/lint-action-manifests.sh
+++ b/tests/lint-action-manifests.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 # Regression tests for the composite-manifest context lint.
 #
-# A gate with no negative case is a gate nobody has proven catches anything, which is exactly how the
-# previous version of this check stayed vacuous: it ran on every PR, printed a tick, and would have
-# missed the reference that took merge-gate offline org-wide had it been written as anything other
-# than the first token of its expression.
-#
-# So every case below is a manifest the linter is run against for real, and the two halves matter
-# equally: the violations must fail, and the deliberate plain-text prose must not.
+# A gate with no negative case is a gate nobody has proven catches anything. Every case below is a
+# manifest the linter runs against for real, and both halves carry weight: the violations have to
+# fail, and the plain-text prose the manifests document caller syntax with has to pass.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -58,7 +54,7 @@ check "context as the first token" fail \
 check "context after an operator" fail \
   "$(fixture after-operator 'echo "${{ inputs.kill_switch || vars.AGENT_KILL_SWITCH }}"')"
 
-# The case a widened ${{[^}]*}} pattern would still miss: [^}]* stops at the } inside '{0}'.
+# A widened ${{[^}]*}} pattern stops at the } inside '{0}' and lets this through.
 check "context inside a function call with braces" fail \
   "$(fixture inside-format "echo \"\${{ format('{0}', secrets.TOKEN) }}\"")"
 
@@ -73,15 +69,15 @@ check "strategy context" fail \
 
 echo "== what the linter must NOT flag =="
 
-# The deliberate convention: these names appear as prose in ten manifests, documenting the syntax a
-# CALLER uses. Flagging them would force the documentation out of the actions.
+# These names appear as prose in ten manifests, documenting the syntax a caller uses. The lint has to
+# leave them alone for that documentation to stay in the actions.
 check "plain-text prose outside an expression" pass \
   "$(fixture prose '# threaded from the caller as kill_switch: vars.AGENT_KILL_SWITCH')"
 
 check "a legal context in an expression" pass \
   "$(fixture legal-ctx 'echo "${{ inputs.client_id }} ${{ github.repository }} ${{ env.FOO }}"')"
 
-# The name is a substring of a longer identifier, not the context.
+# Here the name is a substring of a longer identifier.
 check "a longer identifier ending in a context name" pass \
   "$(fixture substring 'echo "${{ inputs.myvars.thing }}"')"
 

--- a/tests/reconcile-selector.sh
+++ b/tests/reconcile-selector.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 # Regression tests for the reconcile sweep's membership selectors.
 #
-# Same discipline as the other suites: the jq programs are EXTRACTED verbatim from the workflow and
-# run against fixture nodes, so what is asserted here is what ships. There is nothing to stub — the
-# selectors are pure functions of the GraphQL result.
+# Same discipline as the other suites: the jq programs are extracted verbatim from the workflow and
+# run against fixture nodes, so what is asserted here is what ships. There is nothing to stub, since
+# the selectors are pure functions of the GraphQL result.
 #
-# The case that matters: a PR carrying the `epic:<N>` label but no `Closes` line. merge-gate holds
-# every member of an unready set at `failure`, and a held PR is released only by this sweep — so a
-# member the sweep cannot see stays red until someone pushes to it, and the whole wave blocks behind
-# one permanently-red required check. That is the shape of a cross-repo re-pin or infra PR pulled
-# into a wave, which is ordinary rather than exotic.
+# The central case is a PR carrying the `epic:<N>` label with no `Closes` line — the shape of a
+# cross-repo re-pin or an infra PR pulled into a wave. merge-gate holds every member of an unready
+# set at `failure`, and this sweep is the only thing that releases one, so a member it cannot see
+# keeps the whole wave behind a permanently-red required check.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)

--- a/tests/token-expiry-notify.sh
+++ b/tests/token-expiry-notify.sh
@@ -5,9 +5,9 @@
 # the shipped classifier.
 #
 # The action reminds a maintainer before a fine-grained PAT expires. An expired or revoked token
-# returns no expiry header, so collapsing the check onto "is the header empty" reported the one
-# outcome the job exists to catch as the benign one, and exited 0. A daily run then printed a
-# reassuring line forever.
+# returns no expiry header, and neither does a healthy classic PAT, so the header alone cannot tell
+# the outcome the job exists to catch from the one it should ignore. token_state reads the HTTP
+# status alongside it.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)


### PR DESCRIPTION
Five actions and four test suites landed after #345's repo-wide comment pass, written before the
`document-code` rules tightened. They carry the shapes that pass removed.

## What was there

| Shape | Example |
|---|---|
| Change narrative | *"This used to take the lowest-numbered ref and leave the rest…"* |
| Counterfactual defending the code | *"Dropping the Closes-derived set loses nothing…"*, *"a caller that needed to write more than one item would have to reimplement this action"* |
| Contrastive framing | *"checked for agreement rather than sampled from one"* |
| Rhetorical labels | *"The defect:"*, *"The case that matters:"*, *"The deliberate convention:"* |
| Shouted emphasis | `SEVERAL`, `ANY`, `ITS OWN`, `EXTRACTED`, `NOT`, `PLAIN TEXT` |

The pattern behind all of it: I was explaining *why the previous behaviour was wrong* inside the file.
That reads well in a pull request and rots in the tree, because the reader has no access to what the
code used to be. The rationale belongs in the comment; the history was already in the commit message.

## What replaced it

Each comment states the property that holds. `derive-status` no longer recounts what the deriver used
to skip — it says the sweep reaches an issue through its own pull request, so an issue closed by a
sibling's PR is reachable only from the deriver. Same fact, no archaeology.

**Two counter-examples survive**, under the rule that keeps one where the wrong path is the one a
reader would otherwise take: the anchored context pattern and `${{[^}]*}}` stopping inside `'{0}'`.
Both are what someone reaches for first when touching that lint, so naming them is what stops it.

## Scope

Every file whose most recent commit postdates #345 — `board-write`, `derive-status`,
`token-expiry-notify`, `reconcile-board.yaml`, `lint-action-manifests.sh` and the four suites added
with them. `release-train`'s action and suite were in #345's pass and are untouched here.

I checked the other repos before opening this: `golib`, `jwt`, `nodelib` and `service-json-keys` have
all had their pass, and `jwt` a second one targeting counterfactuals specifically. This is the only
tree with a gap.

## Test plan

- [x] All seven suites pass
- [x] The manifest lint passes and `prettier --check` passes
- [x] Documentation only — the non-`#` hunks are the YAML `description:` blocks on
      `board-write.content_id` and its outputs, which are documentation
- [x] 93 deletions against 74 insertions
- [ ] CI green