### PR TITLE
fix(generic-actions): stop lint-dockerfile claiming source files

### DIFF
--- a/generic-actions/lint-dockerfile/action.yaml
+++ b/generic-actions/lint-dockerfile/action.yaml
@@ -9,9 +9,10 @@ inputs:
     required: false
     description: >
       Space- or newline-separated globs of Dockerfiles to lint. Empty (the default) lints every
-      tracked file named `Dockerfile`, `Dockerfile.<x>` or `<x>.Dockerfile` (case-insensitive),
-      which excludes vendored and gitignored trees. The caller must have checked the repo out for
-      the default to see it.
+      tracked file named `Dockerfile`, `<x>.Dockerfile` (the fleet's convention, either casing)
+      or `Dockerfile.<x>` — the last capital-D only, because a lowercase `dockerfile.<x>` is far
+      more likely to be source (`dockerfile.go`) than a Dockerfile variant. Discovery excludes
+      vendored and gitignored trees. The caller must have checked the repo out for it to see them.
   advisory:
     required: false
     default: "false"
@@ -44,8 +45,11 @@ runs:
           # shellcheck disable=SC2206
           files=($PATHS)
         else
-          # Match `Dockerfile`, `Dockerfile.<x>` and the fleet's `<x>.Dockerfile` convention.
-          mapfile -t files < <(git ls-files | grep -iE '\.dockerfile$|(^|/)dockerfile(\.[^/]+)?$')
+          # Match a bare `Dockerfile` and the fleet's `<x>.Dockerfile` in either casing, but the
+          # `Dockerfile.<x>` variant form only with a capital D: a case-insensitive dotted match
+          # also claims ordinary source, and `dockerfile.go` is not a Dockerfile.
+          mapfile -t files < <(git ls-files \
+            | grep -E '(^|/)[Dd]ockerfile$|\.[Dd]ockerfile$|(^|/)Dockerfile\.[^/]+$')
         fi
         if [ ${#files[@]} -eq 0 ]; then
           echo "No Dockerfiles to lint."

--- a/tests/lint-discovery.sh
+++ b/tests/lint-discovery.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Regression tests for what the two lint actions decide to lint.
+#
+# The discovery expressions are extracted verbatim from the manifests and run against a fixture file
+# list, so the assertions are on the shipped patterns rather than a copy of them.
+#
+# Discovery is the whole gate: a path the pattern misses is silently never linted, and a path it
+# wrongly claims fails the check on a file that is not a Dockerfile at all. The second is not
+# hypothetical — a case-insensitive `dockerfile(\.<x>)?$` claimed `dockerfile.go` in the stack repo,
+# which made the "a repo with no Dockerfiles is a clean pass" promise false there.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+DOCKER_ACTION="${1:-$ROOT/generic-actions/lint-dockerfile/action.yaml}"
+SHELL_ACTION="${2:-$ROOT/generic-actions/lint-shell/action.yaml}"
+
+DOCKER_RE=$(sed -n "s/^ *| grep -E '\(.*\)')\$/\1/p" "$DOCKER_ACTION")
+if [ -z "$DOCKER_RE" ]; then
+  echo "::error::could not extract the Dockerfile discovery pattern from $DOCKER_ACTION"
+  exit 1
+fi
+# lint-shell discovers with a pathspec rather than a pattern; assert it is still the one documented.
+SHELL_GLOB=$(sed -n "s/^ *mapfile -t files < <(git ls-files '\(.*\)')\$/\1/p" "$SHELL_ACTION")
+
+fails=0
+check() { # $1=label $2=expected $3=actual
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected [$2], got [$3]"
+    fails=$((fails + 1))
+  fi
+}
+matches() { printf '%s\n' "$1" | grep -cE "$DOCKER_RE"; }
+
+echo "== the naming conventions in the fleet are all discovered =="
+
+check "the fleet's <x>.Dockerfile"      1 "$(matches builds/database.Dockerfile)"
+check "a dotted variant of it"          1 "$(matches builds/standalone.grpc.Dockerfile)"
+check "a bare Dockerfile at the root"   1 "$(matches Dockerfile)"
+check "a bare Dockerfile in a subtree"  1 "$(matches builds/Dockerfile)"
+check "the canonical Dockerfile.<x>"    1 "$(matches builds/Dockerfile.dev)"
+check "an all-lowercase bare one"       1 "$(matches builds/dockerfile)"
+check "a lowercase suffix form"         1 "$(matches builds/database.dockerfile)"
+
+echo "== source files are not =="
+
+# The regression. `dockerfile.go` is the daemon's Dockerfile *discovery* code in the stack repo; a
+# case-insensitive dotted match reads it as a Dockerfile and hadolint fails on Go syntax.
+check "dockerfile.go is source, not a Dockerfile" 0 "$(matches cli/internal/daemon/discovery/dockerfile.go)"
+check "and so is dockerfile.ts"                   0 "$(matches src/dockerfile.ts)"
+check "and dockerfile_test.go"                    0 "$(matches cli/internal/dockerfile_test.go)"
+# A file merely mentioning the word is not one either — the pattern is anchored at both ends.
+check "a doc about Dockerfiles"                   0 "$(matches .agents/skills/write-dockerfiles/SKILL.md)"
+check "a path segment, not a file name"           0 "$(matches dockerfile/notes.txt)"
+
+echo "== lint-shell still discovers by pathspec =="
+
+check "the documented *.sh pathspec is what ships" "*.sh" "$SHELL_GLOB"
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "::error::$fails assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
## Summary

- `lint-dockerfile`'s default discovery matched `(^|/)dockerfile(\.[^/]+)?$` **case-insensitively**,
  so it claimed any `dockerfile.<ext>` — including ordinary source. In the stack repo that is
  `cli/internal/daemon/discovery/dockerfile.go`, and hadolint fails on it with a parse error.
- That makes the action's central promise — *"a repo with no Dockerfiles is a clean pass, so the
  job is safe to add anywhere"* — false for exactly the repo it was about to be added to.

## The fix

`(^|/)[Dd]ockerfile$|\.[Dd]ockerfile$|(^|/)Dockerfile\.[^/]+$`

A bare `Dockerfile` and the fleet's `<x>.Dockerfile` still match in either casing. The dotted
**variant** form (`Dockerfile.dev`) now requires a capital D, because that is the only part of the
old pattern that overlapped source-file naming — nobody writes `Dockerfile.go`, and everybody writes
`dockerfile.go`.

## Tests

New `tests/lint-discovery.sh`, in the repo's usual shape: the pattern is lifted out of the manifest
rather than restated, so it cannot drift from what ships. It pins both directions — every naming
convention in the fleet is discovered, and `dockerfile.go` / `dockerfile.ts` / `dockerfile_test.go` /
a doc *about* Dockerfiles are not. **Verified to fail against the old pattern** (which matches the
first two), so it is a real regression test rather than a restatement of current behaviour. It also
pins `lint-shell`'s `*.sh` pathspec, which had no coverage either.

## Release

Consumers reach this only through a tag, so it needs a **patch release** — the repos adopting
`lint-dockerfile` right now (a-novel/service-jobs#33, service-narrative-engine#469,
service-json-keys#873, service-template#443) are all `<x>.Dockerfile`-only and unaffected either way,
but the stack repo cannot adopt the job until this ships.

## Breaking changes

None in practice. A repo relying on a lowercase `dockerfile.<variant>` being linted would lose it;
no repo in either org has one (verified across all 7 candidate repos).

## Test plan

- [x] `tests/lint-discovery.sh` passes, and fails on the pre-fix pattern
- [x] All 9 suites pass; `shellcheck` clean on the new file
- [x] `lint-action-manifests` clean; `prettier --check` clean
- [ ] CI green