### PR TITLE
fix(detect-partial-landing): per-PR mode consults the claim index before passing standalone

### DIFF
--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -551,6 +551,10 @@ runs:
         # evaluates as a no-op clear with no member head to post on); under-reaching is the bug.
         build_claim_index() { # no args
           CLAIM_EPICS=''
+          # The reverse index: which frozen Epic claims a given member. Read by epic_claiming so a
+          # de-labeled pull request is still recognised as a member without a live label. Repos are
+          # case-folded to match GitHub's case-insensitive resolution, as the writer stores them.
+          CLAIM_MEMBERS='[]'
           local pages nodes n elem body marker total=0 added=0
           if ! pages=$(gh api --paginate "repos/${ORG}/${PLANNING_REPO}/issues?state=open&per_page=100" 2>/dev/null); then
             echo "::warning::could not list open issues in ${ORG}/${PLANNING_REPO} — reaching Epics through live labels only this pass; a de-labeled Epic is not rescued." \
@@ -579,10 +583,28 @@ runs:
                  >/dev/null 2>&1; then
               CLAIM_EPICS="${CLAIM_EPICS}${n}"$'\n'
               added=$((added + 1))
+              # Fold this Epic's well-formed members into the reverse index. A member missing a string
+              # repo or numeric number is skipped: it can match no real pull request, so it belongs in
+              # neither direction. The Epic number is the trusted issue number, never body content.
+              CLAIM_MEMBERS=$(jq -c -n --argjson idx "$CLAIM_MEMBERS" --argjson epic "$n" \
+                --argjson members "$(printf '%s' "$marker" | jq -c '.members')" '
+                $idx + [ $members[]
+                  | select((.repo | type) == "string" and (.number | type) == "number")
+                  | {epic: $epic, repo: (.repo | ascii_downcase), number} ]' 2>/dev/null || printf '%s' "$CLAIM_MEMBERS")
             fi
           done 4< <(printf '%s' "$nodes" | jq -r '.[] | select(has("pull_request") | not) | .number' 2>/dev/null)
           echo "Claim index: ${total} open issue(s) in ${ORG}/${PLANNING_REPO}, ${added} carrying a frozen snapshot." \
             | tee -a "$GITHUB_STEP_SUMMARY"
+        }
+
+        # The Epic whose frozen snapshot claims a given pull request, or empty. Answers "which Epic
+        # claims this pull request" without a live label, from the reverse index build_claim_index
+        # filled. The repo is case-folded to match how the index stores it. First match wins; a pull
+        # request is a member of at most one Epic, and a marker naming it twice is a writer bug the
+        # freeze it produces is harmless against.
+        epic_claiming() { # $1 = owner/repo  $2 = pull request number
+          printf '%s' "${CLAIM_MEMBERS:-[]}" | jq -r --arg r "$1" --argjson n "$2" \
+            'map(select(.repo == ($r | ascii_downcase) and .number == $n))[0].epic // empty' 2>/dev/null || true
         }
 
         # Read an Epic's frozen activation-snapshot members and bucket them by their live state. Once
@@ -1302,10 +1324,26 @@ runs:
           epic=$(printf '%s' "$labels" | jq -r 'map(select(test("^epic:[0-9]+$")))[0] // empty' | grep -oE '[0-9]+' || true)
 
           if [ -z "$epic" ]; then
-            # Standalone fast-path → success.
-            freeze_post "$REPO_FULL" "$HEAD_SHA" "success" \
-              "PR #${classify_pr} has no epic:<N> label — standalone, no partial-landing coordination. epic-freeze clear."
-            return 0
+            # No label — but a frozen snapshot may still claim this pull request as a member whose label
+            # was removed mid-landing. The sweep already resolves membership as labels ∪ frozen set and
+            # holds such a member; per-PR mode classified by label alone, so a non-head-changing event
+            # (a review, a ready_for_review, the unlabel itself) reran this path and posted success on a
+            # head the sweep had frozen — green until the next sweep, ≤15 minutes. Consulting the claim
+            # index closes that window.
+            #
+            # Fail open, like every other uncertainty on this path: a claim-index error posts standalone
+            # success, because merge-gate holds the member independently and the sweep re-derives. Only a
+            # pull request the index positively claims is treated as a member; an ordinary pull request
+            # is never in any frozen set, so the flood still passes without a per-Epic evaluation.
+            build_claim_index >/dev/null 2>&1 || true
+            epic=$(epic_claiming "$REPO_FULL" "$classify_pr")
+            if [ -z "$epic" ]; then
+              freeze_post "$REPO_FULL" "$HEAD_SHA" "success" \
+                "PR #${classify_pr} has no epic:<N> label and no frozen snapshot claims it — standalone, no partial-landing coordination. epic-freeze clear."
+              return 0
+            fi
+            echo "PR #${classify_pr} carries no label but Epic #${epic}'s frozen snapshot claims it (de-labeled mid-landing) — evaluating for a partial landing." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
           # Per-Epic pause: `automation:paused` on the Epic issue leaves partial-landing unevaluated.

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -30,7 +30,7 @@ extract() { # $1 = function name — lift it out of the run: block and de-indent
   ' "$ACTION" | sed 's/^        //'
 }
 
-for fn in extract_marker epic_issue epic_paused build_claim_index snapshot_buckets union_buckets evaluate_epic; do
+for fn in extract_marker epic_issue epic_paused build_claim_index epic_claiming snapshot_buckets union_buckets evaluate_epic per_pr_main; do
   out=$(extract "$fn")
   if [ -z "$out" ]; then
     echo "::error::could not extract $fn from $ACTION — did its definition move or change indent?"
@@ -921,6 +921,89 @@ eq "a frozen body yields its marker object" \
 eq "a body with no fences yields nothing" "$(extract_marker "just prose, no fences")" ""
 
 echo
+echo "the reverse index answers which Epic claims a pull request"
+# build_claim_index also fills CLAIM_MEMBERS, so a de-labeled member can be recognised without a live
+# label. epic_claiming reads it, case-folding the repo the way the writer stores it.
+reset_fixtures
+FX_ISSUE_LIST=$(jq -cs '.' <<EOF
+$(issue_obj 700 "$(marker frozen "$BC")")
+$(issue_obj 701 "$(marker pending "$BC")")
+EOF
+)
+epic_cache_clear; build_claim_index >/dev/null 2>&1
+eq "a frozen member resolves to its Epic" "$(epic_claiming a-novel-kit/repo-b 2)" 700
+eq "the repo match is case-insensitive" "$(epic_claiming A-Novel-Kit/Repo-C 3)" 700
+eq "a pull request in no frozen set resolves to nothing" "$(epic_claiming a-novel-kit/repo-z 9)" ""
+# The right repo but the wrong number is not a member; matching on repo alone would claim it wrongly.
+eq "the same repo at a number not in the set is not claimed" "$(epic_claiming a-novel-kit/repo-b 999)" ""
+# repo-b#2 sits in 700's FROZEN marker and 701's PENDING one; only the frozen claim is indexed.
+eq "a pending marker's members are not indexed" \
+  "$(printf '%s' "$CLAIM_MEMBERS" | jq -r 'map(select(.repo=="a-novel-kit/repo-b" and .number==2)) | length')" 1
+
+# A malformed member must not void the whole Epic's index nor crash it; the good sibling still indexes.
+reset_fixtures
+FX_ISSUE_LIST=$(jq -cs '.' <<EOF
+$(issue_obj 720 "$(marker frozen '[{"repo":"a-novel-kit/repo-a","number":1},{"number":5}]')")
+EOF
+)
+epic_cache_clear; build_claim_index >/dev/null 2>&1
+eq "a good member alongside a malformed one is still indexed" "$(epic_claiming a-novel-kit/repo-a 1)" 720
+eq "and the malformed member contributes nothing" \
+  "$(printf '%s' "$CLAIM_MEMBERS" | jq 'length')" 1
+
+echo
+echo "per-PR mode consults the claim index before passing standalone"
+# The #325 bug: a member de-labeled mid-landing takes the label-only standalone fast path and greens a
+# head the sweep froze. per_pr_main now asks the claim index first.
+# Stubs for the per-PR leaves. evaluate_epic is controlled so the test pins the branch taken, not the
+# Epic's real state; freeze_post records what was posted.
+freeze_post() { printf '%s\n' "$3|$4" >> "$WORK/posts"; }   # $1=repo $2=sha $3=conclusion $4=summary
+fetch_pr_labels() { [ "$FX_LABELS_FAIL" = true ] && return 1; printf '%s' "${FX_FETCH_LABELS:-[]}"; }
+evaluate_epic() { EV_DECISION="$FX_EV"; EV_MERGED_COUNT=1; EV_CLOSED_COUNT=1; EV_STRAY_COUNT=1; EV_OPEN_COUNT=0; }
+posted() { tail -1 "$WORK/posts" 2>/dev/null; }
+run_per_pr() { : > "$WORK/posts"; epic_cache_clear; per_pr_main >/dev/null 2>&1; }
+
+# A native pull_request event for repo-b#2, which carries NO label but sits in Epic 700's frozen set.
+setup_per_pr() {
+  export HEAD_SHA=deadbeef REPO_FULL=a-novel-kit/repo-b PR_NUMBER=2 EVENT_PR=2 EVENT_LABELS='[]'
+  unset IN_QUEUE MG_HEAD_REF
+  FX_EV=frozen
+  FX_ISSUE_LIST=$(jq -cs '.' <<EOF
+$(issue_obj 700 "$(marker frozen "$BC")")
+EOF
+)
+}
+
+reset_fixtures; setup_per_pr
+run_per_pr
+# Evaluated as a member: the post concerns Epic 700, never the standalone message. FX_EV=frozen, so
+# per_pr_main's frozen branch fired rather than the label-only fast path.
+printf '%s' "$(posted)" | grep -q 'standalone' \
+  && ko "a claimed unlabeled PR was passed standalone (the #325 bug)" \
+  || ok "a claimed unlabeled PR is evaluated as a member, not passed standalone"
+printf '%s' "$(posted)" | grep -q '700' && ok "and the post names the claiming Epic" || ko "the claiming Epic was not evaluated"
+
+reset_fixtures; setup_per_pr
+FX_ISSUE_LIST='[]'   # nothing claims it
+run_per_pr
+printf '%s' "$(posted)" | grep -q 'standalone' && ok "a genuinely unclaimed PR still passes standalone" || ko "an unclaimed PR was frozen"
+printf '%s' "$(posted)" | grep -q '^success' && ok "with a success conclusion" || ko "an unclaimed PR did not pass"
+
+reset_fixtures; setup_per_pr
+FX_ISSUE_LIST=FAIL   # the claim lookup errors
+run_per_pr
+printf '%s' "$(posted)" | grep -q '^success' && ok "a claim-index failure fails open (success)" || ko "a claim-index error froze the PR instead of failing open"
+
+reset_fixtures; setup_per_pr
+EVENT_LABELS='[{"name":"epic:700"}]'   # a LABELED member still takes the label path
+FX_EV=clear
+run_per_pr
+printf '%s' "$(posted)" | grep -q '^success' && ok "a labeled member still routes through the label path" || ko "the label path regressed"
+unset HEAD_SHA REPO_FULL PR_NUMBER EVENT_PR EVENT_LABELS
+# Restore the real evaluate_epic wrapper for any later assertions.
+evaluate_epic() { epic_cache_clear; uncached_evaluate_epic "$@"; }
+
+echo
 echo "enumeration is the union of labels and claims"
 # The exact line sweep_main runs, lifted from the manifest rather than restated, so a claim-derived and
 # a label-derived Epic both appear once and dropping the union is observable here.
@@ -942,7 +1025,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -lt 155 ]; then
-  echo "::error::only $ran assertion(s) ran (expected at least 155) — the suite did not execute fully"
+if [ "$ran" -lt 168 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 168) — the suite did not execute fully"
   exit 1
 fi


