### PR TITLE
feat(merge-gate): let the activation-snapshot capture be rehearsed

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -47,6 +47,17 @@ on:
           When "true" (default), the Epic status read-model only logs the table it would render; set
           "false" to rewrite it into each active Epic's issue body. Display-only (no board write, no
           check-run), so it flips live on its own schedule, independent of the other passes.
+      regate_snapshot_dry_run:
+        required: false
+        type: string
+        default: "false"
+        description: >
+          When "true", the re-posted merge-gate logs the activation snapshot it would capture and
+          leaves the Epic body alone; the gate check-run is posted either way. Defaults to writing,
+          unlike the flags around it: those gate the rollout of new behavior, while the capture is
+          already live, and this sweep is usually the only thing that runs on a set that is ready and
+          waiting. A pending marker promotes to frozen on a later pass, so a rehearsing sweep leaves
+          it pending and the Epic lands on live label membership.
       archive_dry_run:
         required: false
         type: string
@@ -225,6 +236,7 @@ jobs:
           repo: ${{ matrix.pr.repo }}
           pull_request_number: ${{ matrix.pr.number }}
           head_sha: ${{ matrix.pr.sha }}
+          snapshot_dry_run: ${{ inputs.regate_snapshot_dry_run }}
           # Org-level halt: when engaged merge-gate holds this idle PR too by posting failure, so a
           # PR that emits no event while halted is still stopped. A gate posts failure; skipping would
           # leave a neutral check that passes.

--- a/generic-actions/merge-gate/action.yaml
+++ b/generic-actions/merge-gate/action.yaml
@@ -89,6 +89,17 @@ inputs:
       (fail-open on a label-read blip). Engaging the switch does NOT retroactively disarm native
       auto-merge already armed on an idle ready PR: merge-gate holds it (the required check goes red),
       but there is a brief latency window before the next event / reconcile sweep re-posts the hold.
+  snapshot_dry_run:
+    required: false
+    default: "false"
+    description: >
+      When "true", log the capture decision and the payload that would be spliced into the Epic body,
+      without editing the issue. Scoped to the snapshot write, which is the action's only mutation of
+      state it does not own, and the only one that cannot be taken back — a frozen marker is the
+      authority every reader acts on and is never rewritten. The `merge-gate` check-run is posted
+      either way, because the gate is required and a pass that posted nothing would block every PR in
+      the repo. Defaults to writing, since a rehearsing gate captures no snapshot and every Epic falls
+      back to live label membership, losing the guarantee the snapshot exists to give.
 
 runs:
   using: composite
@@ -435,7 +446,11 @@ runs:
         # trust boundary the readers act on, so org-wide issues:write would let a bug here reach
         # every issue in the org.
         repositories: ${{ inputs.planning_repo }}
-        permission-issues: write
+        # A rehearsal reads the Epic body and writes nothing, so it mints a read-only token. The
+        # branch in the capture step already skips the write; withholding the capability makes a dry
+        # run structurally unable to edit the issue rather than trusting that branch. GitHub compares
+        # strings case-insensitively, so any casing of "true" reaches this.
+        permission-issues: ${{ inputs.snapshot_dry_run == 'true' && 'read' || 'write' }}
 
     - name: Capture activation snapshot
       if: ${{ steps.evaluate.outputs.capture == 'true' || steps.evaluate.outputs.retire_only == 'true' }}
@@ -453,6 +468,7 @@ runs:
         # Set when this pass arrived from the not-in-set hold. Such a pass is not a member of the set
         # it just read, so it has no standing to capture one; it may only retire the wave holding it.
         RETIRE_ONLY: ${{ steps.evaluate.outputs.retire_only }}
+        SNAPSHOT_DRY_RUN: ${{ inputs.snapshot_dry_run }}
         # How long a frozen wave may sit unfinished before the gate names what it is waiting on. The
         # warning is the whole action: a snapshot that expired on a clock would un-freeze membership
         # mid-landing, which is the failure it exists to prevent. Resolution stays with a human, who
@@ -802,6 +818,20 @@ runs:
           rm -f "$bodyf" "$outf"
           return "$rc"
         }
