### PR TITLE
fix(tests): clear the shellcheck backlog and gate lint-shell

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,10 +82,8 @@ jobs:
   # Shellcheck the repo's bash via the shared generic-actions/lint-shell action (dogfooded here
   # with a relative path). The tests/ suites embed each action's shipped functions verbatim (see
   # test-actions above), so linting them lints the saga logic itself — the errexit-under-`||`,
-  # pipefail and `local`-scoping semantics the landing decisions turn on. Advisory for now: this
-  # repo carries a backlog (dominated by intentional `A && B || C` guards, SC2015) too large to
-  # clear in one pass, so it passes `advisory: "true"` — findings are reported but do not gate.
-  # Phase 2 clears the backlog and drops the input so the check fails on findings. Tracked in #320.
+  # pipefail and `local`-scoping semantics the landing decisions turn on. Gating: the adoption
+  # backlog was cleared in #320, so any new finding fails the check.
   lint-shell:
     runs-on: ubuntu-latest
     permissions:
@@ -93,5 +91,3 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./generic-actions/lint-shell
-        with:
-          advisory: "true"

--- a/tests/detect-partial-landing.sh
+++ b/tests/detect-partial-landing.sh
@@ -1,20 +1,16 @@
 #!/usr/bin/env bash
 # Regression tests for detect-partial-landing's membership sourcing.
 #
-# These actions are bash inside a composite manifest, so there is nothing to import: the harness
-# extracts the functions under test verbatim from the manifest and sources them, which keeps the
-# shipped code the code that runs here. Only the network leaves are stubbed (gh, and the three read
-# helpers evaluate_epic calls), so every decision below is the real predicate running on fixture truth.
-# Offline and deterministic.
+# The functions under test are extracted verbatim from the composite manifest and sourced, so the
+# shipped code is the code that runs here; only the network leaves are stubbed. Offline, deterministic.
 #
 # The central case is a member de-labeled and closed mid-landing. Live label truth has forgotten it —
 # GitHub indexes no "ever carried label X" — so the detector reads the survivors as a clean landing
 # and clears. The frozen activation snapshot is what keeps it a member.
 #
-# The fixtures model the real capture shape. merge-gate captures the set from open pull requests and
-# freezes it once the set holds still, while auto-merge is armed earlier, so a real frozen set omits
-# the members that already merged. The snapshot is added to the live set: `A` merged is visible only
-# live, `B` abandoned only in the snapshot, and the freeze depends on both.
+# The fixtures model the real capture shape: merge-gate freezes from open pull requests while
+# auto-merge is armed earlier, so a frozen set omits members that already merged. `A` is visible only
+# live, `B` only in the snapshot, and the freeze depends on both.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -47,10 +43,11 @@ fi
 
 export ORG=a-novel-kit PLANNING_REPO=.github GRACE_MINUTES=30
 export GITHUB_STEP_SUMMARY="$WORK/summary.md"
-now_epoch=$(date -u +%s)
-# The action computes these outside any extracted function, so the harness reimplements them. A change
-# to the action's own arithmetic escapes this suite; keep the two in sync by hand.
-grace_seconds=$((GRACE_MINUTES * 60))
+# The action computes these outside any extracted function, so the harness reimplements them and the
+# extracted code reads both by name. A change to the action's arithmetic escapes this suite; keep the
+# two in sync by hand.
+# shellcheck disable=SC2034
+now_epoch=$(date -u +%s) grace_seconds=$((GRACE_MINUTES * 60))
 sleep() { :; } # retries are driven by the rehydrate_fails countdown; wall-clock delay is not useful here
 
 # ---- stubbed leaves ---------------------------------------------------------------------
@@ -106,12 +103,10 @@ search_prs() {
     *is:open*) bucket="$FX_LIVE_OPEN" ;;
     *) echo "unexpected search: $1" >&2; return 1 ;;
   esac
-  # Apply the time qualifier the way GitHub does. A bad qualifier silently returns zero rows, so
-  # filtering here is what lets the wave-boundary assertions below run the real predicate against real
-  # truth.
-  # ISO-8601 UTC sorts chronologically, so a string compare is the date compare; the action's own grace
-  # clock leans on the same property. A node with no terminal timestamp is kept: GitHub always has one,
-  # so an undated fixture means "not what this assertion is about".
+  # Apply the time qualifier the way GitHub does, so the wave-boundary assertions run the real
+  # predicate. ISO-8601 UTC sorts chronologically, so a string compare is the date compare. A node
+  # with no terminal timestamp is kept — GitHub always has one, so an undated fixture means "not what
+  # this assertion is about".
   floor=$(printf '%s' "$1" | sed -n 's/.*\(merged\|closed\):>=\([^ ]*\).*/\2/p')
   [ -n "$floor" ] && bucket=$(printf '%s' "$bucket" | jq -c --arg f "$floor" \
     '[.[] | select((.mergedAt // .closedAt // "9999") >= $f)]')
