### PR TITLE
fix(generic-actions): retry the hadolint download

### DIFF
--- a/generic-actions/lint-dockerfile/action.yaml
+++ b/generic-actions/lint-dockerfile/action.yaml
@@ -57,10 +57,14 @@ runs:
           exit 0
         fi
         bin="$RUNNER_TEMP/hadolint"
-        if ! curl -fsSL \
+        # Retried, because this check gates: a single reset connection to the releases CDN would
+        # otherwise fail the build on a repo whose Dockerfiles are fine. `--retry-all-errors` is what
+        # covers a transport-level reset (curl exit 35) — plain `--retry` only covers transient HTTP
+        # statuses and timeouts, and the reset is what was actually observed.
+        if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
           "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
           -o "$bin"; then
-          echo "::error::failed to download hadolint ${HADOLINT_VERSION}"
+          echo "::error::failed to download hadolint ${HADOLINT_VERSION} after 3 retries"
           exit 1
         fi
         chmod +x "$bin"


### PR DESCRIPTION
## Summary

- `lint-dockerfile` downloads the hadolint binary with a bare `curl -fsSL` and no retry. Now that the
  check **gates** across the fleet, one reset connection to the releases CDN fails the build on a repo
  whose Dockerfiles are perfectly fine.
- Not hypothetical: this went red on **`a-novel/service-json-keys` master** an hour after adoption —
  `curl: (35) Recv failure: Connection reset by peer` → `::error::failed to download hadolint v2.12.0`.
  Nothing was wrong with the repo; a re-run went green with no code change.

## The fix

```
curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors …
```

`--retry-all-errors` is the load-bearing flag. Plain `--retry` covers transient *HTTP statuses* and
timeouts only — it does **not** retry a transport-level reset, which is exit code 35 and exactly what
was observed. It needs curl 7.71+; the `ubuntu-24.04` runner ships 8.x.

## Why this matters more than it looks

`lint-shell` has no equivalent exposure — shellcheck is preinstalled on the runner, so this is the
only network fetch in either lint action, and the only place a green repo can be failed by weather.
A flaky *required* check is worse than a missing one: it trains people to re-run rather than read.

## Scope

Not adding a test — a curl flag against a live CDN is not unit-testable here, and `tests/lint-discovery.sh`
(added in #376) already covers the part of this action that has logic worth pinning.

## Release

Consumers reach this through a tag, so it needs a **patch release (v1.25.2)**. Low urgency — the
failure mode is intermittent and a re-run clears it — but every adopting repo is exposed until they
re-pin.

## Breaking changes

None. Same URL, same binary, same failure message shape on genuine failure.

## Test plan

- [x] All 9 suites pass; `shellcheck` clean over all 10 tracked scripts (`lint-shell` gates on this branch)
- [x] `lint-action-manifests` clean; `prettier --check` clean
- [x] `--retry-all-errors` confirmed available in curl 8.x (runner ships 8.x; needs 7.71+)
- [ ] CI green
