### PR TITLE
fix(test-go): fail discovery instead of reporting a green run of zero tests

### DIFF
--- a/go-actions/test-go/action.yaml
+++ b/go-actions/test-go/action.yaml
@@ -59,8 +59,50 @@ runs:
         # Enumerate every package across every module. Iterating modules from
         # `go list -m` is what makes this work in a Go workspace, where packages
         # span more than one module and a single `go list ./...` reaches only one.
-        echo "$(for mod in $(go list -m); do go list ${mod//$(go list .)/.}/... ${{ inputs.filter_patterns }} ${{ inputs.filter_extra_patterns }}; done)" > modules.txt
-        echo "MODULES=$(cat modules.txt | tr '\n' ' ')" >> $GITHUB_ENV
+        #
+        # Every read is checked, and the resulting set has to be non-empty. An empty MODULES is
+        # passed to gotestsum as no package arguments at all, which makes it default to `.` — a
+        # directory that in most of these modules holds no test files. It reports `DONE 0 tests`
+        # and exits 0, coverage comes out as the bare `mode: set` header, and the job goes green
+        # having run nothing. This action is the only place these tests run.
+        discover_modules() {
+          local root modules mod packages
+
+          if ! root=$(go list .); then
+            echo "::error::go list . failed — cannot derive the module path prefix"
+            return 1
+          fi
+
+          if ! modules=$(go list -m); then
+            echo "::error::go list -m failed — cannot enumerate the modules"
+            return 1
+          fi
+
+          : >modules.txt
+
+          for mod in $modules; do
+            if ! packages=$(go list "${mod//$root/.}/..."); then
+              echo "::error::go list failed for module ${mod}"
+              return 1
+            fi
+
+            # A module contributing nothing is legitimate — every one of its packages may be
+            # filtered out, and then the filter chain's last grep exits 1. Only the emptiness of
+            # the whole set is a failure, so it is checked once, below.
+            [ -n "$packages" ] || continue
+
+            printf '%s\n' "$packages" ${{ inputs.filter_patterns }} ${{ inputs.filter_extra_patterns }} >>modules.txt
+          done
+
+          if [ ! -s modules.txt ]; then
+            echo "::error::discovery produced no packages — the test run would report success having run nothing"
+            return 1
+          fi
+        }
+
+        discover_modules || exit 1
+
+        echo "MODULES=$(tr '\n' ' ' <modules.txt)" >>"$GITHUB_ENV"
     - name: run tests
       shell: bash
       run: |