@@ -141,12 +136,21 @@ EPIC_CACHE="$WORK/epic-cache"
 mkdir -p "$EPIC_CACHE"
 epic_cache_clear() { rm -f "$EPIC_CACHE"/*; }
 
-# A pass reads an Epic issue once and both readers share it, so the cache survives for the life of
-# the step. Each case below is its own pass with its own fixture body, so it is cleared per call —
-# otherwise the first case's response would answer every later one. The read-once behavior is
-# asserted directly further down, against an uncleared cache.
+# A pass reads the Epic issue once and both readers share it, so the cache is cleared per call —
+# otherwise the first case's response would answer every later one. (The read-once behavior is
+# asserted further down, against an uncleared cache.) FX_EV pins the verdict for the per-PR section,
+# which needs the branch per_pr_main takes rather than a real evaluation.
 eval "uncached_evaluate_epic() $(declare -f evaluate_epic | tail -n +2)"
-evaluate_epic() { epic_cache_clear; uncached_evaluate_epic "$@"; }
+evaluate_epic() {
+  if [ -n "$FX_EV" ]; then
+    EV_DECISION="$FX_EV"; EV_MERGED_COUNT=1; EV_CLOSED_COUNT=1; EV_OPEN_COUNT=0
+    # shellcheck disable=SC2034  # per_pr_main reads EV_STRAY_COUNT; nothing in this harness does.
+    EV_STRAY_COUNT=1
+    return 0
+  fi
+  epic_cache_clear
+  uncached_evaluate_epic "$@"
+}
 
 # ---- fixtures ---------------------------------------------------------------------------
 # A member node as the re-read returns it. `prov` is how the node proves it belongs to the Epic:
@@ -154,13 +158,10 @@ evaluate_epic() { epic_cache_clear; uncached_evaluate_epic "$@"; }
 #   label    = still carries the label
 #   none     = neither — a pull request named by the marker that was never a member
 node() { # repo number state [terminalAt] [prov: timeline|label|none] [labelAt]
-  # `terminalAt` is when the pull request reached its terminal state: it fills `mergedAt` for a MERGED
-  # one and `closedAt` otherwise, which is how GitHub reports them (a merged PR carries both, equal).
-  # `closedAt` sits outside the action's search-node shape and the action never reads it; it is there
-  # so the stub above can apply a `closed:>=` floor, which the real search applies server-side.
-  # `labelAt` is the LabeledEvent's createdAt, defaulting to AGO5 — recent, so a timeline-proven member
-  # reads as labeled during the current wave under the boundary floor. A previous-wave member is given
-  # an older labelAt explicitly.
+  # `terminalAt` fills `mergedAt` for a MERGED node and `closedAt` otherwise, the way GitHub reports
+  # them. `closedAt` is outside the action's node shape and unread by it; it is here so the stub above
+  # can apply a `closed:>=` floor the real search applies server-side. `labelAt` is the LabeledEvent's
+  # createdAt, defaulting to a recent AGO5 so a timeline-proven member reads as this wave's.
   jq -cn --arg r "$1" --argjson n "$2" --arg s "$3" --arg m "${4:-}" --arg p "${5:-timeline}" \
     --arg la "${6:-$AGO5}" --arg e "epic:900" \
     '{number:$n, headRefOid:("sha"+($n|tostring)),
@@ -230,6 +231,7 @@ reset_fixtures() {
   FX_REST_FAIL=false
   FX_REST_FAIL_ON=none
   FX_QUEUE_FAIL=false
+  FX_EV="" # empty = evaluate_epic really evaluates; the per-PR section pins a verdict instead
 }
 reset_fixtures
 
@@ -239,7 +241,7 @@ fail=0
 note() { printf '  %s %s\n' "$1" "$2"; }
 ok() { note ✓ "$1"; pass=$((pass + 1)); }
 ko() { note ✗ "$1"; fail=$((fail + 1)); }
-eq() { [ "$2" = "$3" ] && ok "$1" || ko "$1 (got '$2', want '$3')"; }
+eq() { if [ "$2" = "$3" ]; then ok "$1"; else ko "$1 (got '$2', want '$3')"; fi; }
 
 check() { # name expected-decision [expected-membership] [expected merged/closed/open counts]
   local name="$1" want="$2" wantsrc="${3:-}" wantcounts="${4:-}" src counts detail=""
@@ -264,8 +266,11 @@ check "on the live set alone, the abandonment is invisible" clear live 1/0/1
 FX_BODY=$(marker frozen "$BC")
 FX_REHYDRATE=$(rehydrate "$B" "$C")
 check "the snapshot supplies it, and the Epic freezes" frozen live+snapshot 1/1/1
-[ "$EV_REASON" = "a member was closed without merging" ] \
-  && ok "and for the right reason" || ko "wrong reason: $EV_REASON"
+if [ "$EV_REASON" = "a member was closed without merging" ]; then
+  ok "and for the right reason"
+else
+  ko "wrong reason: $EV_REASON"
+fi
 
 echo
 echo "the snapshot is ADDED to the live set, never swapped for it"
@@ -281,16 +286,27 @@ FX_REHYDRATE=$(rehydrate "$(node a-novel-kit/repo-b 2 OPEN)" "$C")
 FX_REST='{"a-novel-kit/repo-a#1":"closed true","a-novel-kit/repo-b#2":"open false","a-novel-kit/repo-c#3":"open false"}'
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
-printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/repo-b" and .number == 2)' >/dev/null \
-  && ok "a de-labeled open member is in EV_OPEN, so it gets a check" \
-  || ko "the de-labeled open member is missing from EV_OPEN"
-printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/repo-b" and (.liveMember | not))' >/dev/null \
-  && ok "and is tagged as no longer live-labeled" || ko "liveMember tag missing or wrong"
-printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/repo-c" and .liveMember)' >/dev/null \
-  && ok "while a still-labeled member is tagged live" || ko "a live member was mis-tagged"
+if printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/repo-b" and .number == 2)' >/dev/null; then
+  ok "a de-labeled open member is in EV_OPEN, so it gets a check"
+else
+  ko "the de-labeled open member is missing from EV_OPEN"
+fi
+if printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/repo-b" and (.liveMember | not))' >/dev/null; then
+  ok "and is tagged as no longer live-labeled"
+else
+  ko "liveMember tag missing or wrong"
+fi
+if printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/repo-c" and .liveMember)' >/dev/null; then
+  ok "while a still-labeled member is tagged live"
+else
+  ko "a live member was mis-tagged"
+fi
 # The roll-forward reads exactly this filter; a de-labeled member must not be re-armed.
-printf '%s' "$EV_OPEN" | jq -e '[.[] | select((.isDraft | not) and .liveMember)] | length == 1' >/dev/null \
-  && ok "EV_OPEN offers exactly one roll-forward candidate" || ko "EV_OPEN would offer a de-labeled member to roll-forward"
+if printf '%s' "$EV_OPEN" | jq -e '[.[] | select((.isDraft | not) and .liveMember)] | length == 1' >/dev/null; then
+  ok "EV_OPEN offers exactly one roll-forward candidate"
+else
+  ko "EV_OPEN would offer a de-labeled member to roll-forward"
+fi
 reset_fixtures
 
 echo
@@ -311,9 +327,11 @@ check "an intruder carrying an unrelated label is still rejected" error
 FX_REHYDRATE=$(rehydrate "$B" "$(jq -cn --argjson v "$(node a-novel-kit/VICTIM 4242 OPEN '' none)" \
   '$v | .timelineItems.nodes = [{label:{name:"epic:901"}}]')")
 check "an intruder labeled for a DIFFERENT Epic is rejected" error
-printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/VICTIM")' >/dev/null \
-  && ko "the planted pull request reached the freeze target set" \
-  || ok "and it never reaches the freeze target set"
+if printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/VICTIM")' >/dev/null; then
+  ko "the planted pull request reached the freeze target set"
+else
+  ok "and it never reaches the freeze target set"
+fi
 # A repository outside the org can never be a member: the live label search is org-scoped, and naming
 # one lets the marker's author corroborate in a repository they control.
 FX_BODY=$(marker frozen '[{"repo":"a-novel-kit/repo-b","number":2},{"repo":"attacker/anything","number":1}]')
@@ -372,9 +390,11 @@ FX_REHYDRATE=$(rehydrate "$B" "$C")
 : > "$WORK/gh_calls"
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
-grep -q 'createdAt' "$WORK/gh_calls" \
-  && ok "the member re-read fetches each LabeledEvent's createdAt" \
-  || ko "the re-read never asks for createdAt, so the boundary floor has no data to act on"
+if grep -q 'createdAt' "$WORK/gh_calls"; then
+  ok "the member re-read fetches each LabeledEvent's createdAt"
+else
+  ko "the re-read never asks for createdAt, so the boundary floor has no data to act on"
+fi
 reset_fixtures
 reset_fixtures
 
@@ -388,12 +408,16 @@ FX_QUEUE='[]' # repo-c left its queue: a stray, still labeled, within grace
 FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO5")]"
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
-[ "$(printf '%s' "$EV_STRAYS" | jq '[.[] | select((.isDraft | not) and .liveMember)] | length')" = 1 ] \
-  && ok "no snapshot: EV_STRAYS still offers a roll-forward candidate" \
-  || ko "no snapshot: the roll-forward selected nothing (untagged nodes)"
-[ "$(printf '%s' "$EV_STRAYS" | jq '[.[] | select((.isDraft | not) and (.liveMember | not))] | length')" = 0 ] \
-  && ok "no snapshot: EV_STRAYS reports nothing as de-labeled" \
-  || ko "no snapshot: a labeled stray was warned about as de-labeled"
+if [ "$(printf '%s' "$EV_STRAYS" | jq '[.[] | select((.isDraft | not) and .liveMember)] | length')" = 1 ]; then
+  ok "no snapshot: EV_STRAYS still offers a roll-forward candidate"
+else
+  ko "no snapshot: the roll-forward selected nothing (untagged nodes)"
+fi
+if [ "$(printf '%s' "$EV_STRAYS" | jq '[.[] | select((.isDraft | not) and (.liveMember | not))] | length')" = 0 ]; then
+  ok "no snapshot: EV_STRAYS reports nothing as de-labeled"
+else
+  ko "no snapshot: a labeled stray was warned about as de-labeled"
+fi
 reset_fixtures
 
 echo
@@ -461,11 +485,16 @@ FX_BODY=$(marker frozen "$BC")
 FX_REHYDRATE=$(rehydrate "$B" "$(jq -cn --argjson c "$C" '$c | .headRefOid = "sha3-FRESH"')")
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
-printf '%s' "$EV_OPEN" | jq -e 'any(.number == 3 and .headRefOid == "sha3-FRESH")' >/dev/null \
-  && ok "EV_OPEN carries the snapshot's head, not the index's" \
-  || ko "the freeze would be posted on the stale head"
-[ "$(printf '%s' "$EV_OPEN" | jq '[.[] | select(.number == 3)] | length')" = 1 ] \
-  && ok "and the member appears exactly once" || ko "the member was double-counted across sources"
+if printf '%s' "$EV_OPEN" | jq -e 'any(.number == 3 and .headRefOid == "sha3-FRESH")' >/dev/null; then
+  ok "EV_OPEN carries the snapshot's head, not the index's"
+else
+  ko "the freeze would be posted on the stale head"
+fi
+if [ "$(printf '%s' "$EV_OPEN" | jq '[.[] | select(.number == 3)] | length')" = 1 ]; then
+  ok "and the member appears exactly once"
+else
+  ko "the member was double-counted across sources"
+fi
 
 echo
 echo "membership is bounded by the label and the org"
@@ -474,15 +503,20 @@ evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
 for want in 'label:"epic:900"' 'org:a-novel-kit'; do
   # All three searches: a grep over the whole file passes while two of them run unscoped.
-  [ "$(grep -cF -- "$want" "$WORK/searches")" = 3 ] \
-    && ok "all three member searches are scoped by $want" \
-    || ko "a member search is missing $want — the set would be every open pull request"
+  if [ "$(grep -cF -- "$want" "$WORK/searches")" = 3 ]; then
+    ok "all three member searches are scoped by $want"
+  else
+    ko "a member search is missing $want — the set would be every open pull request"
+  fi
 done
 : > "$WORK/searches"
 evaluate_epic 901 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
-[ "$(grep -cF 'label:"epic:901"' "$WORK/searches")" = 3 ] \
-  && ok "and the label follows the Epic being evaluated" || ko "the Epic label is not interpolated"
+if [ "$(grep -cF 'label:"epic:901"' "$WORK/searches")" = 3 ]; then
+  ok "and the label follows the Epic being evaluated"
+else
+  ko "the Epic label is not interpolated"
+fi
 
 echo
 echo "the merge queue is read per (repo, base), and only members are dequeued"
@@ -491,9 +525,12 @@ reset_fixtures
 FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3"},{"number":999,"state":"QUEUED","headOid":"sha999"}]'
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
-[ "$(printf '%s' "$EV_QUEUE" | jq 'length')" = 1 ] \
-  && ok "an unrelated queue entry is not treated as a member" \
-  || ko "a non-member queue entry leaked into EV_QUEUE (it would be dequeued)"
+# shellcheck disable=SC2153  # EV_QUEUE is evaluate_epic's output, not a typo of the FX_QUEUE fixture.
+if [ "$(printf '%s' "$EV_QUEUE" | jq 'length')" = 1 ]; then
+  ok "an unrelated queue entry is not treated as a member"
+else
+  ko "a non-member queue entry leaked into EV_QUEUE (it would be dequeued)"
+fi
 reset_fixtures
 FX_QUEUE='[{"number":3,"state":"QUEUED","headOid":"sha3","repo":"a-novel-kit/repo-c","base":"master"}]'
 check "the queue is read with the member's own repo and base" clear live 1/0/1
@@ -545,8 +582,11 @@ FX_BODY=$(marker retired '[]' "$AGO20")
 FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO5")]"
 FX_LIVE_CLOSED="[$(node a-novel-kit/repo-b 2 CLOSED "$AGO5")]"
 check "a member closed after the boundary is this wave's abandonment" frozen live 1/1/1
-[ "$EV_REASON" = "a member was closed without merging" ] \
-  && ok "and for the right reason" || ko "wrong reason: $EV_REASON"
+if [ "$EV_REASON" = "a member was closed without merging" ]; then
+  ok "and for the right reason"
+else
+  ko "wrong reason: $EV_REASON"
+fi
 # The closed bucket carries the same hazard and is scoped identically: an abandonment a human has
 # already dealt with must not re-freeze every wave that follows it.
 FX_LIVE_CLOSED="[$(node a-novel-kit/repo-b 2 CLOSED "$AGO40")]"
@@ -598,22 +638,29 @@ FX_BODY=$(marker retired '[]' "$AGO20")
 : > "$WORK/searches"
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
-[ "$(grep -cF "merged:>=$AGO20" "$WORK/searches")" = 1 ] \
-  && ok "the merged search is bounded" || ko "the merged search is not bounded by the boundary"
-[ "$(grep -cF "closed:>=$AGO20" "$WORK/searches")" = 1 ] \
-  && ok "the closed-unmerged search is bounded" || ko "the closed-unmerged search is not bounded"
-grep 'is:open' "$WORK/searches" | grep -q ':>=' \
-  && ko "the open search is bounded — but an open pull request is not history" \
-  || ok "and the open search is left unbounded"
+if [ "$(grep -cF "merged:>=$AGO20" "$WORK/searches")" = 1 ]; then
+  ok "the merged search is bounded"
+else
+  ko "the merged search is not bounded by the boundary"
+fi
+if [ "$(grep -cF "closed:>=$AGO20" "$WORK/searches")" = 1 ]; then
+  ok "the closed-unmerged search is bounded"
+else
+  ko "the closed-unmerged search is not bounded"
+fi
+if grep 'is:open' "$WORK/searches" | grep -q ':>='; then
+  ko "the open search is bounded — but an open pull request is not history"
+else
+  ok "and the open search is left unbounded"
+fi
 reset_fixtures
 
 echo
 echo "an unusable boundary is ignored, and never reaches a query"
-# GitHub answers a malformed time qualifier — and a well-shaped impossible date — with zero rows and no
-# errors array, indistinguishable from a genuinely empty bucket. That bucket gates every decision, and
-# an empty one reads as "nothing has landed" → `clear`, which posts success and lifts a standing freeze.
-# Falling back to unbounded history errs toward freezing. fd 6 keeps this loop's input clear of
-# evaluate_epic's own.
+# GitHub answers a malformed — or well-shaped but impossible — time qualifier with zero rows and no
+# errors array, indistinguishable from an empty bucket. An empty merged bucket reads as "nothing has
+# landed" → `clear`, which posts success and lifts a standing freeze, so an unusable boundary falls
+# back to unbounded history instead. fd 6 keeps this loop's input clear of evaluate_epic's own.
 FX_QUEUE='[]'
 FX_LIVE_MERGED="[$(node a-novel-kit/repo-a 1 MERGED "$AGO40")]"
 while IFS='|' read -r why bad <&6; do
@@ -621,8 +668,11 @@ while IFS='|' read -r why bad <&6; do
   FX_BODY=$(marker retired '[]' "$bad")
   : > "$WORK/searches"
   check "$why" frozen live 1/0/1
-  grep -q ':>=' "$WORK/searches" \
-    && ko "  …but it reached a query anyway" || ok "  …with no floor in any query"
+  if grep -q ':>=' "$WORK/searches"; then
+    ko "  …but it reached a query anyway"
+  else
+    ok "  …with no floor in any query"
+  fi
 done 6<<EOF
 not a timestamp at all|garbage
 a relative date the calendar happily accepts|yesterday
@@ -638,9 +688,11 @@ FX_BODY=$(marker retired '[]' '2026-07-01T00:00:00Z org:attacker')
 : > "$WORK/searches"
 evaluate_epic 900 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
-grep -q 'attacker' "$WORK/searches" \
-  && ko "an injected qualifier reached the search grammar" \
-  || ok "an injected qualifier never reaches the search grammar"
+if grep -q 'attacker' "$WORK/searches"; then
+  ko "an injected qualifier reached the search grammar"
+else
+  ok "an injected qualifier never reaches the search grammar"
+fi
 # Reporting a rejected value is itself a vector. The marker lives in an issue body, jq -r turns an
 # embedded \n into a real newline, and GitHub reads workflow commands line by line, so an unsanitized
 # warning lets the boundary forge a command on the path that rejects it.
@@ -649,9 +701,11 @@ FX_BODY=$(marker retired '[]' "$(printf '2026-07-01T00:00:00Z\n::error::forged')
 check "a boundary carrying a newline is rejected" frozen live 1/0/1
 out=$(evaluate_epic 900 2>&1)
 : > "$GITHUB_STEP_SUMMARY"
-printf '%s\n' "$out" | grep -q '^::error::forged' \
-  && ko "a newline in the boundary forged a workflow command" \
-  || ok "and reporting it cannot forge a workflow command"
+if printf '%s\n' "$out" | grep -q '^::error::forged'; then
+  ko "a newline in the boundary forged a workflow command"
+else
+  ok "and reporting it cannot forge a workflow command"
+fi
 reset_fixtures
 
 echo
@@ -676,10 +730,12 @@ FX_BODY="" # the next Epic in the same sweep has no marker at all
 : > "$WORK/searches"
 evaluate_epic 901 >/dev/null 2>&1
 : > "$GITHUB_STEP_SUMMARY"
-[ -z "$SNAP_SINCE" ] && ok "the next Epic starts with no boundary" || ko "SNAP_SINCE leaked: $SNAP_SINCE"
-grep -q ':>=' "$WORK/searches" \
-  && ko "the previous Epic's boundary bounded this one's searches" \
-  || ok "and its searches are unbounded"
+if [ -z "$SNAP_SINCE" ]; then ok "the next Epic starts with no boundary"; else ko "SNAP_SINCE leaked: $SNAP_SINCE"; fi
+if grep -q ':>=' "$WORK/searches"; then
+  ko "the previous Epic's boundary bounded this one's searches"
+else
+  ok "and its searches are unbounded"
+fi
 reset_fixtures
 
 echo
@@ -757,8 +813,11 @@ FX_BODY=$(printf '%s\n%s\n%s\n\n%s' \
   "$(marker frozen "$BC")")
 FX_REHYDRATE=$(rehydrate "$B" "$C")
 check "a decoy fence in an HTML comment is ignored" frozen live+snapshot 1/1/1
-printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/DECOY")' >/dev/null \
-  && ko "the decoy marker was used" || ok "and the real marker is the one that was read"
+if printf '%s' "$EV_OPEN" | jq -e 'any(.repository.nameWithOwner == "a-novel-kit/DECOY")' >/dev/null; then
+  ko "the decoy marker was used"
+else
+  ok "and the real marker is the one that was read"
+fi
 reset_fixtures
 
 echo
@@ -785,8 +844,11 @@ FX_BODY=$(marker frozen "$BC")
 FX_REHYDRATE=FAIL
 check "re-hydration fails outright" error
 # evaluate_epic returns before it logs anything on this path, so stderr is the only diagnosis.
-evaluate_epic 900 2>&1 >/dev/null | grep -q 'could not re-read all 2 frozen member' \
-  && ok "the reason reaches the run log" || ko "the fail-closed pass is silent"
+if evaluate_epic 900 2>&1 >/dev/null | grep -q 'could not re-read all 2 frozen member'; then
+  ok "the reason reaches the run log"
+else
+  ko "the fail-closed pass is silent"
+fi
 : > "$GITHUB_STEP_SUMMARY"
 FX_REHYDRATE=$(jq -cn '{data:{m0:null,m1:null}, errors:[{message:"NOT_FOUND"}]}')
 check "every alias nulled (data has keys, but no members)" error
@@ -925,11 +987,31 @@ EOF
 )
 epic_cache_clear; build_claim_index >/dev/null 2>&1
 eq "a frozen snapshot is claimed" "$(claims)" 700
-grep -qx 701 <<< "$CLAIM_EPICS" && ko "a pending marker was claimed" || ok "a pending marker is not claimed (not authoritative yet)"
-grep -qx 702 <<< "$CLAIM_EPICS" && ko "a retired tombstone was claimed" || ok "a retired tombstone is not claimed (names no members)"
-grep -qx 703 <<< "$CLAIM_EPICS" && ko "an unmarked issue was claimed" || ok "an unmarked issue is not claimed"
-grep -qx 705 <<< "$CLAIM_EPICS" && ko "a frozen marker with no members was claimed" || ok "a frozen marker with an empty member set is not claimed"
-grep -qx 704 <<< "$CLAIM_EPICS" && ko "a pull request row was claimed" || ok "a pull request row is skipped even carrying a frozen body"
+if grep -qx 701 <<< "$CLAIM_EPICS"; then
+  ko "a pending marker was claimed"
+else
+  ok "a pending marker is not claimed (not authoritative yet)"
+fi
+if grep -qx 702 <<< "$CLAIM_EPICS"; then
+  ko "a retired tombstone was claimed"
+else
+  ok "a retired tombstone is not claimed (names no members)"
+fi
+if grep -qx 703 <<< "$CLAIM_EPICS"; then
+  ko "an unmarked issue was claimed"
+else
+  ok "an unmarked issue is not claimed"
+fi
+if grep -qx 705 <<< "$CLAIM_EPICS"; then
+  ko "a frozen marker with no members was claimed"
+else
+  ok "a frozen marker with an empty member set is not claimed"
+fi
+if grep -qx 704 <<< "$CLAIM_EPICS"; then
+  ko "a pull request row was claimed"
+else
+  ok "a pull request row is skipped even carrying a frozen body"
+fi
 
 echo
 echo "the claim index primes the per-issue cache"
@@ -950,10 +1032,16 @@ epic_cache_clear; build_claim_index >/dev/null 2>&1
 : > "$WORK/gh_calls"
 snapshot_buckets 700 >/dev/null 2>&1
 eq "no issue read was made after priming" "$(grep -c 'issues/700' "$WORK/gh_calls" | tr -d ' ')" 0
-[ "$(grep -c graphql "$WORK/gh_calls")" -gt 0 ] \
-  && ok "and the primed frozen marker drove a member re-read (the markerless network body would not)" \
-  || ko "no member re-read attempted — the markerless network body was used, not the primed one"
-grep -qx 700 <<< "$CLAIM_EPICS" && ok "and the primed frozen Epic is claimed" || ko "the frozen Epic was not claimed"
+if [ "$(grep -c graphql "$WORK/gh_calls")" -gt 0 ]; then
+  ok "and the primed frozen marker drove a member re-read (the markerless network body would not)"
+else
+  ko "no member re-read attempted — the markerless network body was used, not the primed one"
+fi
+if grep -qx 700 <<< "$CLAIM_EPICS"; then
+  ok "and the primed frozen Epic is claimed"
+else
+  ko "the frozen Epic was not claimed"
+fi
 
 echo
 echo "the claim index fails soft"
@@ -1009,11 +1097,10 @@ echo
 echo "per-PR mode consults the claim index before passing standalone"
 # The #325 bug: a member de-labeled mid-landing takes the label-only standalone fast path and greens a
 # head the sweep froze. per_pr_main now asks the claim index first.
-# Stubs for the per-PR leaves. evaluate_epic is controlled so the test pins the branch taken, not the
-# Epic's real state; freeze_post records what was posted.
+# Stubs for the per-PR leaves. FX_EV pins the branch taken rather than the Epic's real state;
+# freeze_post records what was posted.
 freeze_post() { printf '%s\n' "$3|$4" >> "$WORK/posts"; }   # $1=repo $2=sha $3=conclusion $4=summary
 fetch_pr_labels() { [ "$FX_LABELS_FAIL" = true ] && return 1; printf '%s' "${FX_FETCH_LABELS:-[]}"; }
-evaluate_epic() { EV_DECISION="$FX_EV"; EV_MERGED_COUNT=1; EV_CLOSED_COUNT=1; EV_STRAY_COUNT=1; EV_OPEN_COUNT=0; }
 posted() { tail -1 "$WORK/posts" 2>/dev/null; }
 run_per_pr() { : > "$WORK/posts"; epic_cache_clear; per_pr_main >/dev/null 2>&1; }
 
@@ -1032,30 +1119,51 @@ reset_fixtures; setup_per_pr
 run_per_pr
 # Evaluated as a member: the post concerns Epic 700, never the standalone message. FX_EV=frozen, so
 # per_pr_main's frozen branch fired rather than the label-only fast path.
-printf '%s' "$(posted)" | grep -q 'standalone' \
-  && ko "a claimed unlabeled PR was passed standalone (the #325 bug)" \
-  || ok "a claimed unlabeled PR is evaluated as a member, not passed standalone"
-printf '%s' "$(posted)" | grep -q '700' && ok "and the post names the claiming Epic" || ko "the claiming Epic was not evaluated"
+if printf '%s' "$(posted)" | grep -q 'standalone'; then
+  ko "a claimed unlabeled PR was passed standalone (the #325 bug)"
+else
+  ok "a claimed unlabeled PR is evaluated as a member, not passed standalone"
+fi
+if printf '%s' "$(posted)" | grep -q '700'; then
+  ok "and the post names the claiming Epic"
+else
+  ko "the claiming Epic was not evaluated"
+fi
 
 reset_fixtures; setup_per_pr
 FX_ISSUE_LIST='[]'   # nothing claims it
 run_per_pr
-printf '%s' "$(posted)" | grep -q 'standalone' && ok "a genuinely unclaimed PR still passes standalone" || ko "an unclaimed PR was frozen"
-printf '%s' "$(posted)" | grep -q '^success' && ok "with a success conclusion" || ko "an unclaimed PR did not pass"
+if printf '%s' "$(posted)" | grep -q 'standalone'; then
+  ok "a genuinely unclaimed PR still passes standalone"
+else
+  ko "an unclaimed PR was frozen"
+fi
+if printf '%s' "$(posted)" | grep -q '^success'; then
+  ok "with a success conclusion"
+else
+  ko "an unclaimed PR did not pass"
+fi
 
 reset_fixtures; setup_per_pr
 FX_ISSUE_LIST=FAIL   # the claim lookup errors
 run_per_pr
-printf '%s' "$(posted)" | grep -q '^success' && ok "a claim-index failure fails open (success)" || ko "a claim-index error froze the PR instead of failing open"
+if printf '%s' "$(posted)" | grep -q '^success'; then
+  ok "a claim-index failure fails open (success)"
+else
+  ko "a claim-index error froze the PR instead of failing open"
+fi
 
 reset_fixtures; setup_per_pr
 EVENT_LABELS='[{"name":"epic:700"}]'   # a LABELED member still takes the label path
 FX_EV=clear
 run_per_pr
-printf '%s' "$(posted)" | grep -q '^success' && ok "a labeled member still routes through the label path" || ko "the label path regressed"
+if printf '%s' "$(posted)" | grep -q '^success'; then
+  ok "a labeled member still routes through the label path"
+else
+  ko "the label path regressed"
+fi
 unset HEAD_SHA REPO_FULL PR_NUMBER EVENT_PR EVENT_LABELS
-# Restore the real evaluate_epic wrapper for any later assertions.
-evaluate_epic() { epic_cache_clear; uncached_evaluate_epic "$@"; }
+FX_EV="" # back to real evaluations for anything added below
 
 echo
 echo "enumeration is the union of labels and claims"
@@ -1063,6 +1171,7 @@ echo "enumeration is the union of labels and claims"
 # a label-derived Epic both appear once and dropping the union is observable here.
 UNION_LINE=$(awk '/epics=\$\(printf .* "\$label_epics" "\$CLAIM_EPICS"/{sub(/^[[:space:]]*/,""); print; exit}' "$ACTION")
 [ -n "$UNION_LINE" ] || { echo "::error::could not read the enumeration union from $ACTION"; exit 1; }
