### PR TITLE
feat(merge-gate): thread planning_repo and snapshot_dry_run through the reusable workflows

### DIFF
--- a/.github/workflows/merge-gate-run.yaml
+++ b/.github/workflows/merge-gate-run.yaml
@@ -34,6 +34,24 @@ on:
         required: false
         type: string
         default: ""
+      planning_repo:
+        description: >-
+          Repository (name only; owner is the org) holding the Epic issues the gate resolves
+          membership from and writes the activation snapshot into. Defaults to the org `.github` repo.
+          The gate, epic-membership and detect-partial-landing must all read the same repo: the gate
+          writes the snapshot there and the others look for it there, so a value set on one and left
+          default on another degrades every Epic to live label membership without an error anywhere.
+        required: false
+        type: string
+        default: .github
+      snapshot_dry_run:
+        description: >-
+          When "true", the gate logs the activation snapshot it would capture and leaves the Epic body
+          alone; the `merge-gate` check-run is posted either way. Defaults to writing, since a
+          rehearsing gate captures nothing and every Epic falls back to live label membership.
+        required: false
+        type: string
+        default: "false"
     secrets:
       app_private_key:
         description: The [Agent] bot App private key (PEM).
@@ -56,6 +74,8 @@ jobs:
           # org variable because a composite action cannot read `vars` itself, and the variable need
           # not exist: an unset value reads as empty, which is a running state.
           kill_switch: ${{ inputs.kill_switch }}
+          planning_repo: ${{ inputs.planning_repo }}
+          snapshot_dry_run: ${{ inputs.snapshot_dry_run }}
 
   auto-merge:
     # Only where there is a PR to enable (pull_request events), and never on a draft.

--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -47,6 +47,17 @@ on:
           When "true" (default), the Epic status read-model only logs the table it would render; set
           "false" to rewrite it into each active Epic's issue body. Display-only (no board write, no
           check-run), so it flips live on its own schedule, independent of the other passes.
+      planning_repo:
+        required: false
+        type: string
+        default: .github
+        description: >
+          Repository (name only; owner is `org`) holding the Epic issues this sweep reads: the
+          `automation:paused` marker, the activation snapshot, and the status read-model it renders.
+          Defaults to the org `.github` repo. Every pass below is threaded from this one value,
+          because merge-gate writes the snapshot where detect-partial-landing looks for it — set it on
+          one pass and leave another default and every Epic quietly falls back to live label
+          membership, with no error anywhere.
       regate_snapshot_dry_run:
         required: false
         type: string
@@ -237,6 +248,7 @@ jobs:
           pull_request_number: ${{ matrix.pr.number }}
           head_sha: ${{ matrix.pr.sha }}
           snapshot_dry_run: ${{ inputs.regate_snapshot_dry_run }}
+          planning_repo: ${{ inputs.planning_repo }}
           # Org-level halt: when engaged merge-gate holds this idle PR too by posting failure, so a
           # PR that emits no event while halted is still stopped. A gate posts failure; skipping would
           # leave a neutral check that passes.
@@ -254,6 +266,7 @@ jobs:
       - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.22.0
         with:
           client_id: ${{ inputs.client_id }}
+          planning_repo: ${{ inputs.planning_repo }}
           app_private_key: ${{ secrets.private_key }}
           dry_run: ${{ inputs.detect_dry_run }}
           # Org-level halt, fail-safe as in the rollup job: when engaged the sweep skips all work,
@@ -273,6 +286,7 @@ jobs:
       - uses: a-novel-kit/workflows/generic-actions/render-epic-status@v1.22.0
         with:
           client_id: ${{ inputs.client_id }}
+          planning_repo: ${{ inputs.planning_repo }}
           app_private_key: ${{ secrets.private_key }}
           dry_run: ${{ inputs.render_dry_run }}
           # Org-level halt: when engaged this display-only writer no-ops, editing no Epic body.


### PR DESCRIPTION
Closes #322. Part of a-novel-kit/.github#130.

## The gap

`planning_repo` defaults to `.github` in `merge-gate`, `epic-membership` and `detect-partial-landing`, and no caller overrides it — so the default is load-bearing and untested. Two things made an override impossible to do correctly:

- `merge-gate-run.yaml` carried no `planning_repo` among its `workflow_call` inputs, so callers of the reusable engine could not thread it **at all**.
- The reconcile sweep passed it to **none** of the three passes that accept it.

Both now take it and thread it to every action that reads it:

| sweep pass | takes `planning_repo` | now threaded |
| --- | --- | --- |
| `merge-gate` | yes | ✅ |
| `detect-partial-landing` | yes | ✅ |
| `render-epic-status` | yes | ✅ |
| `rollup-board`, `archive-board-items`, `derive-status` | no | — |

**Defaults are unchanged.** Nothing moves until a caller sets one; the point is that the coupling stops depending on three separate defaults agreeing.

A partial override is the failure worth naming: the gate writes the snapshot to *its* `planning_repo` while the two readers look in *theirs*, so setting it on one and leaving another default puts every Epic on live label membership — with no error anywhere. That is why the input descriptions say so at each end rather than only here.

## `snapshot_dry_run` rides along

Same defect, same file. It reached only the sweep, because the per-repo event path runs through this reusable workflow — which is why the live rehearsal on 2026-07-22 could show the set a capture would freeze while the per-repo gates froze it for real. With this, a rehearsal can cover both writers.

## No behavior change to verify

Every new input is optional and defaults to today's value, so a caller that passes nothing gets exactly what it got before. All seven suites green; prettier and `lint-action-manifests` clean.

Worth noting for whoever picks up the per-repo side: the governed repos' own `merge-gate.yaml` and `epic-freeze.yaml` are generated from `cli/internal/repocfg/templates/governance/` in the stack repo. They need no change to keep working, and can now pass these inputs if a repo ever needs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)