### PR TITLE
feat(generic-actions): extract shellcheck into a shared lint-shell action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,39 +79,19 @@ jobs:
           fi
           echo "✓ ${#suites[@]} action test suite(s) passed."
 
-  # Shellcheck the repo's bash. The tests/ suites embed each action's shipped functions verbatim
-  # (see test-actions above), so linting them lints the saga logic itself — the errexit-under-`||`,
-  # pipefail and `local`-scoping semantics the landing decisions turn on. Advisory for now: the step
-  # exits 0, so findings are surfaced (count in the run summary, full output in the log) without
-  # gating — the suites carry a backlog (dominated by intentional `A && B || C` guards, SC2015) too
-  # large to clear in one pass. Phase 2 clears the backlog and swaps `exit 0` for `exit $rc`, so the
-  # check fails on findings and becomes required. Tracked in #320.
+  # Shellcheck the repo's bash via the shared generic-actions/lint-shell action (dogfooded here
+  # with a relative path). The tests/ suites embed each action's shipped functions verbatim (see
+  # test-actions above), so linting them lints the saga logic itself — the errexit-under-`||`,
+  # pipefail and `local`-scoping semantics the landing decisions turn on. Advisory for now: this
+  # repo carries a backlog (dominated by intentional `A && B || C` guards, SC2015) too large to
+  # clear in one pass, so it passes `advisory: "true"` — findings are reported but do not gate.
+  # Phase 2 clears the backlog and drops the input so the check fails on findings. Tracked in #320.
   lint-shell:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - name: shellcheck