+
+        # A rehearsal stops here. Everything above is reads and pure computation, so the decision, the
+        # set it rests on and the byte-exact payload are all known, and the next call is the write.
+        # Naming the members is the point: a capture is judged by whether the right set is in it, and
+        # a frozen marker is the authority every reader acts on from then on.
+        if [ "$(printf '%s' "${SNAPSHOT_DRY_RUN:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+          {
+            echo "Epic #${EPIC}: dry run — would write a \"${do}\" activation snapshot. The Epic body is untouched, so a repeated pass reports this same transition."
+            echo "  set judged ($(printf '%s' "$cur" | jq 'length') member(s)):"
+            printf '%s' "$cur" | jq -r '.[] | "    \(.repo)#\(.number)"'
+            echo "  payload: ${payload}"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
 
         write_marker "$regionf" && wm=0 || wm=$?
         if [ "$wm" = 0 ] && [ "$do" = "retire" ]; then

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -216,6 +216,17 @@ bails() { # $1 = RETIRE_ONLY, $2 = do -> "bailed" (the step returned) or "went-o
   [ -n "$out" ] && echo went-on || echo bailed
 }
 
+# The rehearsal branch, lifted the same way. It stands between the assembled payload and the write,
+# so what it reports is what would have been written rather than a second rendering of it.
+DRY_BLOCK=$(awk '/SNAPSHOT_DRY_RUN:-/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
+[ -n "$DRY_BLOCK" ] || die "could not read the rehearsal branch from $ACTION"
+rehearses() { # $1 = SNAPSHOT_DRY_RUN, $2 = do, $3 = cur, $4 = payload -> the log, or "went-on"
+  local out
+  out=$( SNAPSHOT_DRY_RUN="$1"; do="$2"; cur="$3"; payload="$4"
+         eval "$DRY_BLOCK" 2>/dev/null; printf 'went-on' )
+  printf '%s' "$out"
+}
+
 payload_for() { # $1 = do, $2 = cur, $3 = inherited since -> echoes the payload, sets NOTE_OUT
   local do cur inherited_since payload note
   do="$1"; cur="$2"; inherited_since="${3:-}"
@@ -538,6 +549,34 @@ for step in "Mint snapshot-write token" "Capture activation snapshot"; do
 done
 
 echo
+echo "the capture can be rehearsed"
+# The one write in the saga that cannot be taken back is the only one that had no rehearsal, so a
+# capture bug was found by discovering a wrong marker on a real Epic.
+P=$(payload_for frozen "$M2")
+out=$(rehearses true frozen "$M2" "$P")
+grep -q 'went-on' <<< "$out" && ko "a rehearsal fell through to the write" || ok "a rehearsal stops before the write"
+grep -q 'dry run' <<< "$out" && ok "and says so" || ko "the rehearsal is silent about being one"
+grep -q 'frozen' <<< "$out" && ok "naming the transition it would make" || ko "the transition is not reported"
+grep -qF -- "$P" <<< "$out" && ok "and the exact payload it would splice" || ko "the payload is not reported"
+for m in 'a-novel-kit/repo-a#5' 'a-novel-kit/repo-b#2'; do
+  grep -qF -- "$m" <<< "$out" && ok "listing member $m" || ko "member $m is not named, so the set cannot be eyeballed"
+done
+eq "an off switch writes as before" "$(rehearses false frozen "$M2" "$P")" went-on
+eq "and so does an unset one" "$(rehearses "" frozen "$M2" "$P")" went-on
+grep -q 'retired' <<< "$(rehearses TRUE retire "$M2" "$(payload_for retire "$M2")")" \
+  && ok "a retirement rehearses too, whatever the casing" || ko "retirement cannot be rehearsed"
+
+echo
+echo "a rehearsal cannot write even if the branch fails"
+# The token is minted read-only for a dry run, so the capability is withheld rather than the write
+# merely skipped. GitHub compares strings case-insensitively, so any casing of "true" reaches it.
+perm=$(awk '/name: Mint snapshot-write token/{f=1} f&&/permission-issues:/{print; exit}' "$ACTION")
+grep -q 'snapshot_dry_run' <<< "$perm" \
+  && ok "the snapshot-write token is scoped by the rehearsal flag" \
+  || ko "a rehearsal still mints an issues:write token"
+grep -qE "'read'" <<< "$perm" && ok "down to read" || ko "the dry branch does not drop to read"
+
+echo
 echo "the payload the step builds"
 eq "a frozen payload records when it froze" "$(payload_for frozen "$M2" | jq -r 'has("at")')" true
 eq "and the members it froze"               "$(payload_for frozen "$M2" | jq -c .members)" "$M2"
@@ -698,7 +737,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -ne 138 ]; then
-  echo "::error::$ran assertion(s) ran, expected exactly 138 — the suite did not execute fully (or an assertion was added without raising this)"
+if [ "$ran" -ne 149 ]; then
+  echo "::error::$ran assertion(s) ran, expected exactly 149 — the suite did not execute fully (or an assertion was added without raising this)"
   exit 1
 fi


### PR DESCRIPTION
Closes #321. Part of a-novel-kit/.github#130.

## Two of the issue's premises did not survive checking

**"The other writers all default `dry_run` on" is not so.** Of the 11 actions carrying it, **6 default `"true"` and 5 default `"false"`** — and the split is principled:

| default | actions | what they are |
| --- | --- | --- |
| `"true"` | `detect-partial-landing`, `epic-rollback`, `release-train`, `rollup-board`, `render-epic-status`, `enable-auto-merge` | sweeps and orchestrators that mutate what they do not own |
| `"false"` | `board-write`, `archive-board-items`, `escalate`, `hotfix-reconcile`, `token-expiry-notify` | primitives invoked by an already-guarded caller |

`merge-gate` is neither: it is a **required check fired per pull request by event**. A dry default would stop every Epic freezing and degrade the whole org to live label membership — the silent-failure shape this milestone exists to remove. So it defaults to writing, and the issue's stated rationale for copying the others does not carry.

**The rehearsal surface is the sweep, not the per-repo caller.** Two paths reach the action:

- `reconcile-board.yaml` calls it **directly** and already exposes `rollup_dry_run` / `detect_dry_run` / `render_dry_run` / `archive_dry_run`. That is the "validate against live data" surface, and it needs no change outside this repo.
- `merge-gate.yaml` → `merge-gate-run.yaml` → the action is event-driven, has no `dry_run` input anywhere, **and its caller is generated from `cli/internal/repocfg/templates/governance/merge-gate.yaml` in the stack repo**. Threading there is a cross-repo change and is the same plumbing #322 wants for `planning_repo`, so it stays with #322.

## What this adds

`snapshot_dry_run` (default `"false"`) logs the transition, the set it was judged against, and the byte-exact payload, then returns before the write:

```
Epic #130: dry run — would write a "frozen" activation snapshot. The Epic body is
untouched, so a repeated pass reports this same transition.
  set judged (2 member(s)):
    a-novel-kit/repo-a#5
    a-novel-kit/repo-b#2
  payload: {"status":"frozen","at":"2026-07-22T10:00:00Z","members":[...]}
```

Naming the members is the point the issue asked for: a capture is judged by whether the right set is in it, and there is no second chance once it freezes.

**The rehearsal also cannot write.** The snapshot-write token is minted `permission-issues: read` when the flag is on, so a dry run is structurally unable to edit the issue rather than relying on the branch that skips it. (GitHub compares strings case-insensitively, so any casing of `true` reaches it; the bash side lowercases independently.)

`regate_snapshot_dry_run` threads it through the sweep. It defaults **`"false"`**, unlike the four flags beside it — worth stating because the difference is deliberate: those gate the rollout of new behavior, while the capture is already live, and **this sweep is usually the only thing that runs on a set that is ready and waiting**. A `pending` marker promotes to `frozen` on a later pass, so a rehearsing sweep would leave it pending forever and the Epic would land on live membership.

## Tests: 138 → 149

The rehearsal branch is inline step logic, so it is lifted from the manifest the way the retire-only bail is, and driven directly. Mutants, all previously green:

| Mutant | Result |
| --- | --- |
| the rehearsal never fires | 7 failed |
| the rehearsal does not stop the write | 1 failed |
| the rehearsal hides the member set | 2 failed |
| the rehearsal hides the payload | 2 failed |
| a dry run still mints a write token | 2 failed |
| the casing comparison is made strict | 1 failed |

All seven suites green; prettier clean; `lint-action-manifests` clean.

## Follow-up

Rehearsing on the sweep needs one line flipped in each org's `.github/workflows/reconcile-board.yaml`, which hardcodes these flags in `with:` (its `workflow_dispatch` exposes no inputs). Say the word and I'll open that as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)