--- a/tests/test-go-discovery.sh
+++ b/tests/test-go-discovery.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Regression tests for test-go's package discovery.
+#
+# Same discipline as release-train.sh: discover_modules is extracted verbatim from the manifest and
+# sourced, with only `go` stubbed. The caller-supplied filter expressions are the one thing that
+# cannot survive extraction — they are `${{ }}` expressions GitHub resolves at load time — so they
+# are substituted with their declared defaults, and the substitution is asserted rather than assumed.
+#
+# What is under test is that discovery cannot come back empty and still report success. gotestsum
+# reads MODULES as its package arguments; with none it falls back to `.`, prints `DONE 0 tests` and
+# exits 0, and the coverage step reports 0.0% off a `mode: set` header and exits 0 too. Every read
+# here has to fail loudly instead, because this action is the only place these tests run.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION="${1:-$ROOT/go-actions/test-go/action.yaml}"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+extract() { # $1 = function name — lift it out of the run: block and de-indent
+  awk -v n="$1" '
+    $0 ~ "^        "n"\\(\\) \\{" {f=1}
+    f {print}
+    f && /^        \}$/ {exit}
+  ' "$ACTION" | sed 's/^        //'
+}
+
+out=$(extract discover_modules)
+if [ -z "$out" ]; then
+  echo "::error::could not extract discover_modules from $ACTION — did its definition move or change indent?"
+  exit 1
+fi
+
+# Resolve the two caller expressions to the defaults the manifest declares. Both substitutions have
+# to bite: a renamed input would otherwise leave a `${{ … }}` in the sourced text, and the suite
+# would then cover something the action no longer contains.
+filters="| grep -v /mocks | grep -v /test | grep -v /proto"
+resolved=${out//'${{ inputs.filter_patterns }}'/$filters}
+resolved=${resolved//'${{ inputs.filter_extra_patterns }}'/}
+
+if [ "$resolved" = "$out" ] || [[ "$resolved" == *'${{'* ]]; then
+  echo "::error::filter expressions did not resolve — the input names in the manifest changed"
+  exit 1
+fi
+
+printf '%s\n' "$resolved" >"$WORK/lib.sh"
+
+if ! bash -n "$WORK/lib.sh"; then
+  echo "::error::extracted function does not parse — extraction truncated the definition"
+  exit 1
+fi
+
+# ---- stubbed leaf -----------------------------------------------------------------------
+# The three reads discover_modules makes, each failable on demand.
+GO_ROOT="github.com/a-novel/svc"
+GO_MODULES="github.com/a-novel/svc"
+GO_PACKAGES=""
+GO_ROOT_FAIL=0
+GO_M_FAIL=0
+GO_PKG_FAIL=0
+
+go() {
+  [ "${1:-}" = "list" ] || return 0
+  shift
+
+  case "${1:-}" in
+    .)
+      [ "$GO_ROOT_FAIL" = "1" ] && return 1
+      printf '%s\n' "$GO_ROOT"
+      ;;
+    -m)
+      [ "$GO_M_FAIL" = "1" ] && return 1
+      printf '%s\n' "$GO_MODULES"
+      ;;
+    *)
+      [ "$GO_PKG_FAIL" = "1" ] && return 1
+      [ -n "$GO_PACKAGES" ] && printf '%s\n' "$GO_PACKAGES"
+      ;;
+  esac
+
+  return 0
+}
+
+# shellcheck source=/dev/null
+. "$WORK/lib.sh"
+
+cd "$WORK" || exit 1
+
+fails=0
+check() { # $1=label $2=expected $3=actual
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected [$2], got [$3]"
+    fails=$((fails + 1))
+  fi
+}
+
+run() { # runs discovery quietly and echoes its status
+  discover_modules >/dev/null 2>&1
+  echo "$?"
+}
+
+echo "== a failed read is not an empty package set =="
+
+GO_PACKAGES="github.com/a-novel/svc/internal/dao"
+
+GO_ROOT_FAIL=1
+check "go list . failure fails the step" "1" "$(run)"
+GO_ROOT_FAIL=0
+
+GO_M_FAIL=1
+check "go list -m failure fails the step" "1" "$(run)"
+GO_M_FAIL=0
+
+GO_PKG_FAIL=1
+check "a per-module go list failure fails the step" "1" "$(run)"
+GO_PKG_FAIL=0
+
+echo "== an empty package set is a failure however it arises =="
+
+GO_PACKAGES=""
+check "a module listing no packages fails the step" "1" "$(run)"
+
+# Without the emptiness guard this is the shape that slips through: printf on an empty capture writes
+# a blank line, which survives every grep and makes modules.txt non-empty by size while naming no
+# package at all.
+check "the blank line a no-package module would emit does not count as content" \
+  "" "$(tr -d '[:space:]' <modules.txt)"
+
+GO_PACKAGES="github.com/a-novel/svc/internal/mocks
+github.com/a-novel/svc/internal/test
+github.com/a-novel/svc/internal/models/proto"
+check "a set the filters empty out fails the step" "1" "$(run)"
+
+echo "== the healthy path still discovers, and still filters =="
+
+GO_PACKAGES="github.com/a-novel/svc
+github.com/a-novel/svc/internal/dao
+github.com/a-novel/svc/internal/mocks
+github.com/a-novel/svc/internal/test
+github.com/a-novel/svc/internal/models/proto"
+
+check "a populated set succeeds" "0" "$(run)"
+check "the surviving packages are recorded" "yes" "$(grep -q '/internal/dao$' modules.txt && echo yes || echo no)"
+check "mocks are filtered out" "no" "$(grep -q /mocks modules.txt && echo yes || echo no)"
+check "test helpers are filtered out" "no" "$(grep -q /test modules.txt && echo yes || echo no)"
+check "generated proto is filtered out" "no" "$(grep -q /proto modules.txt && echo yes || echo no)"
+
+GO_MODULES="github.com/a-novel/svc
+github.com/a-novel/svc/pkg/go"
+check "several modules all contribute" "0" "$(run)"
+check "each module appended its packages" "4" "$(wc -l <modules.txt)"
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "::error::$fails assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
## The defect

