### PR TITLE
fix(detect-partial-landing): read each Epic issue once per pass

### DIFF
--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -342,6 +342,12 @@ runs:
         now_epoch=$(date -u +%s)
         grace_seconds=$(( GRACE_MINUTES * 60 ))
 
+        # Where epic_issue keeps one Epic-issue response per pass. It lives on disk rather than in a
+        # shell variable because the readers run inside `$( )`, and a subshell's assignment never
+        # reaches the parent — the same reason the retry counters in the test harness are file-backed.
+        EPIC_CACHE=$(mktemp -d)
+        trap 'rm -rf "$EPIC_CACHE"' EXIT
+
         # ---- Shared GraphQL documents ----------------------------------------------------
 
         # PR search node — one shape reused by enumeration and the three per-Epic resolve passes.
@@ -448,14 +454,63 @@ runs:
           return 1
         }
 
+        # One read of an Epic issue per pass, shared by the pause check and the snapshot reader. Both
+        # want a different part of the same response — `.labels` and `.body` — and reading it twice
+        # costs a request per Epic per sweep and leaves a window in which the Epic is paused between
+        # them, so one pass acts on two views of one issue.
+        #
+        # It caches the RESPONSE, not a verdict. The two callers hold opposite failure policies: a
+        # pause that cannot be read fails open, so a real partial landing is still caught, while a
+        # snapshot that cannot be read fails closed and decides nothing, because a false `clear` posts
+        # success and lifts a standing freeze. A shared verdict would put one of them on the other's
+        # policy. Each reads the same bytes and applies its own.
+        #
+        # Prints the response. 0 = read it, 2 = the Epic issue is not there, 1 = the read failed and
+        # which is unknown. The error text of the last attempt is left in EPIC_ISSUE_ERR.
+        epic_issue() { # $1 = epic number
+          local f="${EPIC_CACHE}/$1.json" rcf="${EPIC_CACHE}/$1.rc" ef="${EPIC_CACHE}/$1.err"
+          local resp errf attempt rc=1
+          if [ -f "$rcf" ]; then
+            EPIC_ISSUE_ERR=$(cat "$ef" 2>/dev/null || true)
+            cat "$f" 2>/dev/null || true
+            return "$(cat "$rcf")"
+          fi
+          EPIC_ISSUE_ERR=''
+          errf=$(mktemp)
+          for attempt in 1 2 3; do
+            # Keep the streams apart: stdout is the payload, stderr is diagnosis, so a benign `gh`
+            # notice cannot land inside the JSON and fail the parse. `.body` is parsed with jq, which
+            # rejects a non-issue response whole.
+            if resp=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" 2>"$errf") \
+              && printf '%s' "$resp" | jq -e 'type == "object" and has("body")' >/dev/null 2>&1; then
+              rc=0
+              break
+            fi
+            EPIC_ISSUE_ERR=$(cat "$errf" 2>/dev/null || true)
+            # The Epic issue is not in the planning repo — nothing to retry.
+            case "$EPIC_ISSUE_ERR" in *"HTTP 404"*) rc=2; break ;; esac
+            [ "$attempt" -lt 3 ] && sleep 2
+          done
+          rm -f "$errf"
+          [ "$rc" = 0 ] && printf '%s' "$resp" > "$f"
+          printf '%s' "$EPIC_ISSUE_ERR" > "$ef"
+          printf '%s' "$rc" > "$rcf"
+          [ "$rc" = 0 ] && printf '%s' "$resp"
+          return "$rc"
+        }
+
         # Is Epic N paused? Reads the `automation:paused` marker on the Epic issue in the planning repo,
         # a label needing at least triage, so the pause is permission-gated and per-Epic. Returns
         # 0 = paused, 1 = not paused, 2 = read error, where the caller proceeds with normal detection so
         # a real partial landing is still caught.
         epic_paused() { # $1 = epic number
-          local out
-          out=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" --jq '.labels[].name' 2>/dev/null) || return 2
-          printf '%s\n' "$out" | grep -qx 'automation:paused'
+          local resp rc=0
+          resp=$(epic_issue "$1") || rc=$?
+          # A missing Epic issue is an answer: it carries no pause marker, so this is "not paused"
+          # rather than the unknown that 2 reports.
+          [ "$rc" = 2 ] && return 1
+          [ "$rc" = 0 ] || return 2
+          printf '%s' "$resp" | jq -e 'any(.labels[]?.name; . == "automation:paused")' >/dev/null 2>&1
         }
 
         # Read an Epic's frozen activation-snapshot members and bucket them by their live state. Once