-        shell: bash
-        run: |
-          set -uo pipefail
-          shopt -s nullglob
-          files=(tests/*.sh .github/scripts/*.sh)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "::error::no shell files found to lint — the job would pass vacuously"
-            exit 1
-          fi
-          # GitHub runs `shell: bash` with -eo pipefail, so the non-zero shellcheck exit on findings
-          # would abort the step here; `|| true` keeps it advisory so the summary and exit 0 below run.
-          shellcheck -f gcc "${files[@]}" | tee "$RUNNER_TEMP/shellcheck.txt" || true
-          total=$(grep -cE ': (error|warning|note|style):' "$RUNNER_TEMP/shellcheck.txt" || true)
-          {
-            echo "## shellcheck — advisory (#320)"
-            echo ""
-            echo "**${total}** finding(s) across ${#files[@]} shell file(s), reported but non-gating."
-            echo "Phase 2 clears the backlog and swaps the \`exit 0\` below for \`exit \$rc\`, so the"
-            echo "check fails on findings and becomes required."
-          } >> "$GITHUB_STEP_SUMMARY"
-          # Advisory: surface findings without failing the check (see the job comment and #320).
-          exit 0
+      - uses: ./generic-actions/lint-shell
+        with:
+          advisory: "true"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | `enable-auto-merge`      | Enable native auto-merge on a PR as the [Agent] App (queue-when-green).                                           |
 | `epic-membership`        | Resolve an Epic's authorized member set — open PRs labeled `epic:<N>`.                                            |
 | `escalate`               | File/update a deduped escalation ticket (+ drive its board Status); page SEV1 via a push webhook.                 |
+| `lint-shell`             | Run shellcheck over the repo's tracked shell scripts (advisory or gating; a no-shell repo passes).                |
 | `merge-gate`             | Required "may this PR merge?" check (epic-atomicity + draft/review).                                              |
 | `pull-bot`               | Mint a bot App token and check out the repo authenticated as it.                                                  |
 | `renovate`               | Run self-hosted Renovate as the bot.                                                                              |

--- a/generic-actions/lint-shell/action.yaml
+++ b/generic-actions/lint-shell/action.yaml
@@ -1,0 +1,57 @@
+name: lint shell
+description: >
+  Run shellcheck over a repo's tracked shell scripts. A repo with no shell files is a clean
+  pass, so the job is safe to add anywhere. Advisory mode reports findings without failing,
+  for a repo clearing an existing backlog before the check gates.
+
+inputs:
+  paths:
+    required: false
+    description: >
+      Space- or newline-separated globs of shell files to lint. Empty (the default) lints
+      every tracked `*.sh` file (`git ls-files '*.sh'`), which excludes vendored and
+      gitignored trees. The caller must have checked the repo out for the default to see it.
+  advisory:
+    required: false
+    default: "false"
+    description: >
+      When "true", findings go to the run summary and the log but the check passes — for a
+      repo adopting the lint over an existing backlog. When "false" (the default), any
+      finding fails the check.
+
+runs:
+  using: composite
+  steps:
+    - name: shellcheck
+      shell: bash
+      env:
+        PATHS: ${{ inputs.paths }}
+        ADVISORY: ${{ inputs.advisory }}
+      run: |
+        # errexit is disabled deliberately: shellcheck exits non-zero on findings and this
+        # step decides gating from that code itself, rather than aborting on it.
+        set +e -u
+        shopt -s nullglob
+        if [ -n "${PATHS//[[:space:]]/}" ]; then
+          # Word-split the caller's globs into a file list on purpose.
+          # shellcheck disable=SC2206
+          files=($PATHS)
+        else
+          mapfile -t files < <(git ls-files '*.sh')
+        fi
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "No shell files to lint."
+          printf '## shellcheck\n\nNo shell files found — nothing to lint.\n' >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+        shellcheck -f gcc "${files[@]}" > "$RUNNER_TEMP/shellcheck.txt" 2>&1
+        rc=$?
+        cat "$RUNNER_TEMP/shellcheck.txt"
+        total=$(grep -cE ': (error|warning|note|style):' "$RUNNER_TEMP/shellcheck.txt")
+        printf '## shellcheck\n\n**%s** finding(s) across %s shell file(s).\n' \
+          "${total:-0}" "${#files[@]}" >> "$GITHUB_STEP_SUMMARY"
+        if [ "$ADVISORY" = "true" ]; then
+          echo "Advisory mode: findings reported without gating."
+          exit 0
+        fi
+        exit "$rc"


### PR DESCRIPTION
## Summary

#372 added a shellcheck job **inline** in this repo's `main.yaml`. But every repo has shell worth linting — build scripts, entrypoints, migration init, test harnesses — so this lifts it into a **shared composite action** any repo can call, the same way `lint-go` / `lint-node` work.

`generic-actions/lint-shell`:
- Lints the caller's **tracked `*.sh` files** (`git ls-files '*.sh'`, so vendored/gitignored trees are excluded) — or an explicit `paths` glob.
- **A repo with no shell files is a clean pass**, so it's safe to drop into any `main.yaml` ("lint their shell if any").
- An **`advisory`** input reports findings without gating — for a repo adopting the lint over an existing backlog before making it required.

This repo **dogfoods** it (relative `./generic-actions/lint-shell`, `advisory: "true"` since its suites carry the SC2015 backlog from #320), replacing the inline script.

## Adoption (follow-up)

Other repos adopt it by adding a `lint-shell` job on the released tag:

```yaml
lint-shell:
  runs-on: ubuntu-latest
  permissions: { contents: read }
  steps:
    - uses: actions/checkout@v7
    - uses: a-novel-kit/workflows/generic-actions/lint-shell@vX.Y.Z
```

That rollout (and making it a required check) is separate, per repo. **Needs a `a-novel-kit/workflows` release** before consumers can pin it.

## Review notes

- Shared-action change → not exercised by other repos' CI here; the **dogfood job on this PR** exercises it directly (advisory, green).
- The action deliberately `set +e` and decides gating from shellcheck's exit code, rather than letting GitHub's `-eo pipefail` abort the step (the trap #372 hit).
- No README `name`/`description` moved; added a catalog row for the new action.

## Test plan

- [x] action + `main.yaml` parse; job now `uses: ./generic-actions/lint-shell`
- [x] no composite-illegal contexts; `prettier --check` clean; action's own `run:` block is shellcheck-clean
- [ ] CI green (dogfood `lint-shell` reports advisory findings, stays green)

Refs #320