### PR DESCRIPTION
Closes #325. Second Task of #360, building on #364 (the claim index).

## The bug

The sweep resolves membership as **live labels ∪ frozen set**, so a member de-labeled mid-landing stays a member and gets `epic-freeze=failure` on its head. **Per-PR mode did not** — `per_pr_main` classified by label alone, so a pull request with no `epic:<N>` label took the standalone fast path and posted **success** on the same head.

The sequence that lands a member out of a frozen Epic:

1. The sweep posts `failure` on a de-labeled-but-open member's head. Correct.
2. A `pull_request` / `pull_request_review` event that does not change the head SHA — a review, `ready_for_review`, the `unlabeled` itself — reruns per-PR mode, which posts **`success`** on that same SHA.
3. Latest check-run of a name wins, so the member is green until the next sweep (≤15 min) — long enough for auto-merge armed before the de-label to merge it.

## The fix

`build_claim_index` (from #364) now also fills a **reverse index** — which frozen Epic claims a given member — and `epic_claiming` reads it. `per_pr_main`'s no-label branch consults it before passing standalone:

- a pull request the frozen set **claims** is evaluated as a member (pause check + `evaluate_epic`, posting on its head);
- a genuinely **unclaimed** one passes standalone, as before.

This is Tide's rule from the #360 research — the frozen record is authority, and a conflict between it and live labels resolves toward the record.

## Why it is safe on the common path

- **Fails open.** A claim-index error posts standalone success, exactly as a label-read error already does, because merge-gate holds the member independently and the sweep re-derives. A planning-repo blip never freezes an ordinary pull request.
- **Only positive claims freeze.** An ordinary pull request is in no frozen set, so the flood still passes without a per-Epic evaluation. The added cost on the no-label path is one planning-repo list call, and only when a frozen snapshot exists to match against.

## Reverse-index correctness

- Case-folds the repo as the writer stores it.
- Keys on repo **and** number — the same repo at a number outside the set is not claimed.
- Skips a malformed member, so it matches no real pull request and does not void its Epic's index (a good member alongside a malformed sibling still resolves).

## Tests: 155 → 168

`per_pr_main` was previously **undriven** by the suite. It now stubs the per-PR leaves (`freeze_post`, `fetch_pr_labels`, a controlled `evaluate_epic`) and drives the function directly. Mutants, all previously green:

| Mutant | Result |
| --- | --- |
| per-PR skips the claim lookup (the bug) | 2 failed |
| epic_claiming ignores the number | 1 failed |
| epic_claiming does not case-fold the repo | 1 failed |
| reverse index indexes pending members too | 3 failed |
| reverse index keeps malformed members | 2 failed |

All eight suites green; prettier and `lint-action-manifests` clean.

## Remaining in #360

- **#329** (head SHAs + wave-boundary corroboration) — independent, last Task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)