### PR TITLE
feat(detect-partial-landing): enumerate Epics through their frozen snapshot

### DIFF
--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -22,9 +22,10 @@ description: >
   added on top — added, never substituted, so a snapshot can only widen what the detector sees and
   never narrow it. That addition is what makes an abandoned member visible: a pull request de-labeled
   and closed mid-landing leaves no trace the live search can find, because GitHub indexes no "ever
-  carried label X", so on the live set alone the survivors read as a clean landing. The sweep still
-  REACHES an Epic through live labels, so an Epic whose last labeled open pull request is de-labeled
-  drops out of enumeration altogether — the snapshot rescues a forgotten member, not a forgotten Epic.
+  carried label X", so on the live set alone the survivors read as a clean landing. The sweep REACHES
+  an Epic through live labels UNION the frozen snapshots it enumerates from the planning repo, so an
+  Epic whose last labeled open pull request is de-labeled is still evaluated through its own marker —
+  the snapshot rescues both a forgotten member and a forgotten Epic.
 
   HISTORY is scoped to the WAVE, membership is not. A merged pull request keeps its `epic:<N>` label
   for good, so an unbounded `is:merged` search reports every wave the Epic has ever landed: `merged >= 1`
@@ -454,10 +455,25 @@ runs:
           return 1
         }
 
+        # The snapshot marker JSON carried by an issue body, or empty. The fence lines are matched as
+        # whole lines, so a pseudo-fence planted in prose cannot shadow the region, and `-s .[0]` takes
+        # the first JSON value if a hand-edit left several. The claim index and snapshot_buckets both
+        # ask "is there a marker" through this one reader, so neither can reach an Epic the other then
+        # refuses to parse. The fence literals match merge-gate's splice; a change to them lands in all
+        # three actions.
+        extract_marker() { # $1 = issue body (CRLF already stripped)
+          local s='<!-- epic-membership:snapshot:start -->' e='<!-- epic-membership:snapshot:end -->'
+          printf '%s\n' "$1" \
+            | awk -v s="$s" -v e="$e" '$0 == s {f=1;next} $0 == e {f=0} f' \
+            | sed -n '/^[[:space:]]*[{[]/,$p' \
+            | jq -s -c '.[0] // empty' 2>/dev/null || true
+        }
+
         # One read of an Epic issue per pass, shared by the pause check and the snapshot reader. Both
         # want a different part of the same response — `.labels` and `.body` — and reading it twice
         # costs a request per Epic per sweep and leaves a window in which the Epic is paused between
-        # them, so one pass acts on two views of one issue.
+        # them, so one pass acts on two views of one issue. The claim index primes this cache from its
+        # one list of the planning repo, so an enumerated Epic whose issue is open is never re-fetched.
         #
         # It caches the RESPONSE, not a verdict. The two callers hold opposite failure policies: a
         # pause that cannot be read fails open, so a real partial landing is still caught, while a
@@ -513,6 +529,62 @@ runs:
           printf '%s' "$resp" | jq -e 'any(.labels[]?.name; . == "automation:paused")' >/dev/null 2>&1
         }
 
