### PR TITLE
fix(detect-partial-landing): scope timeline corroboration to the current wave

### DIFF
--- a/generic-actions/detect-partial-landing/action.yaml
+++ b/generic-actions/detect-partial-landing/action.yaml
@@ -729,7 +729,7 @@ runs:
               "m\(.key): repository(owner:\"\(.value.repo|split("/")[0])\", name:\"\(.value.repo|split("/")[1])\")"
               + "{pullRequest(number:\(.value.number|floor)){number headRefOid mergedAt baseRefName isDraft state repository{nameWithOwner}"
               + " labels(first:100){nodes{name}}"
-              + " timelineItems(last:250, itemTypes:[LABELED_EVENT]){nodes{... on LabeledEvent{label{name}}}}}}"
+              + " timelineItems(last:250, itemTypes:[LABELED_EVENT]){nodes{... on LabeledEvent{label{name} createdAt}}}}}"
             ) | join("\n")')
           rh=""
           for attempt in 1 2 3; do
@@ -763,14 +763,26 @@ runs:
           # Dropping the failing member alone leaves an attacker-chosen subset, and the live floor is the
           # blind spot the snapshot exists to cover; a `clear` from either posts success, lifting a
           # standing freeze and letting the partial landing finish.
+          #
+          # The timeline evidence is scoped to THIS wave. A merged pull request keeps its label and its
+          # LabeledEvent for good, so an un-scoped timeline proves only "ever carried `epic:<N>`" — a pull
+          # request from a completed earlier wave under the same Epic would corroborate forever and re-enter
+          # this wave's membership. The label event must therefore land at or after the wave boundary the
+          # marker carries (SNAP_SINCE). A still-present label is not scoped: it is membership now, not
+          # historical evidence of it. With no boundary — the Epic's first wave — the whole history is one
+          # wave and every event counts, which is the pre-boundary behavior. A member labeled and unlabeled
+          # inside this wave still corroborates: bounding to who may label is a permission read this does
+          # not make, since planning-repo write is the trust boundary and already lets that author name any
+          # member directly.
           local unverified