@@ -489,41 +544,24 @@ runs:
           SNAP_CLOSED='[]'
           SNAP_OPEN='[]'
           SNAP_SINCE=''
-          local resp="" err="" errf body="" ok=false marker frozen want alias_q rh out nodes
+          local resp="" body="" rc=0 marker frozen want alias_q rh out nodes
           local since="" since_epoch="" shown=""
-          errf=$(mktemp)
-          for attempt in 1 2 3; do
-            # Keep the streams apart: stdout is the payload, stderr is diagnosis, so a benign `gh` notice
-            # cannot land inside the JSON and fail the parse. That costs a whole pass, because an
-            # unreadable body does not fall back. `.body` is parsed with jq, which rejects a non-issue
-            # response whole; an empty body reads as "no snapshot".
-            if resp=$(gh api "repos/${ORG}/${PLANNING_REPO}/issues/$1" 2>"$errf") \
-              && printf '%s' "$resp" | jq -e 'type == "object" and has("body")' >/dev/null 2>&1; then
-              # GitHub stores bodies with CRLF; strip \r so the marker fences match.
-              body=$(printf '%s' "$resp" | jq -r '.body // ""' | tr -d '\r')
-              ok=true
-              break
-            fi
-            err=$(cat "$errf" 2>/dev/null || true)
-            # The Epic issue is not in the planning repo — nothing to retry.
-            case "$err" in *"HTTP 404"*) break ;; esac
-            [ "$attempt" -lt 3 ] && sleep 2
-          done
-          rm -f "$errf"
-          if [ "$ok" != true ]; then
-            # A 404 is an answer: the Epic issue is not there, so no snapshot can exist and the live
-            # floor is the whole truth. Any other failure leaves it unknown whether a frozen set exists.
-            # A `clear` posts success and lifts a standing freeze, so an unknown decides nothing and
-            # re-derives next pass, exactly as the re-read failure below does.
-            case "$err" in
-              *"HTTP 404"*)
-                echo "::warning::epic #$1: ${ORG}/${PLANNING_REPO}#$1 not found — no snapshot possible, live label set only."
-                return 2
-                ;;
-            esac
-            echo "::error::epic #$1: could not read ${ORG}/${PLANNING_REPO}#$1 after 3 attempts, so it is unknown whether a snapshot exists — deciding nothing this pass: ${err}"
+          resp=$(epic_issue "$1") || rc=$?
+          # A 404 is an answer: the Epic issue is not there, so no snapshot can exist and the live
+          # floor is the whole truth. Any other failure leaves it unknown whether a frozen set exists.
+          # A `clear` posts success and lifts a standing freeze, so an unknown decides nothing and
+          # re-derives next pass, exactly as the re-read failure below does.
+          if [ "$rc" = 2 ]; then
+            echo "::warning::epic #$1: ${ORG}/${PLANNING_REPO}#$1 not found — no snapshot possible, live label set only."
+            return 2
+          fi
+          if [ "$rc" != 0 ]; then
+            echo "::error::epic #$1: could not read ${ORG}/${PLANNING_REPO}#$1 after 3 attempts, so it is unknown whether a snapshot exists — deciding nothing this pass: ${EPIC_ISSUE_ERR:-}"
             return 1
           fi
+          # GitHub stores bodies with CRLF; strip \r so the marker fences match. An empty body reads
+          # as "no snapshot".
+          body=$(printf '%s' "$resp" | jq -r '.body // ""' | tr -d '\r')
 
           # The fenced region holds a human-readable note and then the JSON, so skip to the first line
           # that opens a value before parsing: the note is not JSON, and the JSON may be pretty-printed

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -30,7 +30,7 @@ extract() { # $1 = function name — lift it out of the run: block and de-indent
   ' "$ACTION" | sed 's/^        //'
 }
 
-for fn in snapshot_buckets union_buckets evaluate_epic; do
+for fn in epic_issue epic_paused snapshot_buckets union_buckets evaluate_epic; do
   out=$(extract "$fn")
   if [ -z "$out" ]; then
     echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