`go-actions/test-go`'s discovery step wraps its whole pipeline in `echo "$(…)"`:

```bash
echo "$(for mod in $(go list -m); do go list ${mod//$(go list .)/.}/... | grep -v /mocks …; done)" > modules.txt
echo "MODULES=$(cat modules.txt | tr '\n' ' ')" >> $GITHUB_ENV
```

Command substitution inside `echo` discards the inner exit status, so `set -e` never sees a failure — `echo` itself always succeeds. Reproduced with the inner command failing:

```
step exit: 0
MODULES=[ ]
```

Note `MODULES` comes out as a **space**, not empty, so a naive `[ -n "$MODULES" ]` downstream would pass too.

An empty `MODULES` reaches gotestsum as no package arguments at all, so it falls back to `.`. Verified against the real `run tests` command:

```
∅  .
DONE 0 tests in 0.000s
```

`coverage.txt` is written as the bare line `mode: set`, `go tool cover -func` reports `total: 0.0%`, and both steps exit 0. The job goes green having run nothing — and this action is the only place these tests run in every repo that calls it.

## The fix

Each read is checked on its own, and the discovered set has to name at least one package.

Two things the obvious `set -euo pipefail` would get wrong:

- **A module contributing nothing is legitimate.** All of its packages may be filtered out, and then the filter chain's last `grep` exits 1. Emptiness is judged once over the whole set instead of per module.
- **An empty capture appends a blank line.** `printf '%s\n' ""` writes a newline that survives every `grep -v` and makes `modules.txt` non-empty *by size* while naming no package. Empty captures are skipped, and the suite pins that case.

No coverage floor. Coverage is advisory here by standing decision; the defect is that discovery can come back empty, and that is what now fails.

## Verification

`tests/test-go-discovery.sh` extracts `discover_modules` verbatim from the manifest and sources it with only `go` stubbed — the same discipline as `release-train.sh` and `detect-partial-landing.sh`. The two `${{ inputs.filter_* }}` expressions cannot survive extraction, so they are substituted with their declared defaults and **the substitution is asserted**, so renaming an input fails the suite rather than quietly covering code the action no longer contains.

Red check — the same 14 assertions against the previous one-liner:

```
FAIL go list . failure fails the step: expected [1], got [0]
FAIL go list -m failure fails the step: expected [1], got [0]
FAIL a per-module go list failure fails the step: expected [1], got [0]
FAIL a module listing no packages fails the step: expected [1], got [0]
FAIL a set the filters empty out fails the step: expected [1], got [0]
```

The healthy path is unchanged: the discovered package list is **byte-identical** old vs new on five real modules.

| module | packages |
|---|---|
| `stack/cli` | 23 |
| `service-json-keys` | 14 |
| `service-authentication` | 16 |
| `golib` | 15 |
| `jwt` | 11 |

All eight suites in `tests/` pass, `lint-action-manifests.sh` is clean, and prettier is happy.

## Scope

`a-novel-kit/stack` carries an **inlined transcription** of this same step in `.github/workflows/main.yaml` (the shared action assumes the module sits at the repo root; the CLI module lives under `cli/`). It has the identical defect and gets the identical fix in a separate stack PR — it does not consume this action, so the two are independent.

Refs a-novel-kit/stack#286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