-          unverified=$(printf '%s' "$rh" | jq -r --arg lbl "epic:$1" '
+          unverified=$(printf '%s' "$rh" | jq -r --arg lbl "epic:$1" --arg since "${SNAP_SINCE:-}" '
             [ (.data // {}) | to_entries[] | .value.pullRequest | select(. != null)
               | select((([(.labels.nodes // [])[].name]
-                  + [(.timelineItems.nodes // [])[] | .label.name // empty]) | index($lbl)) | not)
+                  + [(.timelineItems.nodes // [])[]
+                       | select($since == "" or (.createdAt // "") >= $since) | .label.name // empty]) | index($lbl)) | not)
               | "\(.repository.nameWithOwner)#\(.number)" ] | join(", ")' 2>/dev/null || printf 'PARSE_FAILURE')
           if [ -n "$unverified" ]; then
-            echo "::error::epic #$1: the activation snapshot names pull request(s) that never carried the \`epic:$1\` label (${unverified}) — refusing to decide anything for this Epic until it is corrected. Check who edited ${ORG}/${PLANNING_REPO}#$1."
+            echo "::error::epic #$1: the activation snapshot names pull request(s) not labeled \`epic:$1\` during this wave (${unverified}) — refusing to decide anything for this Epic until it is corrected. Check who edited ${ORG}/${PLANNING_REPO}#$1."
             return 1
           fi
 

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -153,18 +153,22 @@ evaluate_epic() { epic_cache_clear; uncached_evaluate_epic "$@"; }
 #   timeline = de-labeled now, but its timeline records having been labeled (the regression case)
 #   label    = still carries the label
 #   none     = neither — a pull request named by the marker that was never a member
-node() { # repo number state [terminalAt] [prov: timeline|label|none]
+node() { # repo number state [terminalAt] [prov: timeline|label|none] [labelAt]
   # `terminalAt` is when the pull request reached its terminal state: it fills `mergedAt` for a MERGED
   # one and `closedAt` otherwise, which is how GitHub reports them (a merged PR carries both, equal).
   # `closedAt` sits outside the action's search-node shape and the action never reads it; it is there
   # so the stub above can apply a `closed:>=` floor, which the real search applies server-side.
-  jq -cn --arg r "$1" --argjson n "$2" --arg s "$3" --arg m "${4:-}" --arg p "${5:-timeline}" --arg e "epic:900" \
+  # `labelAt` is the LabeledEvent's createdAt, defaulting to AGO5 — recent, so a timeline-proven member
+  # reads as labeled during the current wave under the boundary floor. A previous-wave member is given
+  # an older labelAt explicitly.
+  jq -cn --arg r "$1" --argjson n "$2" --arg s "$3" --arg m "${4:-}" --arg p "${5:-timeline}" \
+    --arg la "${6:-$AGO5}" --arg e "epic:900" \
     '{number:$n, headRefOid:("sha"+($n|tostring)),
       mergedAt:(if $m=="" or $s!="MERGED" then null else $m end),
       closedAt:(if $m=="" or $s=="OPEN" then null else $m end),
       baseRefName:"master", isDraft:false, state:$s, repository:{nameWithOwner:$r},
       labels:{nodes:(if $p=="label" then [{name:$e}] else [] end)},
-      timelineItems:{nodes:(if $p=="timeline" then [{label:{name:$e}}] else [] end)}}'
+      timelineItems:{nodes:(if $p=="timeline" then [{label:{name:$e}, createdAt:$la}] else [] end)}}'
 }
 rehydrate() { # the aliased re-read response, one alias per member
   jq -s -c '{data: ([.[] | {pullRequest: .}] | to_entries
@@ -325,6 +329,53 @@ check "a de-labeled member is corroborated by its timeline" frozen live+snapshot
 FX_REST=$(printf '%s' "$FX_REST" | jq -c '. + {"a-novel-kit/repo-b-renamed#2":"closed false"}')
 FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b-renamed 2 CLOSED)" "$C")
 check "a member whose repository was renamed still resolves" frozen live+snapshot 1/1/1
+
+echo
+echo "timeline corroboration is scoped to the current wave"
+# The #329 fix. A merged pull request keeps its label and its LabeledEvent for good, so an un-scoped
+# timeline proves only "ever carried epic:<N>". A member whose label event predates the wave boundary
+# belongs to a retired wave and must not corroborate for this one; a timeline event at or after the
+# boundary is this wave's evidence.
+reset_fixtures
+FX_BODY=$(marker frozen "$BC" "$AGO20")
+# repo-b#2: de-labeled, its only LabeledEvent at AGO40 — before the AGO20 boundary (a previous wave).
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 CLOSED "$AGO40" timeline "$AGO40")" "$C")
+check "a member labeled only before the boundary does not corroborate" error
+reset_fixtures
+FX_BODY=$(marker frozen "$BC" "$AGO20")
+# Same member, LabeledEvent at AGO5 — after the boundary, this wave's evidence. It corroborates
+# (membership resolves to live+snapshot, not the error a failed corroboration leaves); the decision is
+# clear only because the sole live-merged member sits before the boundary and is scoped out.
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 CLOSED "$AGO5" timeline "$AGO5")" "$C")
+check "a member labeled after the boundary corroborates" clear live+snapshot 0/1/1
+reset_fixtures
+FX_BODY=$(marker frozen "$BC" "$AGO20")
+# A present label is membership now, not historical evidence, so the boundary never floors it out even
+# with an old label event.
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 CLOSED "$AGO40" label "$AGO40")" "$C")
+check "a member still carrying the label corroborates despite the boundary" clear live+snapshot 0/1/1
+reset_fixtures
+FX_BODY=$(marker frozen "$BC" "$AGO20")
+# A label event exactly at the boundary belongs to the new wave: the floor is inclusive (>=).
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 CLOSED "$AGO20" timeline "$AGO20")" "$C")
+check "a label event exactly at the boundary corroborates" clear live+snapshot 0/1/1
+reset_fixtures
+# With no boundary — the Epic's first wave — the whole history is one wave and an old event still counts.
+FX_BODY=$(marker frozen "$BC")
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 CLOSED "$AGO40" timeline "$AGO40")" "$C")
+check "with no boundary an old timeline event still corroborates" frozen live+snapshot 1/1/1
+reset_fixtures
+# The scoping is only real if the query fetches the event time. Assert the re-read document asks for it,
+# since the stub supplies createdAt regardless of what the query requested.
+FX_BODY=$(marker frozen "$BC" "$AGO20")
+FX_REHYDRATE=$(rehydrate "$B" "$C")
+: > "$WORK/gh_calls"
+evaluate_epic 900 >/dev/null 2>&1
+: > "$GITHUB_STEP_SUMMARY"
+grep -q 'createdAt' "$WORK/gh_calls" \
+  && ok "the member re-read fetches each LabeledEvent's createdAt" \
+  || ko "the re-read never asks for createdAt, so the boundary floor has no data to act on"
+reset_fixtures
 reset_fixtures
 
 echo
@@ -534,7 +585,10 @@ echo "the boundary bounds HISTORY, never the frozen set"
 # member the snapshot is kept for.
 FX_LIVE_MERGED='[]'
 FX_BODY=$(marker frozen "$BC" "$AGO20")
-FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 MERGED "$AGO40")" "$C")
+# The member still carries the label, so it corroborates by its present label rather than a timeline
+# event — a merged pull request keeps its labels. Its old mergedAt makes a wrongly time-filtered frozen
+# set observable: only the frozen bucket, never scoped, still counts it.
+FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 MERGED "$AGO40" label)" "$C")
 check "a frozen member that merged before the boundary still counts" clear live+snapshot 1/0/1
 reset_fixtures
 
@@ -1025,7 +1079,7 @@ if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"
   exit 1
 fi
-if [ "$ran" -lt 168 ]; then
-  echo "::error::only $ran assertion(s) ran (expected at least 168) — the suite did not execute fully"
+if [ "$ran" -lt 174 ]; then
+  echo "::error::only $ran assertion(s) ran (expected at least 174) — the suite did not execute fully"
   exit 1
 fi


### PR DESCRIPTION
Closes #329. Last Task of #360.

## The gap

The reader corroborates each frozen member against the `epic:<N>` label — it must still carry the label, or its timeline must record a `LabeledEvent` for it. A merged pull request keeps both **for good**, so the timeline proved only *"ever carried `epic:<N>`"*, not *"is a member of this landing"*. A pull request from a completed earlier wave under the same Epic corroborated forever and re-entered this wave's membership.

## The fix

The `LabeledEvent` must land **at or after the wave boundary** the marker carries (`SNAP_SINCE`, added with #340). A previous wave's label event is no longer this wave's evidence.

- A **still-present label** is not scoped — it is membership *now*, not historical evidence of it.
- With **no boundary** — the Epic's first wave — the whole history is one wave, which is the pre-boundary behavior.
- The re-read query already fetched the `LabeledEvent`; it now also fetches its `createdAt`.

## Scope: the floor, not the head SHA

#329 was filed the day before the wave boundary landed, and its two cases have since diverged:

- Its **realistic case** — an old wave corroborating forever — is what this closes. It happens with no attacker at all.
- Its **victim-injection case** (label a pull request, unlabel it seconds later, name it in the marker) stays **accepted**: naming a member needs planning-repo write, the settled trust boundary (see #360), which already lets that author name any member directly. The prior-art pass found this is the field norm — no merge system authorizes set membership per-member; the defense is member-level re-authorization at merge time, which merge-gate already does.

The issue also mentioned storing each member's **head SHA** at capture. That enables a *separate* "member whose head moved after capture" check, which #360 lists as out of scope. Storing it now is an unused marker field across all three actions, so I've deferred it to its own follow-up (filed) rather than change the marker shape for a check this Task does not make.

## Tests: 168 → 174

| Mutant | Result |
| --- | --- |
| floor removed (timeline unbounded again) | 1 failed |
| floor uses `>` not `>=` (boundary instant excluded) | 1 failed |
| floor also scopes the present label | 2 failed |
| createdAt dropped from the query | 1 failed |

The `node` fixture gained a `LabeledEvent` timestamp; the "merged before the boundary still counts" case now corroborates via a still-present label (a merged pull request keeps its labels) rather than an impossible labeled-after-merge timeline. All eight suites green; prettier and `lint-action-manifests` clean.

## #360 complete after this

All three defects closed: #319 (enumerate via snapshot), #325 (per-PR consults the claim index), #329 (wave-scoped corroboration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)