+# shellcheck disable=SC2034  # UNION_LINE, lifted from the manifest, reads label_epics by name.
 union() { local label_epics="$1" CLAIM_EPICS="$2" epics; eval "$UNION_LINE"; printf '%s' "$epics" | paste -sd, -; }
 eq "a claim-only Epic joins the label set" "$(union "$(printf '810\n')" "$(printf '700\n')")" 700,810
 eq "an Epic reached both ways appears once" "$(union "$(printf '700\n')" "$(printf '700\n')")" 700
@@ -1070,10 +1179,8 @@ eq "a non-numeric token is dropped" "$(union "$(printf '700\nfoo\n')" "")" 700
 
 printf '%d passed, %d failed\n' "$pass" "$fail"
 # A floor on the count as well as on failures: a suite that runs no assertions exits 0 and reads as
-# green. Raise this when assertions are added; never lower it to make a run pass.
-# Failures are reported first, since they are the useful diagnosis. The floor covers assertions that
-# never ran, so it counts executions (pass + fail); counting passes alone turns an ordinary failure
-# into a truncated-suite report.
+# green. It counts executions (pass + fail), so an ordinary failure is not reported as a truncated
+# suite. Raise it when assertions are added; never lower it to make a run pass.
 ran=$((pass + fail))
 if [ "$fail" -gt 0 ]; then
   echo "::error::$fail assertion(s) failed"