+        # Epics reachable through their own frozen snapshot, independent of any live label. The sweep
+        # otherwise finds active Epics only through `epic:<N>` labels on open pull requests, so an Epic
+        # whose last labeled open pull request is de-labeled drops out of enumeration and its partial
+        # landing is never evaluated — the snapshot rescued a forgotten member, not a forgotten Epic.
+        # This lists the planning repo's open issues once, reads each body, and fills CLAIM_EPICS
+        # (newline-separated) with the numbers carrying a frozen marker.
+        #
+        # The list is a single call over a small set — planning issues, not pull requests — read
+        # directly rather than by an `in:body` marker search: GitHub tokenizes punctuation away, so a
+        # marker query is approximate, and its search index is documented to silently omit an item that
+        # genuinely matches, which is the exact failure this rescue exists to remove. It also primes the
+        # epic_issue cache with every issue it read, so the per-Epic pause and snapshot reads below reuse
+        # this list instead of re-fetching.
+        #
+        # It fails soft: the claim set is unioned with the label set and only ever widens it, so a list
+        # error costs the de-label rescue for one pass and never narrows what the sweep already sees.
+        # Enumeration is looser than snapshot_buckets' resolution on purpose — any body whose marker is a
+        # frozen object with a non-empty member array is reached, and snapshot_buckets then applies the
+        # strict per-member validation. Over-reaching is harmless (an Epic that resolves to nothing
+        # evaluates as a no-op clear with no member head to post on); under-reaching is the bug.
+        build_claim_index() { # no args
+          CLAIM_EPICS=''
+          local pages nodes n elem body marker total=0 added=0
+          if ! pages=$(gh api --paginate "repos/${ORG}/${PLANNING_REPO}/issues?state=open&per_page=100" 2>/dev/null); then
+            echo "::warning::could not list open issues in ${ORG}/${PLANNING_REPO} — reaching Epics through live labels only this pass; a de-labeled Epic is not rescued." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            return 0
+          fi
+          # --paginate concatenates one JSON array per page; `-s add` merges them whether the reply was
+          # one page or several. A parse failure yields an empty index rather than aborting the sweep.
+          nodes=$(printf '%s' "$pages" | jq -s -c 'add // []' 2>/dev/null) || nodes='[]'
+          total=$(printf '%s' "$nodes" | jq '[.[] | select(has("pull_request") | not)] | length' 2>/dev/null || echo 0)
+          # fd 4 isolates this feed from the gh calls the loop body would otherwise consume; the body
+          # runs in this shell, so CLAIM_EPICS and the cache primes persist. The list endpoint returns
+          # pull requests too, filtered by the `pull_request` key an issue never carries.
+          while IFS= read -r n <&4; do
+            [ -n "$n" ] || continue
+            elem=$(printf '%s' "$nodes" | jq -c --argjson n "$n" 'map(select(.number == $n))[0] // empty' 2>/dev/null)
+            [ -n "$elem" ] || continue
+            # Prime epic_issue's cache: a later pause or snapshot read of this number reuses this body.
+            printf '%s' "$elem" > "${EPIC_CACHE}/$n.json"
+            : > "${EPIC_CACHE}/$n.err"
+            printf '0' > "${EPIC_CACHE}/$n.rc"
+            body=$(printf '%s' "$elem" | jq -r '.body // ""' | tr -d '\r')
+            marker=$(extract_marker "$body")
+            if printf '%s' "$marker" | jq -e \
+                 'type == "object" and .status == "frozen" and (.members | type == "array") and (.members | length > 0)' \
+                 >/dev/null 2>&1; then
+              CLAIM_EPICS="${CLAIM_EPICS}${n}"$'\n'
+              added=$((added + 1))
+            fi
+          done 4< <(printf '%s' "$nodes" | jq -r '.[] | select(has("pull_request") | not) | .number' 2>/dev/null)
+          echo "Claim index: ${total} open issue(s) in ${ORG}/${PLANNING_REPO}, ${added} carrying a frozen snapshot." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+        }
+
         # Read an Epic's frozen activation-snapshot members and bucket them by their live state. Once
         # landing stabilizes, merge-gate captures the member set into a marker in the Epic body. That set
         # is what the live label search cannot reconstruct: GitHub indexes no "ever carried label X", so
