### PR TITLE
fix(lint-go): exercise the golangci-lint tool modfile so its .sum cannot rot

### DIFF
--- a/go-actions/lint-go/action.yaml
+++ b/go-actions/lint-go/action.yaml
@@ -32,6 +32,22 @@ runs:
           exit 1
         fi
         echo "version=$version" >> "$GITHUB_OUTPUT"
+    # Prove the golangci-lint tool module actually resolves from its modfile, so
+    # golangci-lint.sum completeness is exercised by CI. The lint step below runs a
+    # prebuilt binary for speed and reads golangci-lint.mod only for a version
+    # string, so nothing here otherwise touches the .sum. Without this step it can
+    # rot until `pnpm lint:go` (go tool -modfile=golangci-lint.mod golangci-lint)
+    # breaks locally with `missing go.sum entry` while master stays green — the
+    # exact drift that sat unnoticed across three repos. Running the tool the same
+    # way developers do forces every module-content hash to be present.
+    - name: Verify the golangci-lint tool module resolves
+      shell: bash
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        cd "${WORKING_DIRECTORY:-.}"
+        go tool -modfile=golangci-lint.mod golangci-lint version
     - uses: golangci/golangci-lint-action@v9
       with:
         version: ${{ steps.golangci-version.outputs.version }}


### PR DESCRIPTION
## Summary

`lint-go` resolved `golangci-lint.mod` for a version string and then linted with a **prebuilt binary** (`golangci/golangci-lint-action`), so `golangci-lint.sum` completeness was never exercised by anything in CI. The documented local command — `go tool -modfile=golangci-lint.mod golangci-lint`, i.e. `pnpm lint:go` — and the CI check were two different programs, and only one was watched. That is how three repos sat with an incomplete `golangci-lint.sum` (75 `missing go.sum entry` errors locally) on a green `master` for weeks.

Adds one step that runs the tool the way developers actually run it — `go tool -modfile=golangci-lint.mod golangci-lint version` — forcing every module-content hash to be resolved. A rotted `.sum` now fails CI with the same `missing go.sum entry` a developer hits locally. This mirrors `test-go`, which already drives `gotestsum` through its tool modfile.

## Review notes

- **Cost:** the tool compiles from source once per `lint-go` run (cached by `setup-go`); the actual lint still uses the fast prebuilt binary. This is the deliberate tradeoff the issue asks for — one lane proving the other.
- **Shared-action change:** this manifest is not exercised by the workflows repo's own PR CI; it is proven when a consumer re-pins to the released tag. So this **needs a `a-novel-kit/workflows` release** before it reaches the fleet, and Renovate then rolls it out.
- **New failure mode for consumers:** on re-pin, a repo whose `golangci-lint.sum` is *already* rotten will newly fail `lint-go` — which is the point. The three known-broken repos were repaired 2026-07-22, so the fleet should re-pin clean. Worth a line in the release notes (`prepare-release` owns sizing).

## Breaking changes

None to the action's interface (no input renamed, no path changed). Additive step only.

## Test plan

- [x] `prettier --check` clean; `lint-action-manifests` grep clean (no `vars`/`secrets`/`needs`/`matrix` contexts)
- [ ] CI green
- [ ] Proven on first consumer re-pin after release

Closes #349