### PR TITLE
fix(renovate): heal an incomplete go.sum after a main-module go bump

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -99,6 +99,16 @@ runs:
               "groupName": "go toolchain"
             },
             {
+              "description": "Complete an incomplete go.sum after a main-module bump. Renovate's built-in gomodTidy aborts intermittently when a vanity-import host (gonum.org has done this) resets the direct-mode fetch, committing a go.sum that has the /go.mod hashes but none of the module-content (h1:) hashes — every compile then fails with `missing go.sum entry` while lint-only jobs stay green, and it has needed a hand-pushed tidy several times in a week. This postUpgradeTask runs `go mod download all` after the update: it re-fetches the module graph (through proxy.golang.org first, per GOPROXY above) and writes the missing h1: hashes, so a complete go.sum ships in the same PR. It is additive and idempotent — a no-op when gomodTidy already succeeded, and it never prunes, so it cannot corrupt the file. Scoped to a repo-root go.mod so it never touches the tool modfiles (golangci-lint.mod, gotestsum.mod, mockery.mod), whose canonical state comes from `go get -tool` and which tidy would prune; `go mod download` is already in every Go consumer's allowed_commands. Renovate swallows a failing postUpgradeTask (renovatebot/renovate#8856), so this heals rather than gates — its success is the fix, and the rare download-still-fails residual surfaces as a red PR through consumer CI exactly as before. A non-root main module (stack's cli/go.mod) is out of scope here and carries its own rule.",
+              "matchManagers": ["gomod"],
+              "matchFileNames": ["go.mod"],
+              "postUpgradeTasks": {
+                "commands": ["go mod download all"],
+                "fileFilters": ["go.sum"],
+                "executionMode": "branch"
+              }
+            },
+            {
               "matchPackageNames": ["/.*a-novel-kit\\/nodelib.*/"],
               "groupName": "nodelib"
             },


### PR DESCRIPTION
## Summary

Renovate's built-in `gomodTidy` aborts intermittently when a vanity-import host resets the direct-mode fetch (gonum.org has done this), committing a `go.sum` that has the `/go.mod` hashes but **none of the module-content `h1:` hashes**. Every job that compiles then fails with `missing go.sum entry` while lint-only jobs stay green — three times in one week, each needing a hand-pushed `go mod tidy`.

Adds a fleet-wide gomod `postUpgradeTask` that runs **`go mod download all`** after the update, re-fetching the module graph and writing the missing `h1:` hashes so a complete `go.sum` ships in the same PR.

## Why `go mod download all`, and why this shape

- **Additive + idempotent.** It only *adds* hashes and never prunes, so it's a no-op when `gomodTidy` already succeeded and it can't corrupt the file. (`go mod tidy` would be the "exact" tool but isn't in the services' allowlists, whereas `^go mod download .*` already is — so this needs **no per-repo allowlist change**, keeping it genuinely one-place.)
- **Modfile-safe.** Scoped to a repo-root `go.mod` (`matchFileNames: ["go.mod"]`), so it never runs on the tool modfiles (`golangci-lint.mod`, `gotestsum.mod`, `mockery.mod`) — those are `go get -tool`-managed and `tidy` would prune their `-tool` requires.
- **Heals, not gates.** Renovate swallows a failing `postUpgradeTask` ([renovatebot/renovate#8856](https://github.com/renovatebot/renovate/issues/8856)), so a verify-and-fail approach can't block a bad PR anyway. This heals the common (transient) case; the rare download-still-fails residual surfaces as a red PR through consumer CI, exactly as today.

## Scope / review notes

- **Covers the four root-module services** (`service-authentication`, `service-json-keys`, `service-narrative-engine`, `service-template`) — 2 of the 3 documented incidents. stack's **non-root `cli/go.mod`** carries the same risk but doesn't match `matchFileNames: ["go.mod"]` and has a bespoke allowlist; it needs its own companion rule. **So this refs but does not close #314.**
- **Shared-action change:** not exercised by this repo's PR CI; proven on the next fleet Renovate pass. **Needs a `a-novel-kit/workflows` release** to reach consumers.
- **Rollback:** additive single package rule; reverting the rule restores prior behaviour with no state to unwind.

## Test plan

- [x] `RENOVATE_PACKAGE_RULES` re-parses as valid JSON (18 rules); rule shape verified
- [x] `prettier --check` clean; `lint-action-manifests` grep clean (no vars/secrets/needs/matrix)
- [ ] CI green
- [ ] Proven on the next fleet Renovate gomod bump after release

Refs #314