### PR TITLE
docs(migrations): add the v2.0.0 upgrade guide

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -2,7 +2,8 @@
 
 One immutable guide per release that asks consumers to change something. Newest first.
 
-| Version                 | Summary                                                                           |
-| ----------------------- | --------------------------------------------------------------------------------- |
-| [v1.21.0](./v1.21.0.md) | Activation-snapshot wave boundary — converge every repo, planning repos included. |
-| [v1.1.0](./v1.1.0.md)   | `client_id` bot-token input (deprecates `app_id`); UI-dispatched releases added.  |
+| Version                 | Summary                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [v2.0.0](./v2.0.0.md)   | Removes the `go-actions/go-report-card` action; activation-snapshot membership resolves without the label. |
+| [v1.21.0](./v1.21.0.md) | Activation-snapshot wave boundary — converge every repo, planning repos included.                          |
+| [v1.1.0](./v1.1.0.md)   | `client_id` bot-token input (deprecates `app_id`); UI-dispatched releases added.                           |

--- a/docs/migrations/v2.0.0.md
+++ b/docs/migrations/v2.0.0.md
@@ -1,0 +1,44 @@
+# Upgrading to v2.0.0
+
+`v2.0.0` removes the `go-actions/go-report-card` composite action. Everything else in the release is
+additive — the activation-snapshot membership work, which needs no consumer action.
+
+## Do I need to act?
+
+**Only if a workflow references `go-actions/go-report-card`.** If it does, remove that step; the action
+no longer exists and a caller pinned to `@v2` fails to load it. Every in-org consumer was updated in
+the same sweep, so most repos need nothing.
+
+## Remove the `go-report-card` step
+
+[Go Report Card was sunset in July 2026](https://goreportcard.com), so the action's
+`POST goreportcard.com/checks` hit a dead endpoint and every consumer's `report-grc` job was already a
+no-op. The action is gone in `v2.0.0`.
+
+```yaml
+# before — delete this step
+- uses: a-novel-kit/workflows/go-actions/go-report-card@v1
+  with:
+    repo: ${{ github.repository }}
+# after — nothing; the job that ran it can go too
+```
+
+- **Was it a required check?** No. `report-grc` is a `report-*` job, which repo config excludes from
+  required checks, so no ruleset references it and dropping it wedges no branch protection. `a-novel
+repo update` is not needed for this change.
+- **Verify:** the repo's `main.yaml` no longer contains `go-report-card`, and CI is green.
+
+## Also in this release (no action needed)
+
+The activation-snapshot machinery resolves Epic membership without depending on the `epic:<N>` label,
+closing the last three correctness gaps:
+
+- The reconcile sweep reaches an Epic through its own frozen snapshot, not only through live labels, so
+  a de-labeled Epic is still evaluated.
+- Per-PR `epic-freeze` consults the frozen snapshot before passing a pull request as standalone, so a
+  member de-labeled mid-landing is no longer greened.
+- Snapshot corroboration is scoped to the current wave, so a pull request from a completed earlier wave
+  no longer counts as a member of this one.
+
+These change the engine's internal behavior only; the `merge-gate` and `epic-freeze` contracts are
+unchanged.


### PR DESCRIPTION
Ships with the tag. Advisory output of a `prepare-release` pass — this does not cut the release.

## Proposed bump: `v1.23.1` → **`v2.0.0`** (major)

Four commits since `v1.23.1`:

- **`chore(ci)!` #363** — drops the `go-actions/go-report-card` composite action. The `!` marks it breaking: a consumer pinned to `@v2` with a `uses: …/go-report-card` step fails to load it. This drives the major bump.
- `feat` #364, `fix` #365, `fix` #366 — the activation-snapshot membership work (#360). Additive; no consumer action.

The workflows repo's **first major**. Flagging that explicitly, since a major triggers a Renovate major-bump on every consumer.

## The breaking change is low-risk

I checked the wedge concern from the earlier fleet notes, and it does **not** apply here:

- `report-grc` is a `report-*` job, and repo config **excludes `report-*` from required checks** (`repocfg` `Exclude.Prefixes`). Verified no ruleset on service-authentication, service-template or golib requires a grc/report context.
- So dropping the action wedges no branch protection, and **`a-novel repo update` is not needed** for this release (unlike a change that removes a *required* check).
- Every in-org consumer was updated in #363's sweep — `service-authentication`'s `main.yaml` has zero references left.

So the migration is: external consumers (if any) remove the step. In-org, nothing.

## To cut the release

Merge this, then Actions ▸ `release` ▸ **major**. Then the fleet's Renovate picks up the `@v2` major bump on its own schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)