--- a/tests/lint-action-manifests.sh
+++ b/tests/lint-action-manifests.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Regression tests for the composite-manifest context lint.
+# shellcheck disable=SC2016
+# ^ fixtures carry literal `${{ … }}` GitHub expressions that must not expand.
 #
-# A gate with no negative case is a gate nobody has proven catches anything. Every case below is a
-# manifest the linter runs against for real, and both halves carry weight: the violations have to
-# fail, and the plain-text prose the manifests document caller syntax with has to pass.
+# Regression tests for the composite-manifest context lint: each case is a manifest the linter runs
+# against for real. Both halves matter — the violations must fail, and the plain-text prose that
+# documents caller syntax must pass.
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)

--- a/tests/merge-gate-snapshot-write.sh
+++ b/tests/merge-gate-snapshot-write.sh
@@ -2,20 +2,15 @@
 # Regression tests for merge-gate's activation-snapshot write path.
 #
 # Same approach as tests/detect-partial-landing.sh: the functions under test are extracted verbatim
-# from the action manifest and sourced. Only `gh` is stubbed.
+# from the action manifest and sourced, and only `gh` is stubbed. It drives `write_marker` and its
+# helpers plus the decision and payload the step builds before calling it — all lifted from the
+# manifest rather than restated, so a fixture cannot encode a belief about the format.
 #
