### PR TITLE
chore(ci)!: drop the go-report-card composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,10 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 
 ### `go-actions`
 
-| Action           | Purpose                                                        |
-| ---------------- | -------------------------------------------------------------- |
-| `go-report-card` | Refresh the repo's [Go Report Card](https://goreportcard.com). |
-| `lint-go`        | Run `golangci-lint` (supports a non-root module dir).          |
-| `test-go`        | Run the workspace's Go tests with coverage via `gotestsum`.    |
+| Action    | Purpose                                                     |
+| --------- | ----------------------------------------------------------- |
+| `lint-go` | Run `golangci-lint` (supports a non-root module dir).       |
+| `test-go` | Run the workspace's Go tests with coverage via `gotestsum`. |
 
 ### `node-actions`
 

--- a/go-actions/go-report-card/action.yaml
+++ b/go-actions/go-report-card/action.yaml
@@ -1,9 +1,0 @@
-name: go report card
-description: Refresh the repository's goreportcard.com report.
-
-runs:
-  using: "composite"
-  steps:
-    - name: update report card
-      shell: bash
-      run: curl -X POST -F "repo=github.com/${{ github.repository }}" https://goreportcard.com/checks


### PR DESCRIPTION
## Summary

- Removes the `go-actions/go-report-card` composite action and its README row.
- [Go Report Card was sunset](https://goreportcard.com/report/github.com/a-novel/service-authentication) in July 2026 — the action's `POST goreportcard.com/checks` now hits a dead endpoint, so every consumer's `report-grc` job is a no-op.

## Breaking changes

The `go-actions/go-report-card` action is removed. Any caller with a `uses: a-novel-kit/workflows/go-actions/go-report-card@<tag>` step must drop it. All in-org consumers are being updated in the same sweep (service-authentication, service-template, service-narrative-engine, service-json-keys, service-jobs, golib, jwt).

## Test plan

- [ ] CI green