@@ -537,9 +609,6 @@ runs:
         # membership readers select on `status` and `members` alone, so a marker carrying it resolves
         # there exactly as one without.
         snapshot_buckets() { # $1 = epic number
-          # The fence strings, matched as whole lines — the same match merge-gate's splice uses, so a
-          # pseudo-fence planted inside an HTML comment cannot shadow the real region.
-          local START_M='<!-- epic-membership:snapshot:start -->' END_M='<!-- epic-membership:snapshot:end -->'
           SNAP_MERGED='[]'
           SNAP_CLOSED='[]'
           SNAP_OPEN='[]'
@@ -563,15 +632,9 @@ runs:
           # as "no snapshot".
           body=$(printf '%s' "$resp" | jq -r '.body // ""' | tr -d '\r')
 
-          # The fenced region holds a human-readable note and then the JSON, so skip to the first line
-          # that opens a value before parsing: the note is not JSON, and the JSON may be pretty-printed
-          # across several lines. `-s .[0]` takes the first value if a hand-edit left several; trailing
-          # prose inside the region voids the whole marker, which fails safe. All three participants
-          # extract identically — see the contract note above.
-          marker=$(printf '%s\n' "$body" \
-            | awk -v s="$START_M" -v e="$END_M" '$0 == s {f=1;next} $0 == e {f=0} f' \
-            | sed -n '/^[[:space:]]*[{[]/,$p' \
-            | jq -s -c '.[0] // empty' 2>/dev/null || true)
+          # The fenced region holds a human-readable note and then the JSON. extract_marker skips the
+          # note to the first value and voids the marker if trailing prose follows, which fails safe.
+          marker=$(extract_marker "$body")
 
           # The wave boundary, read from any well-formed marker whatever its `status`, and read ahead of
           # the frozen-only returns below because the paths that report no frozen set need it most. A
@@ -1126,7 +1189,7 @@ runs:
           # Blast-cap tripwire: set true by sweep_post_freeze when an Epic's freeze exceeds
           # max_freeze_repos. Checked at the end, so the whole sweep run ends red.
           blast_cap_tripped=false
-          echo "Enumerating active Epics (distinct epic:<N> labels on open PRs, org=${ORG})…" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Enumerating active Epics (epic:<N> labels on open PRs ∪ frozen snapshots, org=${ORG})…" | tee -a "$GITHUB_STEP_SUMMARY"
           if ! all_open=$(search_prs "org:${ORG} is:pr is:open"); then
             echo "::error::could not enumerate open PRs (GraphQL search failed after retries) — nothing done this sweep"
             exit 1
@@ -1134,10 +1197,17 @@ runs:
 
           # Distinct Epic numbers from the `epic:<N>` labels; the jq `test` is the injection guard, the
           # per-Epic loop re-checks numeric-ness.
-          local epics
-          epics=$(printf '%s' "$all_open" | jq -r '
+          local label_epics epics
+          label_epics=$(printf '%s' "$all_open" | jq -r '
             [ .[] | (.labels.nodes // [])[].name | select(test("^epic:[0-9]+$")) | ltrimstr("epic:") ]
             | unique | .[]')
+
+          # Union with Epics reached through their own frozen snapshot, so an Epic whose last labeled
+          # open pull request was de-labeled is still evaluated. build_claim_index also primes the
+          # per-issue cache the loop below reads from. The union only widens the set; the per-Epic loop
+          # re-validates each token as numeric.
+          build_claim_index
+          epics=$(printf '%s\n%s\n' "$label_epics" "$CLAIM_EPICS" | grep -E '^[0-9]+$' | sort -un || true)
 
           # Backstop first, so the epic pass posts last and wins on a head both touch, flipping a
           # contested head to fail-closed. Two things contest a head: a lagging label index, and a
@@ -1164,7 +1234,7 @@ runs:
               sweep_epic "$EPIC" || echo "::warning::epic #$EPIC aborted unexpectedly (fail-closed); next sweep re-derives"
             done 3< <(printf '%s\n' "$epics")
           else
-            echo "No active Epics (no open epic:<N> PRs)." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "No active Epics (no open epic:<N> PRs and no frozen snapshot)." | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "Partial-landing sweep complete." | tee -a "$GITHUB_STEP_SUMMARY"

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -30,7 +30,7 @@ extract() { # $1 = function name — lift it out of the run: block and de-indent
   ' "$ACTION" | sed 's/^        //'
 }
 
-for fn in epic_issue epic_paused snapshot_buckets union_buckets evaluate_epic; do
+for fn in extract_marker epic_issue epic_paused build_claim_index snapshot_buckets union_buckets evaluate_epic; do
   out=$(extract "$fn")
   if [ -z "$out" ]; then
     echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
@@ -71,6 +71,12 @@ gh() {
       fi
       [ "$FX_REHYDRATE" = "FAIL" ] && { echo "gh: Bad credentials" >&2; return 1; }
       printf '%s' "$FX_REHYDRATE" ;;
+    *"issues?state=open"*)
+      # The claim-index list. FX_ISSUE_LIST is a JSON array of issue objects the endpoint would return
+      # (each {number, body, labels?} plus {pull_request:{}} on a PR row). Ordered before the
+      # single-issue branch below, which its glob would otherwise also match.
+      [ "$FX_ISSUE_LIST" = FAIL ] && { echo "gh: HTTP 502" >&2; return 1; }
+      printf '%s' "${FX_ISSUE_LIST:-[]}" ;;
     *issues*)
       case "$FX_BODY" in
         FAIL404) echo "gh: Not Found (HTTP 404)" >&2; return 1 ;;
@@ -207,6 +213,9 @@ reset_fixtures() {
   FX_BODY=""
   # One response carries both the pause marker and the snapshot, so the fixture carries both.
   FX_LABELS='[]'
+  # The planning repo's open-issue list the claim index reads. Default empty so the per-Epic
+  # assertions, which drive evaluate_epic directly, see no claim additions.
+  FX_ISSUE_LIST='[]'
   FX_REHYDRATE=""
   printf 0 > "$WORK/rehydrate_fails"
   : > "$WORK/gh_calls"
@@ -838,6 +847,90 @@ epic_cache_clear
 epic_paused 900 && rc=0 || rc=$?
 eq "a label merely containing it is not a pause" "$rc" 1
 
+echo
+echo "the claim index reaches Epics through their own frozen snapshot"
+# The sweep otherwise finds active Epics only through epic:<N> labels on open pull requests, so an
+# Epic whose last labeled open pull request was de-labeled would vanish from enumeration. The claim
+# index lists the planning repo's open issues directly and returns the ones carrying a frozen marker.
+issue_obj() { jq -cn --argjson n "$1" --arg b "$2" '{number:$n, body:$b, labels:[]}'; }
+pr_obj() { jq -cn --argjson n "$1" '{number:$n, body:"", pull_request:{url:"x"}}'; }
+claim_of() { CLAIM_EPICS=''; epic_cache_clear; build_claim_index >/dev/null 2>&1; printf '%s' "$CLAIM_EPICS" | grep -c '^[0-9]' | tr -d ' '; }
+claims() { printf '%s' "$CLAIM_EPICS" | grep -E '^[0-9]+$' | sort -n | paste -sd, -; }
+
+# A PR row carrying a frozen-marker body would be claimed if the pull-request filter were dropped, so
+# the fixture makes the skip observable rather than incidental to an empty body.
+reset_fixtures
+FX_ISSUE_LIST=$(jq -cs '.' <<EOF
+$(issue_obj 700 "$(marker frozen "$BC")")
+$(issue_obj 701 "$(marker pending "$BC")")
+$(issue_obj 702 "$(marker retired '[]' "$AGO20")")
+$(issue_obj 703 "No marker here at all.")
+$(issue_obj 705 "$(marker frozen '[]')")
+$(jq -cn --argjson n 704 --arg b "$(marker frozen "$BC")" '{number:$n, body:$b, pull_request:{url:"x"}}')
+EOF
+)
+epic_cache_clear; build_claim_index >/dev/null 2>&1
+eq "a frozen snapshot is claimed" "$(claims)" 700
+grep -qx 701 <<< "$CLAIM_EPICS" && ko "a pending marker was claimed" || ok "a pending marker is not claimed (not authoritative yet)"
+grep -qx 702 <<< "$CLAIM_EPICS" && ko "a retired tombstone was claimed" || ok "a retired tombstone is not claimed (names no members)"
+grep -qx 703 <<< "$CLAIM_EPICS" && ko "an unmarked issue was claimed" || ok "an unmarked issue is not claimed"
+grep -qx 705 <<< "$CLAIM_EPICS" && ko "a frozen marker with no members was claimed" || ok "a frozen marker with an empty member set is not claimed"
+grep -qx 704 <<< "$CLAIM_EPICS" && ko "a pull request row was claimed" || ok "a pull request row is skipped even carrying a frozen body"
+
+echo
+echo "the claim index primes the per-issue cache"
+# It reads every open issue once; a later snapshot read of the same number must resolve from that
+# primed body, not spend a second request. The single-issue stub is armed with a DIFFERENT body, so a
+# read that reached the network would resolve the wrong set and the assertion would catch it.
+reset_fixtures
+FX_ISSUE_LIST=$(jq -cs '.' <<EOF
+$(issue_obj 700 "$(marker frozen "$BC")")
+EOF
+)
+# The single-issue stub is armed with a MARKERLESS body, so a read that reached the network would
+# find no frozen set and return 2 without ever attempting the member re-read. The primed body carries
+# a frozen marker, so snapshot_buckets attempts that re-read (a graphql call) — which is how the two
+# sources are told apart without arming the full rehydrate fixture.
+FX_BODY="No marker — this is the network answer, which priming must make unreachable."
+epic_cache_clear; build_claim_index >/dev/null 2>&1
+: > "$WORK/gh_calls"
+snapshot_buckets 700 >/dev/null 2>&1
+eq "no issue read was made after priming" "$(grep -c 'issues/700' "$WORK/gh_calls" | tr -d ' ')" 0
+[ "$(grep -c graphql "$WORK/gh_calls")" -gt 0 ] \
+  && ok "and the primed frozen marker drove a member re-read (the markerless network body would not)" \
+  || ko "no member re-read attempted — the markerless network body was used, not the primed one"
+grep -qx 700 <<< "$CLAIM_EPICS" && ok "and the primed frozen Epic is claimed" || ko "the frozen Epic was not claimed"
+
+echo
+echo "the claim index fails soft"
+# The claim set is unioned with the label set and only ever widens it, so a list failure must cost the
+# de-label rescue for one pass and never abort the sweep or narrow what labels already reach.
+reset_fixtures
+FX_ISSUE_LIST=FAIL
+CLAIM_EPICS='sentinel'
+build_claim_index >/dev/null 2>&1 && rc=0 || rc=$?
+eq "a list failure returns success (soft)" "$rc" 0
+eq "and claims nothing" "$(printf '%s' "$CLAIM_EPICS" | grep -c '^[0-9]' | tr -d ' ')" 0
+
+echo
+echo "extract_marker reads a marker, or nothing"
+# The one reader both the claim index and snapshot_buckets ask "is there a marker" through. A body
+# with no fences must yield empty, not a placeholder that later parses as present.
+eq "a frozen body yields its marker object" \
+  "$(extract_marker "$(marker frozen "$BC")" | jq -r '.status')" frozen
+eq "a body with no fences yields nothing" "$(extract_marker "just prose, no fences")" ""
+
+echo
+echo "enumeration is the union of labels and claims"
+# The exact line sweep_main runs, lifted from the manifest rather than restated, so a claim-derived and
+# a label-derived Epic both appear once and dropping the union is observable here.
+UNION_LINE=$(awk '/epics=\$\(printf .* "\$label_epics" "\$CLAIM_EPICS"/{sub(/^[[:space:]]*/,""); print; exit}' "$ACTION")
+[ -n "$UNION_LINE" ] || { echo "::error::could not read the enumeration union from $ACTION"; exit 1; }
+union() { local label_epics="$1" CLAIM_EPICS="$2" epics; eval "$UNION_LINE"; printf '%s' "$epics" | paste -sd, -; }
+eq "a claim-only Epic joins the label set" "$(union "$(printf '810\n')" "$(printf '700\n')")" 700,810
+eq "an Epic reached both ways appears once" "$(union "$(printf '700\n')" "$(printf '700\n')")" 700
+eq "a non-numeric token is dropped" "$(union "$(printf '700\nfoo\n')" "")" 700
+
 printf '%d passed, %d failed\n' "$pass" "$fail"
 # A floor on the count as well as on failures: a suite that runs no assertions exits 0 and reads as
 # green. Raise this when assertions are added; never lower it to make a run pass.
@@ -849,7 +942,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -lt 139 ]; then
-  echo "::error::only $ran assertion(s) ran (expected at least 139) — the suite did not execute fully"
+if [ "$ran" -lt 155 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 155) — the suite did not execute fully"
   exit 1
 fi


### PR DESCRIPTION
Closes #319. First Task of #360 (label-independent Epic membership).

## The hole

The sweep enumerates active Epics from `epic:<N>` labels on **open** pull requests. A merged member keeps its label, so a partially-landed Epic usually stays reachable through a sibling — but if the *last* open labeled pull request is de-labeled, the Epic drops out of enumeration entirely, and its partial landing is never evaluated. The activation snapshot rescued a forgotten *member*; nothing rescued a forgotten *Epic*.

## The fix

`build_claim_index` lists the planning repo's open issues once and returns the numbers carrying a frozen marker. `sweep_main` unions that with the label-derived set:

```
epics = (epic:<N> labels on open PRs)  ∪  (open planning issues with a frozen snapshot)
```

The union **only widens** — no snapshot, however degraded, shrinks what labels already reach, so this cannot introduce a false clear.

## Why direct listing, not `in:body` search

The design's load-bearing choice, and it's backed by the prior-art research on #360:

- GitHub tokenizes punctuation as delimiters, so a marker query (`"epic-membership:snapshot:start"`) is approximate and collides with prose.
- Prow's maintainers document a live GitHub bug where the search index *"becomes corrupted and the search API will have some incorrect belief about the affected PR, e.g. that it is missing a required label"* — it has silently omitted correctly-matching items for Kubernetes, OpenShift and Jetstack.

A rescue built on search would import the exact silent-omission failure it exists to remove. Direct listing is exact, and over the planning repo's handful of open issues it's one call.

## Efficiency: one read of the planning repo per sweep

The index **primes `epic_issue`'s per-pass cache** (added in #323) with every issue it read, so an enumerated Epic whose issue is open is never re-fetched by the downstream pause or snapshot reads. Net: the whole sweep now reads the planning repo in a single paginated list.

## Correctness seams

- **One marker reader.** The fence extraction `snapshot_buckets` did inline is factored into `extract_marker`, shared by both — so the claim index cannot reach an Epic `snapshot_buckets` then refuses to parse, or vice versa.
- **Looser on purpose.** Enumeration accepts any frozen marker with a non-empty member array; `snapshot_buckets` applies the strict per-member validation. Over-reaching evaluates an Epic that resolves to nothing — a no-op clear with no member head to post on. Under-reaching is the bug.
- **Fails soft.** A list error logs a warning and returns the label set unchanged; the sweep is never aborted by it.

## Tests: 139 → 155

Both new functions are extracted from the manifest and driven directly; the enumeration union is **lifted from the manifest line**, not restated, so dropping it is observable. Mutants, all previously green:

| Mutant | Result |
| --- | --- |
| claim accepts a pending marker | 2 failed |
| claim accepts an empty member array | 2 failed |
| claim does not skip PR rows (frozen-body PR fixture) | 2 failed |
| claim primes only rc, not the body | 1 failed |
| list failure aborts instead of failing soft | 1 failed |
| enumeration drops the claim union | suite aborts (extraction guard) |
| extract_marker returns a placeholder not empty | 1 failed |
| union stops filtering non-numeric tokens | 1 failed |

All eight suites green; prettier and `lint-action-manifests` clean.

## Next in #360

- #325 (per-PR mode consults the claim index) — **blocked by this**, since it reuses `build_claim_index`.
- #329 (head SHAs + wave-boundary corroboration) — independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)