-# What this covers is the lost-update race. The reconcile sweep runs merge-gate as a matrix over
-# every open member pull request with no concurrency bound, and render-epic-status edits the same
-# issue body from a job that does not wait for it, so writers overlap by design against an API with
-# no conditional update.
-#
-# The write acts on a decision made earlier: `$do` and `$payload` are computed from a body read
-# before the loop, so a writer that re-reads without re-deriving freezes a member set the world has
-# already moved past, and a retry loop makes it win. Several cases below exist to pin that.
-#
-# Scope: this drives `write_marker` and its helpers, plus the decision the step makes before calling
-# it and the payload it assembles. Both are lifted out of the manifest rather than restated, so a
-# fixture cannot encode a belief about the format in place of observing it.
+# What it covers is the lost-update race: the reconcile sweep runs merge-gate as an unbounded matrix
+# over every open member pull request while render-epic-status edits the same issue body, against an
+# API with no conditional update. The write also acts on a decision made earlier — `$do` and
+# `$payload` come from a body read before the loop — so a writer that re-reads without re-deriving
+# freezes a set the world has moved past, and a retry loop makes it win.
 set -euo pipefail
 
 TOP_PID=$$
@@ -57,7 +52,7 @@ export GITHUB_STEP_SUMMARY="$WORK/summary.md"
 # note and `current_marker` reads every marker as absent.
 START=$(sed -n "s/^ *START='\(.*\)'\$/\1/p" "$ACTION" | head -1)
 END=$(sed -n "s/^ *END='\(.*\)'\$/\1/p" "$ACTION" | head -1)
