### PR TITLE
docs(migrations): add the v1.24.0 upgrade guide

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -2,7 +2,8 @@
 
 One immutable guide per release that asks consumers to change something. Newest first.
 
-| Version                 | Summary                                                                           |
-| ----------------------- | --------------------------------------------------------------------------------- |
-| [v1.21.0](./v1.21.0.md) | Activation-snapshot wave boundary — converge every repo, planning repos included. |
-| [v1.1.0](./v1.1.0.md)   | `client_id` bot-token input (deprecates `app_id`); UI-dispatched releases added.  |
+| Version                 | Summary                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| [v1.24.0](./v1.24.0.md) | Removes the `go-actions/go-report-card` action (dead service); activation-snapshot membership resolves without the label. |
+| [v1.21.0](./v1.21.0.md) | Activation-snapshot wave boundary — converge every repo, planning repos included.                                         |
+| [v1.1.0](./v1.1.0.md)   | `client_id` bot-token input (deprecates `app_id`); UI-dispatched releases added.                                          |

--- a/docs/migrations/v1.24.0.md
+++ b/docs/migrations/v1.24.0.md
@@ -1,0 +1,47 @@
+# Upgrading to v1.24.0
+
+`v1.24.0` removes the `go-actions/go-report-card` composite action. Everything else in the release is
+additive — the activation-snapshot membership work, which needs no consumer action.
+
+Removing the action is a breaking change, but a small one — a capability that no longer works, whose
+service was shut down — so it ships as a minor. A major here is reserved for a planned, initiative-led
+migration on its own release line, not a single dead-endpoint removal.
+
+## Do I need to act?
+
+**Only if a workflow references `go-actions/go-report-card`.** If it does, remove that step; the action
+no longer exists. Every in-org consumer was updated in the same sweep, so most repos need nothing.
+
+## Remove the `go-report-card` step
+
+[Go Report Card was sunset in July 2026](https://goreportcard.com), so the action's
+`POST goreportcard.com/checks` hit a dead endpoint and every consumer's `report-grc` job was already a
+no-op.
+
+```yaml
+# before — delete this step
+- uses: a-novel-kit/workflows/go-actions/go-report-card@v1
+  with:
+    repo: ${{ github.repository }}
+# after — nothing; the job that ran it can go too
+```
+
+- **Was it a required check?** No. `report-grc` is a `report-*` job, which repo config excludes from
+  required checks, so no ruleset references it and dropping it wedges no branch protection. `a-novel
+repo update` is not needed for this change.
+- **Verify:** the repo's `main.yaml` no longer contains `go-report-card`, and CI is green.
+
+## Also in this release (no action needed)
+
+The activation-snapshot machinery resolves Epic membership without depending on the `epic:<N>` label,
+closing the last three correctness gaps:
+
+- The reconcile sweep reaches an Epic through its own frozen snapshot, not only through live labels, so
+  a de-labeled Epic is still evaluated.
+- Per-PR `epic-freeze` consults the frozen snapshot before passing a pull request as standalone, so a
+  member de-labeled mid-landing is no longer greened.
+- Snapshot corroboration is scoped to the current wave, so a pull request from a completed earlier wave
+  no longer counts as a member of this one.
+
+These change the engine's internal behavior only; the `merge-gate` and `epic-freeze` contracts are
+unchanged.


### PR DESCRIPTION
Ships with the tag. Advisory output of a `prepare-release` pass — this does not cut the release. Replaces #368 (which proposed v2.0.0).

## Proposed bump: `v1.23.1` → **`v1.24.0`** (minor)

Four commits since `v1.23.1`:

- `chore(ci)!` #363 — drops the `go-actions/go-report-card` action (dead endpoint).
- `feat` #364, `fix` #365, `fix` #366 — the activation-snapshot membership work (#360). Additive.

## Why a minor, not a major, despite the `!`

Per the repo's versioning policy: **a major is a planned, initiative-led migration on its own `vX` release line** — a global sweep, a paradigm shift — not something that falls out of a normal release. **A small breaking change — removing a capability, especially one that no longer works — stays a minor.**

The `go-report-card` removal qualifies: its service was sunset, so the action was already a no-op against a dead endpoint. Removing it breaks only a consumer still referencing it, and:

- it was never a required check (`report-*` jobs are excluded from required checks — verified across the fleet), so no ruleset reconcile and no `a-novel repo update` needed;
- every in-org consumer was already de-referenced in #363's sweep.

There is also no other breaking or deprecation debt to batch into a major — `app_id` was fully migrated to `client_id` at v1.1.0 — so a major would have been a lonely version jump for one dead action.

The mechanical conventional-commits reading (`!` → major) does not apply here; I'm updating the `prepare-release` skill to encode the policy so the next pass sizes it correctly.

## To cut the release

Merge this, then Actions ▸ `release` ▸ **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)