### PR TITLE
fix(renovate): guard pnpm-workspace.yaml overrides from Renovate bumps

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -142,8 +142,8 @@ runs:
               "groupName": "javascript dependencies"
             },
             {
-              "description": "Leave pnpm audit-managed overrides to the audit action. node-actions/audit runs `pnpm audit --fix=override` daily and pins vulnerable transitive dependencies to the minimal patched version within each consumer's supported range. Renovate's npm manager otherwise re-reads the override value as an ordinary dependency and bumps it to the latest major, pushing the pin past the parent's compatibility ceiling (e.g. undici v8 breaks jsdom's private wrap-handler.js deep-import). Audit owns these values; Renovate must not touch them.",
-              "matchDepTypes": ["pnpm.overrides", "overrides"],
+              "description": "Leave pnpm audit-managed overrides to the audit action. node-actions/audit runs `pnpm audit --fix=override` daily and pins vulnerable transitive dependencies to the minimal patched version within each consumer's supported range. Renovate's npm manager otherwise re-reads the override value as an ordinary dependency and bumps it to the latest major, pushing the pin past the parent's compatibility ceiling (e.g. undici v8 breaks jsdom's private wrap-handler.js deep-import). Audit owns these values; Renovate must not touch them. All three depTypes must stay listed: Renovate types package.json `pnpm.overrides` and its `overrides` alias, but overrides declared in pnpm-workspace.yaml (pnpm 10's preferred location) get `pnpm-workspace.overrides` — omit it and the guard silently no-ops for every workspace-level override.",
+              "matchDepTypes": ["pnpm.overrides", "overrides", "pnpm-workspace.overrides"],
               "enabled": false
             }
           ]


### PR DESCRIPTION
## Problem

The `packageRules` entry that disables Renovate on audit-managed pnpm overrides matched only `matchDepTypes: ["pnpm.overrides", "overrides"]`. Those cover overrides in **package.json**. Overrides declared in **`pnpm-workspace.yaml`** — pnpm 10's preferred location, and where the fleet now keeps them — are typed **`pnpm-workspace.overrides`** by Renovate's npm manager. Neither listed depType matched, so the guard silently no-opped for every workspace-level override.

## Impact

Renovate bumped the audit-pinned `undici` override (`^7.28.0` → `^8.0.0`). undici v8 removed the private `undici/lib/handler/wrap-handler.js` deep-import that jsdom's `jsdom-dispatcher.js` requires, so the vitest jsdom environment fails to boot and `test-pkg-js` goes red across consumers.

- Reproduced on: a-novel/service-authentication#1156 (`Cannot find module 'undici/lib/handler/wrap-handler.js'`).
- Latent across the whole fleet: every repo keeps overrides in `pnpm-workspace.yaml`; undici is just the first audit-pinned override to have a new major above its pin.

## Fix

Add `pnpm-workspace.overrides` to `matchDepTypes`, and document in the rule description why all three depTypes must stay listed so this can't silently regress.

Verified: YAML + embedded `RENOVATE_PACKAGE_RULES` JSON parse; prettier clean.

## Follow-up (not in this PR)

- Close a-novel/service-authentication#1156 (the bad bump).
- After release, consumers re-pin `generic-actions/renovate` to pick up the guard.
- The audit action should re-derive the contradictory `undici` override pair on consumers (`undici@>=7.0.0 <7.28.0: ^8.0.0` vs `undici@>=7.23.0 <7.28.0: ^7.28.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)