@@ -75,8 +75,8 @@ gh() {
       case "$FX_BODY" in
         FAIL404) echo "gh: Not Found (HTTP 404)" >&2; return 1 ;;
         FAIL500) echo "gh: HTTP 502" >&2; return 1 ;;
-        NOISE) echo "gh: a deprecation notice" >&2; jq -cn --arg b "$FX_MARKER_BODY" '{body: $b}' ;;
-        *) jq -cn --arg b "$FX_BODY" '{body: $b}' ;;
+        NOISE) echo "gh: a deprecation notice" >&2; jq -cn --arg b "$FX_MARKER_BODY" --argjson l "$FX_LABELS" '{body: $b, labels: $l}' ;;
+        *) jq -cn --arg b "$FX_BODY" --argjson l "$FX_LABELS" '{body: $b, labels: $l}' ;;
       esac ;;
     *) echo "unexpected gh call: $*" >&2; return 1 ;;
   esac
@@ -129,6 +129,18 @@ rest_pr_state() {
 
 # shellcheck disable=SC1091
 . "$WORK/lib.sh"
+
+# Where epic_issue keeps one Epic-issue response per pass.
+EPIC_CACHE="$WORK/epic-cache"
+mkdir -p "$EPIC_CACHE"
+epic_cache_clear() { rm -f "$EPIC_CACHE"/*; }
+
+# A pass reads an Epic issue once and both readers share it, so the cache survives for the life of
+# the step. Each case below is its own pass with its own fixture body, so it is cleared per call —
+# otherwise the first case's response would answer every later one. The read-once behavior is
+# asserted directly further down, against an uncleared cache.
+eval "uncached_evaluate_epic() $(declare -f evaluate_epic | tail -n +2)"
+evaluate_epic() { epic_cache_clear; uncached_evaluate_epic "$@"; }
 
 # ---- fixtures ---------------------------------------------------------------------------
 # A member node as the re-read returns it. `prov` is how the node proves it belongs to the Epic:
@@ -193,6 +205,8 @@ reset_fixtures() {
   FX_LIVE_CLOSED='[]'   # B is de-labeled, so live truth has forgotten it entirely
   FX_LIVE_OPEN="[$C]"
   FX_BODY=""
+  # One response carries both the pause marker and the snapshot, so the fixture carries both.
+  FX_LABELS='[]'
   FX_REHYDRATE=""
   printf 0 > "$WORK/rehydrate_fails"
   : > "$WORK/gh_calls"
@@ -212,6 +226,7 @@ fail=0
 note() { printf '  %s %s\n' "$1" "$2"; }
 ok() { note ✓ "$1"; pass=$((pass + 1)); }
 ko() { note ✗ "$1"; fail=$((fail + 1)); }
+eq() { [ "$2" = "$3" ] && ok "$1" || ko "$1 (got '$2', want '$3')"; }
 
 check() { # name expected-decision [expected-membership] [expected merged/closed/open counts]
   local name="$1" want="$2" wantsrc="${3:-}" wantcounts="${4:-}" src counts detail=""
@@ -774,6 +789,55 @@ FX_BODY="" # the next Epic has no snapshot at all
 check "an Epic with no snapshot sees none of the previous one's" clear live 1/0/1
 
 echo
+echo
+echo "one read of the Epic issue per pass"
+# The pause check wants .labels and the snapshot reader wants .body, and one response carries both.
+# Two reads cost a request per Epic per sweep and leave a window in which the Epic is paused between
+# them, so a pass would act on two views of one issue. Driven against an uncleared cache, which is
+# how a real pass runs.
+reset_fixtures
+FX_BODY=$(marker frozen "$BC")
+epic_cache_clear; : > "$WORK/gh_calls"
+epic_paused 900 && true
+uncached_evaluate_epic 900 >/dev/null 2>&1
+reads=$(grep -c 'issues/900' "$WORK/gh_calls" || true)
+eq "the pause check and the snapshot share one read" "$reads" 1
+
+echo
+echo "the two readers keep their own failure policies"
+# They disagree on purpose. A pause that cannot be read must fail OPEN, or a blip on the label read
+# stops the sweep and a real partial landing goes uncaught. A snapshot that cannot be read must fail
+# CLOSED, because a false clear posts success and lifts a standing freeze. Caching a shared verdict
+# would put one of them on the other's policy.
+reset_fixtures
+FX_BODY=FAIL500
+epic_cache_clear
+epic_paused 900 && rc=0 || rc=$?
+eq "an unreadable issue leaves the pause unknown" "$rc" 2
+snapshot_buckets 900 >/dev/null 2>&1 && rc=0 || rc=$?
+eq "and the same response decides no snapshot" "$rc" 1
+
+reset_fixtures
+FX_BODY=FAIL404
+epic_cache_clear
+epic_paused 900 && rc=0 || rc=$?
+eq "a missing Epic issue is not paused, rather than unknown" "$rc" 1
+snapshot_buckets 900 >/dev/null 2>&1 && rc=0 || rc=$?
+eq "and carries no snapshot" "$rc" 2
+
+echo
+echo "the pause marker is read from the shared response"
+reset_fixtures
+FX_LABELS='[{"name":"automation:paused"}]'
+epic_cache_clear
+epic_paused 900 && rc=0 || rc=$?
+eq "automation:paused is seen" "$rc" 0
+reset_fixtures
+FX_LABELS='[{"name":"automation:paused-not-really"},{"name":"bug"}]'
+epic_cache_clear
+epic_paused 900 && rc=0 || rc=$?
+eq "a label merely containing it is not a pause" "$rc" 1
+
 printf '%d passed, %d failed\n' "$pass" "$fail"
 # A floor on the count as well as on failures: a suite that runs no assertions exits 0 and reads as
 # green. Raise this when assertions are added; never lower it to make a run pass.
@@ -785,7 +849,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -lt 132 ]; then
-  echo "::error::only $ran assertion(s) ran (expected at least 132) — the suite did not execute fully"
+if [ "$ran" -lt 139 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 139) — the suite did not execute fully"
   exit 1
 fi


### PR DESCRIPTION
Closes #323. Part of a-novel-kit/.github#130.

## The duplicate

`epic_paused` and `snapshot_buckets` each did `GET repos/<org>/<planning_repo>/issues/<n>` for the same Epic, back to back, on every evaluation. One response carries both the `.labels` the first wants and the `.body` the second wants.

Cost is a request per Epic per sweep — and per PR event, where the trigger set is wide. The consistency gap matters more: between the two reads the Epic can be paused, so a single pass acts on two different views of one issue.

## Why it caches the response and not a verdict

This is the part that shaped the change. The two readers hold **opposite** failure policies:

| reader | on an unreadable issue | why |
| --- | --- | --- |
| `epic_paused` | fails **open** — returns 2, caller proceeds with normal detection | a blip on the label read must not stop the sweep, or a real partial landing goes uncaught |
| `snapshot_buckets` | fails **closed** — returns 1, "decide nothing this pass" | a false `clear` posts success and lifts a standing freeze |

Caching a shared verdict would put one of them on the other's policy. `epic_issue` caches the **bytes** and each caller applies its own policy to them — the same "canonicalise the value once, never the interpretation" rule the rest of this milestone kept arriving at.

## Two behavior changes that fall out

**The pause check gains retries.** The retry-and-404 handling moves out of `snapshot_buckets` into the shared reader, so a label read that previously gave up on the first blip now gets three attempts. Strictly better for a check whose failure mode is fail-open.

**A missing Epic issue now reports "not paused" rather than "unknown".** A 404 is an answer: there is no issue, so there is no pause marker. Both still route the caller to normal detection, so no outcome changes — the reported reason is just true now.

Also: the pause label is read from the response with jq instead of a second `--jq` fetch, and matched whole, so `automation:paused-not-really` is not a pause. The old `grep -qx` matched whole lines already; this keeps that property through the new path rather than inheriting it by accident.

## Tests: 132 → 139

The suite drives ~20 cases through `evaluate_epic 900`, so a per-pass cache would leak one case's fixture into the next. Production keeps the cache for the life of the step; the harness wraps `evaluate_epic` to clear it per call, and the read-once assertion runs against an **uncleared** cache, which is how a real pass behaves.

| Mutant | Result |
| --- | --- |
| the cache never hits (two reads again) | 1 failed |
| a 404 leaves the pause unknown | 1 failed |
| an unreadable snapshot fails open | 2 failed |
| the pause label matches a prefix | 1 failed |
| the pause reads labels it was not given | 1 failed |

All seven suites green; prettier and `lint-action-manifests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)