### PR TITLE
docs(migrations): add the v1.21.0 upgrade guide

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -2,6 +2,7 @@
 
 One immutable guide per release that asks consumers to change something. Newest first.
 
-| Version               | Summary                                                                          |
-| --------------------- | -------------------------------------------------------------------------------- |
-| [v1.1.0](./v1.1.0.md) | `client_id` bot-token input (deprecates `app_id`); UI-dispatched releases added. |
+| Version                 | Summary                                                                           |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| [v1.21.0](./v1.21.0.md) | Activation-snapshot wave boundary — converge every repo, planning repos included. |
+| [v1.1.0](./v1.1.0.md)   | `client_id` bot-token input (deprecates `app_id`); UI-dispatched releases added.  |

--- a/docs/migrations/v1.21.0.md
+++ b/docs/migrations/v1.21.0.md
@@ -1,0 +1,77 @@
+# Upgrading to v1.21.0
+
+`v1.21.0` completes the activation-snapshot wave boundary: `merge-gate` now retires a snapshot once
+its wave has landed, so an Epic can land a second wave. Two governance jobs also start failing on
+conditions they previously reported as success.
+
+## Do I need to act?
+
+**Recommended, not required.** Nothing breaks and no input changed. Two things are worth doing:
+
+- **Converge every repo on `v1.21.0`.** The wave boundary is written by one repo and read by another,
+  so a split fleet gets the writer without the reader and the feature does nothing. This is the one
+  migration with a real consequence.
+- **Expect two jobs to start failing** where they used to pass — both are the failure they exist to
+  report.
+
+## Converge the fleet, readers included
+
+The snapshot machinery is split across two deployment scopes, and the wave boundary needs both.
+
+`merge-gate` **writes** the marker and runs in **every** repo, from that repo's own
+`.github/workflows/merge-gate.yaml`. `detect-partial-landing` **reads** it and runs only from the
+sweep, `reconcile-board.yaml`, which lives in the **planning repo of each org** — `a-novel/.github`
+and `a-novel-kit/.github`.
+
+So a member repo on `v1.21.0` writes a `retired` tombstone carrying the boundary, while a planning
+repo still on `v1.20.x` ignores it: the detector scopes an Epic's history to the whole Epic, the
+second wave reads as a stray past grace, and `epic-freeze` blocks it on every sweep. The symptom is
+the one `v1.21.0` exists to remove, appearing after the upgrade because only half of it landed.
+
+Upgrade the two planning repos first, then the member repos:
+
+```yaml
+# every a-novel-kit/workflows reference in .github/workflows/*.yaml
+uses: a-novel-kit/workflows/generic-actions/merge-gate@v1.21.0
+```
+
+- **Prerequisite:** none.
+- **Old path:** an older reader ignores a `retired` marker rather than misreading it, because both
+  membership readers select on `status == "frozen"`. A mixed fleet loses the feature; it does not
+  corrupt a snapshot.
+- **Verify:** a sweep log line reports `wave_since=<instant>` for an Epic whose first wave has landed.
+  `wave_since=none` after a wave landed means the reader is still on an older tag.
+
+## Expect `token-expiry-notify` to fail on a bad credential
+
+A fine-grained PAT sends its expiry in a response header, and a revoked or expired token sends none —
+the same empty header a classic PAT or App token sends. The check read only the header, so it reported
+a dead credential as the benign no-expiry case and exited 0.
+
+It now classifies transport failure, rejection, and no-expiry separately. A rejected credential posts a
+red alert to the reminder's webhook and **fails the job**.
+
+- **Verify:** the daily run stays green. A failure means a credential the automation depends on is
+  already dead, which is what the job is for.
+
+## Expect `derive-status` to fail on a mixed-intent pull request
+
+A pull request closing several issues derived a status for one of them and left the rest wherever they
+were. Nothing reached those issues later, because the sweep re-derives an issue from its own pull
+request and an issue closed by a sibling's has none.
+
+Status is now derived for **every** closing issue. A pull request that closes both a cleanup Task and
+an ordinary one fails rather than picking one terminal status for both.
+
+- **What to change:** split a pull request that closes issues wanting different terminal statuses.
+- **Verify:** every issue a pull request closes moves to its terminal status when the PR merges.
+
+## Also in this release
+
+- `board-write` accepts several content ids in `content_id`, separated by newlines or spaces, so one
+  caller can write several board items. A single id still works unchanged.
+- The reconcile sweep selects Epic members by the `epic:<N>` label rather than the `Closes` walk, so a
+  member carrying the label with no `Closes` line — a cross-repo re-pin, an infra change — is no longer
+  invisible to it and left permanently red.
+- The composite-manifest lint detects an illegal expression context anywhere in an expression, not only
+  at its start.


### PR DESCRIPTION
Ships with the tag, so `v1.21.0` already contains its own guide. Advisory output of a `prepare-release` pass — this does not cut the release.

## Proposed bump: `v1.20.3` → **`v1.21.0`** (minor)

Five commits since `v1.20.3`: one `feat` (#351, the snapshot retirement), four `fix` (#352, #350, #348, #347). No `BREAKING CHANGE` footer and no `!`.

One discipline note rather than a blocker: **#350's subject is `fix(derive-status)` but its body carries a `feat(board-write): accept several content ids`.** In a squash-merge repo the subject is the release signal, so a `feat` inside the body is invisible to the bump math. Here it changes nothing — #351 is already a `feat` — but it would have under-sized a release that contained only #350.

## Why a guide, for a release that breaks nothing

The wave boundary has **two deployment scopes**, and it only works with both:

| | runs from | pinned by |
| --- | --- | --- |
| `merge-gate` — **writes** the marker | every repo's own `merge-gate.yaml` | that repo |
| `detect-partial-landing` — **reads** it | the sweep, `reconcile-board.yaml` | `a-novel/.github` and `a-novel-kit/.github` only |

A member repo on `v1.21.0` writes a `retired` tombstone carrying the boundary; a planning repo still on `v1.20.x` ignores it, scopes the Epic's history to the whole Epic, and `epic-freeze` blocks the second wave on every sweep. That is the symptom `v1.21.0` exists to remove — showing up *after* the upgrade, because only half of it landed.

The fleet is currently split, which is what makes this concrete rather than theoretical:

```
v1.20.3   a-novel/.github, service-authentication, kit/jwt, kit/golib
v1.20.2   service-json-keys, service-narrative-engine, service-template,
          kit/nodelib, kit/stack, kit/.github          <- a-novel-kit's reader
```

`a-novel-kit/.github` runs that org's sweep and sits on `v1.20.2`, so it has no `since` support at all. The guide says to upgrade the two planning repos first, and gives the log line to verify against (`wave_since=<instant>` rather than `wave_since=none`).

An older reader ignores a `retired` marker rather than misreading it — both membership readers select on `status == "frozen"` — so a mixed fleet loses the feature without corrupting a snapshot.

## Two jobs start failing where they passed

Both are `fix` commits whose whole point is that the previous behaviour reported a real fault as success, so the guide sets the expectation instead of explaining how to suppress it:

- **`token-expiry-notify`** now fails and posts a red alert on a rejected credential, instead of reading the empty expiry header as the benign no-expiry case.
- **`derive-status`** now derives every closing issue, and fails on a pull request closing issues that want different terminal statuses rather than picking one for both.

## To cut the release

Merge this, then Actions ▸ `release` ▸ **minor**. Rolling the pins across the fleet afterwards is separate execution; I can open it as a follow-up issue if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)