-[ -n "$START" ] && [ -n "$END" ] || die "could not read the fence literals from $ACTION"
+if [ -z "$START" ] || [ -z "$END" ]; then die "could not read the fence literals from $ACTION"; fi
 # Matched without regard to indentation, so wrapping the block in a conditional does not silently
 # stop the anchor from matching.
 REGION_BLOCK=$(awk '
@@ -135,11 +130,13 @@ note_of() { # frozen|pending|retire
   sed -n "s/^ *note=\"\(_Epic membership, $key.*\)\"$/\1/p" "$ACTION" | head -1
 }
 region_file() { # $1 = payload json, $2 = frozen|pending -> the region the action itself would build
-  local f note payload regionf
+  local f note payload
   note=$(note_of "${2:-pending}")
   [ -n "$note" ] || die "could not read the note text from $ACTION"
   payload="$1"
-  f=$(mktemp -p "$WORK"); regionf="$f"
+  f=$(mktemp -p "$WORK")
+  # shellcheck disable=SC2034  # REGION_BLOCK, lifted from the manifest, redirects into regionf.
+  local regionf="$f"
   # Run the manifest's own assembly. `$( )` strips the trailing newline, so the closing brace needs
   # its own separator or bash reads it as an argument to the last command.
   eval "{ $REGION_BLOCK
@@ -163,7 +160,7 @@ pass=0
 fail=0
 ok() { printf '  ✓ %s\n' "$1"; pass=$((pass + 1)); }
 ko() { printf '  ✗ %s\n' "$1"; fail=$((fail + 1)); }
-eq() { [ "$2" = "$3" ] && ok "$1" || ko "$1 (got '$2', want '$3')"; }
+eq() { if [ "$2" = "$3" ]; then ok "$1"; else ko "$1 (got '$2', want '$3')"; fi; }
 
 reset() {
   printf 0 > "$WORK/read_fails"; : > "$WORK/writes"; : > "$WORK/steal"; : > "$WORK/noop"
@@ -171,8 +168,9 @@ reset() {
   : > "$GITHUB_STEP_SUMMARY"; server_body ""
 }
 # Capture the function's output so it cannot be mistaken for the exit code, and so tee'd and plain
-# log lines are asserted from one place.
-run() { write_marker "$(region_file "$payload" "$do")" > "$WORK/out" 2>&1 && echo 0 || echo $?; }
+# log lines are asserted from one place. write_marker re-derives against `cur` out of the
+# environment, so name it here — a case that forgets it then fails by name, not inside the extraction.
+run() { : "${cur:?}"; write_marker "$(region_file "$payload" "$do")" > "$WORK/out" 2>&1 && echo 0 || echo $?; }
 said() { grep -q "$1" "$WORK/out"; }
 
 # The member normalization, lifted from the manifest. It decides what `$cur` is, so the
@@ -211,8 +209,9 @@ PAYLOAD_BLOCK=$(awk '/if \[ "\$do" = "retire" \]; then/{f=1} f{print} f&&/^[[:sp
 BAIL_BLOCK=$(awk '/RETIRE_ONLY:-/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
 [ -n "$BAIL_BLOCK" ] || die "could not read the retire-only bail from $ACTION"
 bails() { # $1 = RETIRE_ONLY, $2 = do -> "bailed" (the step returned) or "went-on"
-  local out
-  out=$( RETIRE_ONLY="$1"; do="$2"; eval "$BAIL_BLOCK" >/dev/null 2>&1; printf 'went-on' )
+  # shellcheck disable=SC2034  # BAIL_BLOCK, lifted from the manifest, reads both out of the scope.
+  local out RETIRE_ONLY="$1" "do"="$2"
+  out=$( eval "$BAIL_BLOCK" >/dev/null 2>&1; printf 'went-on' )
   [ -n "$out" ] && echo went-on || echo bailed
 }
 
@@ -221,14 +220,15 @@ bails() { # $1 = RETIRE_ONLY, $2 = do -> "bailed" (the step returned) or "went-o
 DRY_BLOCK=$(awk '/SNAPSHOT_DRY_RUN:-/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
 [ -n "$DRY_BLOCK" ] || die "could not read the rehearsal branch from $ACTION"
 rehearses() { # $1 = SNAPSHOT_DRY_RUN, $2 = do, $3 = cur, $4 = payload -> the log, or "went-on"
-  local out
-  out=$( SNAPSHOT_DRY_RUN="$1"; do="$2"; cur="$3"; payload="$4"
-         eval "$DRY_BLOCK" 2>/dev/null; printf 'went-on' )
+  # Local, so a rehearsal cannot disturb the case in progress; DRY_BLOCK reads all four by name.
+  # shellcheck disable=SC2034
+  local out SNAPSHOT_DRY_RUN="$1" "do"="$2" cur="$3" payload="$4"
+  out=$( eval "$DRY_BLOCK" 2>/dev/null; printf 'went-on' )
   printf '%s' "$out"
 }
 
 payload_for() { # $1 = do, $2 = cur, $3 = inherited since -> echoes the payload, sets NOTE_OUT
-  local do cur inherited_since payload note
+  local "do" cur inherited_since payload note
   do="$1"; cur="$2"; inherited_since="${3:-}"
   eval "$PAYLOAD_BLOCK"
   NOTE_OUT="$note"
@@ -267,7 +267,7 @@ reset
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
 eq "a fresh pending marker is written" "$(run)" 0
 eq "and the server carries it" "$(marker_now | jq -r .status)" pending
-grep -q 'Some prose' "$WORK/body" && ok "human prose either side survives" || ko "prose was dropped"
+if grep -q 'Some prose' "$WORK/body"; then ok "human prose either side survives"; else ko "prose was dropped"; fi
 
 echo
 echo "a peer that writes after us"
@@ -279,9 +279,11 @@ do=pending; cur="$M2"; payload=$(pending_json "$M2")
 eq "we retry until our write survives" "$(run)" 0
 eq "and our marker is what finally stands" "$(marker_now | jq -r '.members | length')" 2
 eq "which took two writes, not one" "$(writes)" 2
-grep -q 'rendered by the peer' "$WORK/body" \
-  && ok "and the peer's own edit outside our region survives" \
-  || ko "LOST UPDATE: we overwrote the peer's edit"
+if grep -q 'rendered by the peer' "$WORK/body"; then
+  ok "and the peer's own edit outside our region survives"
+else
+  ko "LOST UPDATE: we overwrote the peer's edit"
+fi
 
 echo
 echo "a wiped marker invalidates a freeze in flight"
@@ -302,7 +304,7 @@ eq "a pending writer yields rather than resetting it" "$(run)" 2
 eq "the frozen marker is left intact" "$(marker_now | jq -r .status)" frozen
 eq "with its member set untouched" "$(marker_now | jq -r '.members | length')" 2
 eq "and nothing was written" "$(writes)" 0
-said 'already frozen' && ok "and it says so in the run log" || ko "the yield is silent"
+if said 'already frozen'; then ok "and it says so in the run log"; else ko "the yield is silent"; fi
 
 echo
 echo "a stale freeze must not become permanent"
@@ -316,7 +318,7 @@ eq "the writer abandons instead of freezing a superseded set" "$(run)" 2
 eq "the peer's pending marker stands" "$(marker_now | jq -r .status)" pending
 eq "with the peer's member set" "$(marker_now | jq -r '.members | length')" 1
 eq "and nothing was written" "$(writes)" 0
-said 'member set moved' && ok "and the abandonment is explained" || ko "abandoning is silent"
+if said 'member set moved'; then ok "and the abandonment is explained"; else ko "abandoning is silent"; fi
 
 echo
 echo "equivalent writers agree instead of fighting"
@@ -352,8 +354,11 @@ for bad in '"not-a-date"' 'null'; do
   do=pending; cur="$M2"; payload=$(pending_json "$M2")
   eq "an unreadable at ($bad) is rewritten" "$(run)" 0
   eq "which takes exactly one write" "$(writes)" 1
-  marker_now | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null \
-    && ok "and the marker can age again" || ko "the marker still cannot age"
+  if marker_now | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null; then
+    ok "and the marker can age again"
+  else
+    ko "the marker still cannot age"
+  fi
 done
 
 echo
@@ -401,9 +406,16 @@ eq "the tombstone is written" "$(run)" 0
 eq "leaving a retired marker" "$(marker_now | jq -r .status)" retired
 eq "carrying the boundary it drew" "$(marker_now | jq -r .since)" "$now"
 eq "and naming no members" "$(marker_now | jq -r '.members // "none"')" none
-grep -q 'Some prose' "$WORK/body" && ok "with the human prose untouched" || ko "prose was dropped retiring"
-grep -qF -- "$START" "$WORK/body" && ok "and the region still standing" \
-  || ko "the fences went with it, so the boundary has nowhere to live"
+if grep -q 'Some prose' "$WORK/body"; then
+  ok "with the human prose untouched"
+else
+  ko "prose was dropped retiring"
+fi
+if grep -qF -- "$START" "$WORK/body"; then
+  ok "and the region still standing"
+else
+  ko "the fences went with it, so the boundary has nowhere to live"
+fi
 
 echo
 echo "retirement re-derives like every other write"
@@ -487,13 +499,21 @@ echo
 echo "a terminal marker is settled by equality alone"
 # frozen and retired carry no aging clock, so equality settles them. A tombstone asked for a
 # parseable `at` is never settled, and the retirement retries to exhaustion.
-marker_settled "$(retired_json "$W")" "$(retired_json "$W")" \
-  && ok "a tombstone matching our payload counts as settled" \
-  || ko "a tombstone can never settle, so retirement never converges"
-marker_settled "$(frozen_json "$M2")" "$(frozen_json "$M2")" \
-  && ok "and so does a frozen marker" || ko "a frozen marker cannot settle"
-marker_settled "$(retired_json "$W")" "$(retired_json 2026-07-01T00:00:00Z)" \
-  && ko "two different boundaries read as one marker" || ok "but two boundaries apart do not"
+if marker_settled "$(retired_json "$W")" "$(retired_json "$W")"; then
+  ok "a tombstone matching our payload counts as settled"
+else
+  ko "a tombstone can never settle, so retirement never converges"
+fi
+if marker_settled "$(frozen_json "$M2")" "$(frozen_json "$M2")"; then
+  ok "and so does a frozen marker"
+else
+  ko "a frozen marker cannot settle"
+fi
+if marker_settled "$(retired_json "$W")" "$(retired_json 2026-07-01T00:00:00Z)"; then
+  ko "two different boundaries read as one marker"
+else
+  ok "but two boundaries apart do not"
+fi
 
 echo
 echo "what counts as a landed wave"
@@ -536,9 +556,11 @@ echo "and it is reachable from that hold"
 # only path by which a completed wave is retired, so assert it structurally, as the fence agreement
 # above is.
 hold_block=$(awk '/is not in the member set/{f=1} f{print} f&&/^[[:space:]]*fi$/{exit}' "$ACTION")
-grep -q 'retire_only=true' <<< "$hold_block" \
-  && ok "the not-in-set hold enables the capture step before it returns" \
-  || ko "the hold returns without enabling retirement — a pull request held there is held forever"
+if grep -q 'retire_only=true' <<< "$hold_block"; then
+  ok "the not-in-set hold enables the capture step before it returns"
+else
+  ko "the hold returns without enabling retirement — a pull request held there is held forever"
+fi
 for step in "Mint snapshot-write token" "Capture activation snapshot"; do
   if awk -v s="$step" '$0 ~ "name: " s {f=1;next} f && /^ *if:/ {print; exit}' "$ACTION" \
     | grep -q 'retire_only'; then
@@ -554,27 +576,48 @@ echo "the capture can be rehearsed"
 # capture bug was found by discovering a wrong marker on a real Epic.
 P=$(payload_for frozen "$M2")
 out=$(rehearses true frozen "$M2" "$P")
-grep -q 'went-on' <<< "$out" && ko "a rehearsal fell through to the write" || ok "a rehearsal stops before the write"
-grep -q 'dry run' <<< "$out" && ok "and says so" || ko "the rehearsal is silent about being one"
-grep -q 'frozen' <<< "$out" && ok "naming the transition it would make" || ko "the transition is not reported"
-grep -qF -- "$P" <<< "$out" && ok "and the exact payload it would splice" || ko "the payload is not reported"
+if grep -q 'went-on' <<< "$out"; then
+  ko "a rehearsal fell through to the write"
+else
+  ok "a rehearsal stops before the write"
+fi
+if grep -q 'dry run' <<< "$out"; then ok "and says so"; else ko "the rehearsal is silent about being one"; fi
+if grep -q 'frozen' <<< "$out"; then
+  ok "naming the transition it would make"
+else
+  ko "the transition is not reported"
+fi
+if grep -qF -- "$P" <<< "$out"; then
+  ok "and the exact payload it would splice"
+else
+  ko "the payload is not reported"
+fi
 for m in 'a-novel-kit/repo-a#5' 'a-novel-kit/repo-b#2'; do
-  grep -qF -- "$m" <<< "$out" && ok "listing member $m" || ko "member $m is not named, so the set cannot be eyeballed"
+  if grep -qF -- "$m" <<< "$out"; then
+    ok "listing member $m"
+  else
+    ko "member $m is not named, so the set cannot be eyeballed"
+  fi
 done
 eq "an off switch writes as before" "$(rehearses false frozen "$M2" "$P")" went-on
 eq "and so does an unset one" "$(rehearses "" frozen "$M2" "$P")" went-on
-grep -q 'retired' <<< "$(rehearses TRUE retire "$M2" "$(payload_for retire "$M2")")" \
-  && ok "a retirement rehearses too, whatever the casing" || ko "retirement cannot be rehearsed"
+if grep -q 'retired' <<< "$(rehearses TRUE retire "$M2" "$(payload_for retire "$M2")")"; then
+  ok "a retirement rehearses too, whatever the casing"
+else
+  ko "retirement cannot be rehearsed"
+fi
 
 echo
 echo "a rehearsal cannot write even if the branch fails"
 # The token is minted read-only for a dry run, so the capability is withheld rather than the write
 # merely skipped. GitHub compares strings case-insensitively, so any casing of "true" reaches it.
 perm=$(awk '/name: Mint snapshot-write token/{f=1} f&&/permission-issues:/{print; exit}' "$ACTION")
-grep -q 'snapshot_dry_run' <<< "$perm" \
-  && ok "the snapshot-write token is scoped by the rehearsal flag" \
-  || ko "a rehearsal still mints an issues:write token"
-grep -qE "'read'" <<< "$perm" && ok "down to read" || ko "the dry branch does not drop to read"
+if grep -q 'snapshot_dry_run' <<< "$perm"; then
+  ok "the snapshot-write token is scoped by the rehearsal flag"
+else
+  ko "a rehearsal still mints an issues:write token"
+fi
+if grep -qE "'read'" <<< "$perm"; then ok "down to read"; else ko "the dry branch does not drop to read"; fi
 
 echo
 echo "the payload the step builds"
@@ -604,35 +647,53 @@ inner() { awk -v s="$START" -v e="$END" '$0==s{f=1;next} $0==e{f=0} f' <<< "$1" 
 P=$(frozen_json "$M2")
 out=$(sp "$(printf 'top\n\n%s\n_note_\n%s\n%s\n\nbottom\n' "$START" "$(pending_json "$M1")" "$END")" "$P")
 eq "an existing region is replaced in place" "$(inner "$out" | jq -r .status)" frozen
-one_region "$out" && ok "leaving exactly one region" || ko "region count wrong"
-grep -q '^top$' <<< "$out" && grep -q '^bottom$' <<< "$out" \
-  && ok "with the prose either side intact" || ko "prose was dropped by the in-place branch"
+if one_region "$out"; then ok "leaving exactly one region"; else ko "region count wrong"; fi
+if grep -q '^top$' <<< "$out" && grep -q '^bottom$' <<< "$out"; then
+  ok "with the prose either side intact"
+else
+  ko "prose was dropped by the in-place branch"
+fi
 # The replaced payload leaves the body entirely: a stale copy left loose in it is what lets a
 # whole-body match report a marker that is not there.
-grep -qF -- "$(pending_json "$M1")" <<< "$out" \
-  && ko "the replaced payload is still in the body" \
-  || ok "and the payload it replaced is gone entirely"
+if grep -qF -- "$(pending_json "$M1")" <<< "$out"; then
+  ko "the replaced payload is still in the body"
+else
+  ok "and the payload it replaced is gone entirely"
+fi
 
 out=$(sp "$(printf 'only prose\n')" "$P")
 eq "a body with no region gains one" "$(inner "$out" | jq -r .status)" frozen
-grep -q '^only prose$' <<< "$out" && ok "and keeps the prose" || ko "prose lost on append"
+if grep -q '^only prose$' <<< "$out"; then ok "and keeps the prose"; else ko "prose lost on append"; fi
 
 out=$(sp "$(printf 'HUMAN-A\n%s\nA\n%s\ntext\n%s\nB\n%s\nHUMAN-B\n' "$START" "$END" "$START" "$END")" "$P")
-one_region "$out" && ok "duplicate fences are healed to one region" || ko "duplicate fences survived"
-grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
-  && ok "without dropping the prose around them" || ko "prose was destroyed healing duplicate fences"
+if one_region "$out"; then ok "duplicate fences are healed to one region"; else ko "duplicate fences survived"; fi
+if grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out"; then
+  ok "without dropping the prose around them"
+else
+  ko "prose was destroyed healing duplicate fences"
+fi
 
 # Prose between a stray fence and the end discriminates the two branches: an in-place replace spans
 # from the first START to the END and discards everything inside, while the recovery path strips the
 # fence lines and keeps it. A malformed region takes the recovery path.
 out=$(sp "$(printf '%s\nHUMAN-A\n%s\nHUMAN-B\n%s\n' "$START" "$START" "$END")" "$P")
-one_region "$out" && ok "an unbalanced fence pair is healed to one region" || ko "unbalanced fences survived"
-grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
-  && ok "keeping prose that was trapped inside it" || ko "prose between stray fences was destroyed"
+if one_region "$out"; then
+  ok "an unbalanced fence pair is healed to one region"
+else
+  ko "unbalanced fences survived"
+fi
+if grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out"; then
+  ok "keeping prose that was trapped inside it"
+else
+  ko "prose between stray fences was destroyed"
+fi
 out=$(sp "$(printf 'HUMAN-A\n%s\nstray end first\n%s\nHUMAN-B\n' "$END" "$START")" "$P")
-one_region "$out" && ok "inverted fences are healed to one region" || ko "inverted fences survived"
-grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out" \
-  && ok "keeping the prose around those too" || ko "prose was destroyed healing inverted fences"
+if one_region "$out"; then ok "inverted fences are healed to one region"; else ko "inverted fences survived"; fi
+if grep -q '^HUMAN-A$' <<< "$out" && grep -q '^HUMAN-B$' <<< "$out"; then
+  ok "keeping the prose around those too"
+else
+  ko "prose was destroyed healing inverted fences"
+fi
 
 echo
 echo "same status, different members of the same size"
@@ -682,8 +743,11 @@ printf 'Some prose.\n\n%s\n%s\n%s\n%s\n\nMore prose.\n' "$START" "$(note_of pend
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
 eq "the repair is retried until it sticks" "$(run)" 0
 eq "which takes two writes" "$(writes)" 2
-marker_now | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null \
-  && ok "and the marker can age at the end of it" || ko "the marker still cannot age"
+if marker_now | jq -e '.at | try (fromdateiso8601 | true) catch false' >/dev/null; then
+  ok "and the marker can age at the end of it"
+else
+  ko "the marker still cannot age"
+fi
 
 echo
 echo "a give-up message carries the error, not the success output"
@@ -691,8 +755,11 @@ reset
 do=pending; cur="$M2"; payload=$(pending_json "$M2")
 printf 'x' > "$WORK/noop"          # every edit returns success but changes nothing
 eq "an unlandable write gives up" "$(run)" 1
-said 'https://' && ko "the edit's success output was captured as an error" \
-  || ok "the success URL is not mistaken for an error"
+if said 'https://'; then
+  ko "the edit's success output was captured as an error"
+else
+  ok "the success URL is not mistaken for an error"
+fi
 
 echo
 echo "a failing edit"
@@ -701,7 +768,11 @@ do=pending; cur="$M2"; payload=$(pending_json "$M2")
 printf 'x' > "$WORK/edit_fails"
 eq "an edit that errors is retried, then given up on" "$(run)" 1
 eq "after three attempts" "$(writes)" 3
-said 'HTTP 422' && ok "and the API's own error text is surfaced, not swallowed" || ko "the edit error was discarded"
+if said 'HTTP 422'; then
+  ok "and the API's own error text is surfaced, not swallowed"
+else
+  ko "the edit error was discarded"
+fi
 
 echo
 echo "a give-up after mixed failures names a real cause"
@@ -712,8 +783,11 @@ do=pending; cur="$M2"; payload=$(pending_json "$M2")
 printf 'x' > "$WORK/edit_fails"
 printf 2 > "$WORK/read_fail_from"   # attempt 1 reads, edits, fails; every later read fails too
 eq "the pass gives up" "$(run)" 1
-said 'could not read' && ok "and names the failure that actually ended it" \
-  || ko "the give-up quotes a stale error from an earlier attempt"
+if said 'could not read'; then
+  ok "and names the failure that actually ended it"
+else
+  ko "the give-up quotes a stale error from an earlier attempt"
+fi
 
 echo
 echo "read failures"
@@ -727,8 +801,11 @@ printf 'Important human prose.\n\nA hand-written plan.\n' > "$WORK/body"
 printf 99 > "$WORK/read_fails"
 eq "a total read failure gives up rather than claiming success" "$(run)" 1
 eq "and writes nothing at all" "$(writes)" 0
-grep -q 'A hand-written plan' "$WORK/body" \
-  && ok "leaving the Epic body untouched" || ko "the body was written blind after a failed read"
+if grep -q 'A hand-written plan' "$WORK/body"; then
+  ok "leaving the Epic body untouched"
+else
+  ko "the body was written blind after a failed read"
+fi
 
 echo
 printf '%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/test-go-discovery.sh
+++ b/tests/test-go-discovery.sh
@@ -1,15 +1,10 @@
 #!/usr/bin/env bash
-# Regression tests for test-go's package discovery.
+# shellcheck disable=SC2016
+# ^ the suite matches literal `${{ … }}` GitHub template strings, which must not expand.
 #
-# Same discipline as release-train.sh: discover_modules is extracted verbatim from the manifest and
-# sourced, with only `go` stubbed. The caller-supplied filter expressions are the one thing that
-# cannot survive extraction — they are `${{ }}` expressions GitHub resolves at load time — so they
-# are substituted with their declared defaults, and the substitution is asserted rather than assumed.
-#
-# What is under test is that discovery cannot come back empty and still report success. gotestsum
-# reads MODULES as its package arguments; with none it falls back to `.`, prints `DONE 0 tests` and
-# exits 0, and the coverage step reports 0.0% off a `mode: set` header and exits 0 too. Every read
-# here has to fail loudly instead, because this action is the only place these tests run.
+# Regression tests for test-go's package discovery: discover_modules is extracted from the manifest
+# and sourced with `go` stubbed. Guards that discovery can never come back empty yet report success
+# (gotestsum with no packages falls back to `.` and exits 0 — every empty read must fail loudly).
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -31,9 +26,8 @@ if [ -z "$out" ]; then
   exit 1
 fi
 
-# Resolve the two caller expressions to the defaults the manifest declares. Both substitutions have
-# to bite: a renamed input would otherwise leave a `${{ … }}` in the sourced text, and the suite
-# would then cover something the action no longer contains.
+# Resolve the two `${{ }}` inputs to their manifest defaults; both must bite (a renamed input would
+# leave a `${{ … }}` behind), so the substitution is asserted below.
 filters="| grep -v /mocks | grep -v /test | grep -v /proto"
 resolved=${out//'${{ inputs.filter_patterns }}'/$filters}
 resolved=${resolved//'${{ inputs.filter_extra_patterns }}'/}
@@ -122,9 +116,8 @@ echo "== an empty package set is a failure however it arises =="
 GO_PACKAGES=""
 check "a module listing no packages fails the step" "1" "$(run)"
 
-# Without the emptiness guard this is the shape that slips through: printf on an empty capture writes
-# a blank line, which survives every grep and makes modules.txt non-empty by size while naming no
-# package at all.
+# The shape that slips past a size check: a blank line survives every grep, making modules.txt
+# non-empty while naming no package.
 check "the blank line a no-package module would emit does not count as content" \
   "" "$(tr -d '[:space:]' <modules.txt)"
 


### PR DESCRIPTION
## Summary

- Clears the last **106 shellcheck findings** in `tests/detect-partial-landing.sh` (63) and
  `tests/merge-gate-snapshot-write.sh` (43), and drops `advisory: "true"` from the `lint-shell`
  job so a new finding now fails the check. Phase 2 of the adoption started in #372/#373.
- All 9 tracked scripts are clean; the two suites still report **174** and **149** assertions, the
  exact counts their own floors assert.

## How each class was resolved

- **SC2015 (75)** — the `cond && ok "…" || ko "…"` assertion idiom. Provably safe here (`ok`/`ko`
  always return 0), but rewritten as `if/then/else` rather than disabled: that is already how the
  five suites that were clean all along are written, and it is what pulled these two files back
  under the ~115-column line width every other suite respects.
- **SC2218 (14) + SC2317 (5) + one SC2034** — all fell out of `evaluate_epic` being redefined as a
  stub mid-file and restored afterwards. Replaced with a **single definition** that returns a
  pinned verdict when the new `FX_EV` fixture is set. The per-PR section still intercepts the
  call under the real name, so the test design is unchanged; there is just no longer a second
  definition sitting after 14 call sites. No disable needed for any of the 19.
  (A scoped disable could not have worked regardless — SC2218 is reported at the *call* site, not
  at the stub.)
- **SC1010** — `local do …` parsed `do` as the loop keyword. Fixed by quoting (`local "do" …`), as
  shellcheck itself suggests; the variable must keep that name because the manifest block the
  harness `eval`s reads `$do`.
- **SC2030/SC2031** — `payload` assigned inside a `$( )` in `rehearses`. Fixed by declaring the
  four step variables `local` on the function instead, which is also what the helper meant.
- **SC2034 `cur`** — read by the extracted `write_marker`, never by the harness. `run()` now names
  it (`: "${cur:?}"`), so a case that forgets to set it fails by name instead of deep inside the
  extracted code. Shellcheck was reporting this at an arbitrary one of ~20 identical assignment
  lines, so a disable there would have moved with the next added case.
- **Justified disables (6, all one-line and scoped)** — `now_epoch`/`grace_seconds`, `EV_STRAY_COUNT`,
  `label_epics`, `regionf`, `RETIRE_ONLY`/`SNAPSHOT_DRY_RUN`, and `EV_QUEUE` (SC2153). Every one is
  the same false positive: the value is produced or consumed by code lifted out of the action
  manifest and `source`d/`eval`d, which shellcheck cannot see. Each carries its reason inline.

Comments in both files were also trimmed — headers and the longest blocks — to the density of the
two suites cleared in the first commit.

## Risk

These two suites guard the landing saga, where a wrong edit fails silently. Every change was made
against a running suite: both were re-run after each step and never dropped below their full
assertion counts, and the `lint-shell` and `test-actions` jobs were both reproduced locally
(`git ls-files '*.sh'` → shellcheck exit 0 over 9 files; 8/8 suites pass).

## Breaking changes

None. Test-harness and CI-config only; no action manifest is touched.

## Test plan

- [x] `shellcheck -f gcc $(git ls-files '*.sh')` → 0 findings
- [x] All 8 suites pass (174 and 149 assertions respectively)
- [x] `prettier@3.9.2 --check .` clean
- [ ] CI green with `lint-shell` now gating

Closes #320