### PR TITLE
feat(generic-actions): add a lint-dockerfile (hadolint) action

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | `enable-auto-merge`      | Enable native auto-merge on a PR as the [Agent] App (queue-when-green).                                           |
 | `epic-membership`        | Resolve an Epic's authorized member set — open PRs labeled `epic:<N>`.                                            |
 | `escalate`               | File/update a deduped escalation ticket (+ drive its board Status); page SEV1 via a push webhook.                 |
+| `lint-dockerfile`        | Run hadolint over the repo's Dockerfiles (advisory or gating; a no-Dockerfile repo passes).                       |
 | `lint-shell`             | Run shellcheck over the repo's tracked shell scripts (advisory or gating; a no-shell repo passes).                |
 | `merge-gate`             | Required "may this PR merge?" check (epic-atomicity + draft/review).                                              |
 | `pull-bot`               | Mint a bot App token and check out the repo authenticated as it.                                                  |

--- a/generic-actions/lint-dockerfile/action.yaml
+++ b/generic-actions/lint-dockerfile/action.yaml
@@ -1,0 +1,73 @@
+name: lint dockerfile
+description: >
+  Run hadolint over a repo's Dockerfiles. A repo with no Dockerfiles is a clean pass, so the
+  job is safe to add anywhere. Advisory mode reports findings without failing, for a repo
+  clearing an existing backlog before the check gates. hadolint also shellchecks each RUN block.
+
+inputs:
+  paths:
+    required: false
+    description: >
+      Space- or newline-separated globs of Dockerfiles to lint. Empty (the default) lints every
+      tracked file named `Dockerfile`, `Dockerfile.<x>` or `<x>.Dockerfile` (case-insensitive),
+      which excludes vendored and gitignored trees. The caller must have checked the repo out for
+      the default to see it.
+  advisory:
+    required: false
+    default: "false"
+    description: >
+      When "true", findings go to the run summary and the log but the check passes — for a repo
+      adopting the lint over an existing backlog. When "false" (the default), any finding fails.
+  version:
+    required: false
+    default: "v2.12.0"
+    description: >
+      The hadolint release to pin — a `hadolint/hadolint` git tag. The binary is fetched from that
+      release; it is not preinstalled on the runner as shellcheck is.
+
+runs:
+  using: composite
+  steps:
+    - name: hadolint
+      shell: bash
+      env:
+        PATHS: ${{ inputs.paths }}
+        ADVISORY: ${{ inputs.advisory }}
+        HADOLINT_VERSION: ${{ inputs.version }}
+      run: |
+        # errexit is disabled deliberately: hadolint exits non-zero on findings and this step
+        # decides gating from that code itself, rather than aborting on it.
+        set +e -u
+        shopt -s nullglob
+        if [ -n "${PATHS//[[:space:]]/}" ]; then
+          # Word-split the caller's globs into a file list on purpose.
+          # shellcheck disable=SC2206
+          files=($PATHS)
+        else
+          # Match `Dockerfile`, `Dockerfile.<x>` and the fleet's `<x>.Dockerfile` convention.
+          mapfile -t files < <(git ls-files | grep -iE '\.dockerfile$|(^|/)dockerfile(\.[^/]+)?$')
+        fi
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "No Dockerfiles to lint."
+          printf '## hadolint\n\nNo Dockerfiles found — nothing to lint.\n' >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+        bin="$RUNNER_TEMP/hadolint"
+        if ! curl -fsSL \
+          "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
+          -o "$bin"; then
+          echo "::error::failed to download hadolint ${HADOLINT_VERSION}"
+          exit 1
+        fi
+        chmod +x "$bin"
+        "$bin" "${files[@]}" > "$RUNNER_TEMP/hadolint.txt" 2>&1
+        rc=$?
+        cat "$RUNNER_TEMP/hadolint.txt"
+        total=$(grep -cE 'DL[0-9]+|SC[0-9]+' "$RUNNER_TEMP/hadolint.txt")
+        printf '## hadolint\n\n**%s** finding(s) across %s Dockerfile(s).\n' \
+          "${total:-0}" "${#files[@]}" >> "$GITHUB_STEP_SUMMARY"
+        if [ "$ADVISORY" = "true" ]; then
+          echo "Advisory mode: findings reported without gating."
+          exit 0
+        fi
+        exit "$rc"


### PR DESCRIPTION
## Summary

Nothing statically lints Dockerfiles in the fleet. Build *correctness* (a `COPY` of a missing source, syntax errors) is already caught by the `build-*` jobs' real `docker build` — but best-practice **hygiene** (unpinned `apt`, missing `--no-install-recommends`, root `USER`, `ADD` where `COPY` suffices, shell-form `CMD`) goes unchecked. hadolint covers that gap, and shellchecks each `RUN` block as a bonus.

`generic-actions/lint-dockerfile` **mirrors `lint-shell`**: lints the caller's tracked Dockerfiles (`git ls-files` matching `Dockerfile`, `Dockerfile.<x>` and the fleet's `<x>.Dockerfile` convention), a **no-Dockerfile repo is a clean pass**, and an **`advisory`** input reports findings without gating.

## Why the binary, not `hadolint/hadolint-action`

`hadolint-action` lints a **single fixed filename** (or recurses on that one name) with **no glob support** — but our repos have **six differently-named** `builds/*.Dockerfile` files, and you can't loop `uses:` over a dynamic list in a composite action. The hadolint **binary takes a file list**, which pairs with `git ls-files` discovery and keeps this behaviorally identical to `lint-shell`. (This differs from `lint-go` wrapping `golangci-lint-action` because golangci-lint's whole-module model fits our layout; hadolint's named-file model does not.)

## Validation

Verified **end to end** against `service-template`'s six Dockerfiles: discovery found all six, hadolint ran them **clean** (exit 0, 0 findings). So unlike shell (a 116-finding backlog), services can adopt this **gating from the start** — no advisory phase needed.

## Review notes

- **No dogfood job here** — this repo has no Dockerfiles; per the shared-action convention (like `lint-go`), it's proven on adoption. The `lint-action-manifests` check confirms the manifest loads.
- The hadolint version is a pinned `version` input (`v2.12.0`); a Renovate custom-manager to auto-bump it can follow.
- Same `set +e` / exit-code-driven gating as `lint-shell` (avoids GitHub's `-eo pipefail` aborting the step).
- Bundles into the **same pending workflows release** as the `lint-shell` work; fleet adoption (adding the job per repo) is the follow-up session.

## Test plan

- [x] Manifest parses; no composite-illegal contexts; `prettier --check` clean
- [x] Action `run:` block shellcheck-clean (bar extraction-only SC2148)
- [x] End-to-end: discovery + hadolint on service-template's 6 Dockerfiles (clean)
- [ ] CI green (manifest lints; no dogfood by design)