### PR TITLE
feat(security-actions): CI-native secret, convention and workflow scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | `setup-node` | Set up Node + pnpm (GitHub registry) and install. |
 | `test-node`  | Run the package's tests and upload coverage.      |
 
+### `security-actions`
+
+Each ships its own config, so a consuming repo carries none. All three run offline: nothing
+off-repo can stall them, which is the property a required check needs.
+
+| Action           | Purpose                                                                |
+| ---------------- | ---------------------------------------------------------------------- |
+| `lint-semgrep`   | Enforce the Agora structural conventions golangci-lint cannot express. |
+| `scan-secrets`   | Scan the working tree for committed credentials (gitleaks).            |
+| `lint-workflows` | Audit GitHub Actions workflows for security defects (zizmor).          |
+
+Each takes `advisory: "true"` to report without failing, for a repo adopting the check over an
+existing backlog.
+
 ### `publish-actions`
 
 | Action                | Purpose                                                                                        |

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ it — `scan-secrets` writes the baseline to `.gitleaks-base.toml` in the worksp
 `.gitleaks.toml` opens with `[extend] path = ".gitleaks-base.toml"`. Allowlists from both layers
 apply; a config that omits the block replaces the baseline and the action warns.
 
+Call the three as separate jobs, not through one reusable workflow. A reusable-workflow caller's
+checks are named `<caller-job>/<inner-job>`, but required-check discovery reads the caller's job id
+verbatim — so the required context would be one GitHub never posts, and the PR could never merge.
+
 ### `publish-actions`
 
 | Action                | Purpose                                                                                        |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ off-repo can stall them, which is the property a required check needs.
 Each takes `advisory: "true"` to report without failing, for a repo adopting the check over an
 existing backlog.
 
+`version` is **required** on all three. The pin lives in the calling repo so Renovate sees it there
+and bumps each repo on its own cadence, instead of every tool upgrade waiting on a workflows
+release. Annotate it so Renovate can resolve the datasource:
+
+```yaml
+- uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.25.1
+  with:
+    # renovate: datasource=github-releases depName=gitleaks/gitleaks
+    version: "8.30.1"
+```
+
+A repo needing its own gitleaks allowlist **extends** the shipped baseline rather than replacing
+it — `scan-secrets` writes the baseline to `.gitleaks-base.toml` in the workspace, and the repo's
+`.gitleaks.toml` opens with `[extend] path = ".gitleaks-base.toml"`. Allowlists from both layers
+apply; a config that omits the block replaces the baseline and the action warns.
+
 ### `publish-actions`
 
 | Action                | Purpose                                                                                        |

--- a/generic-actions/lint-dockerfile/action.yaml
+++ b/generic-actions/lint-dockerfile/action.yaml
@@ -21,7 +21,7 @@ inputs:
       adopting the lint over an existing backlog. When "false" (the default), any finding fails.
   version:
     required: false
-    default: "v2.12.0"
+    default: "2.12.0"
     description: >
       The hadolint release to pin — a `hadolint/hadolint` git tag. The binary is fetched from that
       release; it is not preinstalled on the runner as shellcheck is.
@@ -62,7 +62,7 @@ runs:
         # covers a transport-level reset (curl exit 35) — plain `--retry` only covers transient HTTP
         # statuses and timeouts, and the reset is what was actually observed.
         if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
-          "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
+          "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION#v}/hadolint-Linux-x86_64" \
           -o "$bin"; then
           echo "::error::failed to download hadolint ${HADOLINT_VERSION} after 3 retries"
           exit 1

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -70,7 +70,8 @@ runs:
               "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
               "matchStrings": [
                 "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
-              ]
+              ],
+              "extractVersionTemplate": "^v?(?<version>.+)$"
             }
           ]
 

--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -60,6 +60,20 @@ runs:
         RENOVATE_ASSIGN_AUTOMERGE: true
         RENOVATE_ASSIGNEES_FROM_CODE_OWNERS: true
         RENOVATE_LABELS: "['dependencies', 'renovate']"
+        # Tool versions pinned in a workflow's `with:` block are invisible to every
+        # built-in manager. The annotation names the datasource; this reads it.
+        RENOVATE_CUSTOM_MANAGERS: |
+          [
+            {
+              "customType": "regex",
+              "description": "Versions pinned in workflow with: blocks, annotated with a renovate datasource comment.",
+              "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+              "matchStrings": [
+                "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
+              ]
+            }
+          ]
+
         # TODO: two temporary allowedVersions holds below — drop each once its condition clears
         # (see the rule descriptions). Tracked in https://github.com/a-novel-kit/workflows/issues/308
         RENOVATE_PACKAGE_RULES: |

--- a/security-actions/lint-semgrep/action.yaml
+++ b/security-actions/lint-semgrep/action.yaml
@@ -1,19 +1,16 @@
 name: lint semgrep
 description: >
-  Enforce the Agora structural conventions golangci-lint cannot express — a call that must be
-  present, a pairing that must hold. The ruleset ships with this action, so a consuming repo
-  carries no semgrep config of its own; the version it runs is the workflows tag it pins.
-  Rules are read from disk only, so the scan makes no network call and cannot be stalled by a
-  third-party service — the failure that took GitGuardian off the merge path.
+  Enforce the Agora structural conventions golangci-lint cannot express: a call that must be
+  present, a pairing that must hold. The ruleset ships with the action, so a consuming repo carries
+  no semgrep config. Rules are read from disk — no network call, so nothing off-repo can stall it.
 
 inputs:
   ruleset:
     required: false
     default: "service"
     description: >
-      Which bundled ruleset to run. "service" is the clean-architecture set for repos shaped as
-      cmd/ + internal/{config,lib,dao,core,handlers}. Libraries pass "none": their conventions are
-      covered by golangci-lint, and every rule here assumes the service layout.
+      "service" for the clean-architecture layout; "none" for libraries, whose conventions
+      golangci-lint already covers.
   advisory:
     required: false
     default: "false"
@@ -23,12 +20,9 @@ inputs:
   version:
     required: true
     description: >
-      REQUIRED. Pin it in the caller so Renovate sees it there and can bump it per repo,
-      rather than every tool upgrade waiting on a workflows release. The caller annotates it:
+      semgrep image tag. Pinned by the caller so Renovate bumps it per repo instead of every
+      upgrade waiting on a workflows release. Annotate it:
       `# renovate: datasource=docker depName=semgrep/semgrep`.
-      The semgrep image tag to pin. Run as a container step rather than a `container:` job,
-      because a job container makes GitHub inject its Node runtime into the image and
-      actions/checkout cannot start in one that lacks libstdc++.
 
 runs:
   using: composite

--- a/security-actions/lint-semgrep/action.yaml
+++ b/security-actions/lint-semgrep/action.yaml
@@ -21,9 +21,11 @@ inputs:
       When "true", findings go to the run summary and the log but the check passes — for a repo
       adopting the rules over an existing backlog. When "false" (the default), any finding fails.
   version:
-    required: false
-    default: "1.171.0"
+    required: true
     description: >
+      REQUIRED. Pin it in the caller so Renovate sees it there and can bump it per repo,
+      rather than every tool upgrade waiting on a workflows release. The caller annotates it:
+      `# renovate: datasource=docker depName=semgrep/semgrep`.
       The semgrep image tag to pin. Run as a container step rather than a `container:` job,
       because a job container makes GitHub inject its Node runtime into the image and
       actions/checkout cannot start in one that lacks libstdc++.

--- a/security-actions/lint-semgrep/action.yaml
+++ b/security-actions/lint-semgrep/action.yaml
@@ -1,0 +1,85 @@
+name: lint semgrep
+description: >
+  Enforce the Agora structural conventions golangci-lint cannot express — a call that must be
+  present, a pairing that must hold. The ruleset ships with this action, so a consuming repo
+  carries no semgrep config of its own; the version it runs is the workflows tag it pins.
+  Rules are read from disk only, so the scan makes no network call and cannot be stalled by a
+  third-party service — the failure that took GitGuardian off the merge path.
+
+inputs:
+  ruleset:
+    required: false
+    default: "service"
+    description: >
+      Which bundled ruleset to run. "service" is the clean-architecture set for repos shaped as
+      cmd/ + internal/{config,lib,dao,core,handlers}. Libraries pass "none": their conventions are
+      covered by golangci-lint, and every rule here assumes the service layout.
+  advisory:
+    required: false
+    default: "false"
+    description: >
+      When "true", findings go to the run summary and the log but the check passes — for a repo
+      adopting the rules over an existing backlog. When "false" (the default), any finding fails.
+  version:
+    required: false
+    default: "1.171.0"
+    description: >
+      The semgrep image tag to pin. Run as a container step rather than a `container:` job,
+      because a job container makes GitHub inject its Node runtime into the image and
+      actions/checkout cannot start in one that lacks libstdc++.
+
+runs:
+  using: composite
+  steps:
+    - name: semgrep
+      shell: bash
+      env:
+        RULESET: ${{ inputs.ruleset }}
+        ADVISORY: ${{ inputs.advisory }}
+        SEMGREP_VERSION: ${{ inputs.version }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+
+        if [ "$RULESET" = "none" ]; then
+          echo "ruleset=none — nothing to enforce for this repo kind."
+          exit 0
+        fi
+
+        rules="$ACTION_PATH/rules/$RULESET.yaml"
+        if [ ! -f "$rules" ]; then
+          echo "::error::unknown ruleset '$RULESET'; expected one of: none, $(cd "$ACTION_PATH/rules" && ls *.yaml | sed 's/\.yaml$//' | tr '\n' ' ')"
+          exit 1
+        fi
+
+        # errexit is disabled around the scan deliberately: semgrep exits non-zero
+        # on findings and this step decides gating from that code itself.
+        set +e
+        docker run --rm \
+          -v "$PWD:/src:ro" -v "$ACTION_PATH/rules:/rules:ro" \
+          "semgrep/semgrep:$SEMGREP_VERSION" \
+          semgrep --config="/rules/$RULESET.yaml" --metrics=off --error /src \
+          | tee /tmp/semgrep.out
+        code=${PIPESTATUS[0]}
+        set -e
+
+        if [ "$code" = "0" ]; then
+          echo "semgrep: clean" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        {
+          echo "### semgrep findings"
+          echo ""
+          echo '```'
+          cat /tmp/semgrep.out
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "$ADVISORY" = "true" ]; then
+          echo "::warning::semgrep reported findings; advisory mode, not failing the check."
+          exit 0
+        fi
+
+        echo "::error::semgrep reported findings."
+        exit "$code"

--- a/security-actions/lint-semgrep/rules/service.yaml
+++ b/security-actions/lint-semgrep/rules/service.yaml
@@ -1,0 +1,288 @@
+# Conventions specific to the clean-architecture SERVICES (`cmd/` +
+# `internal/{config,lib,dao,core,handlers,models}`).
+#
+# There is no companion generic ruleset. Every rule that survived the audit turned
+# out to be service-shaped: tracing is a service concern (a library repo emits no
+# spans — golib only provides the helpers), and the conventions that do hold
+# everywhere are already covered by golangci-lint. Libraries get the linters and
+# nothing here. If a genuinely repo-shape-agnostic rule ever appears, it earns its
+# own file then, rather than an empty one kept warm now.
+#
+# What is deliberately NOT here, because golangci-lint already owns it:
+#   - `defer span.End()`          -> spancheck (on by default)
+#   - error recorded on the span  -> spancheck `record-error` + `set-status`
+#   - layer import direction      -> depguard
+#   - context stored in a struct  -> containedctx
+# Adding a second checker for any of those buys nothing and doubles the places a
+# false positive must be silenced.
+#
+# Two Semgrep limits shape what can live here:
+#   - Go patterns must enumerate return arity; there is no wildcard for it, so
+#     every signature match is repeated for no-return, one return, two returns.
+#   - Test files are skipped by Semgrep's built-in .semgrepignore, so NO rule can
+#     target *_test.go without replacing that default wholesale. Test conventions
+#     (sub-test naming, mock.Anything for ctx, AssertExpectations) therefore stay
+#     with review and the write-go-tests skill.
+
+rules:
+  # Every layer that carries a context is traced: core, dao, handlers and lib all
+  # open spans today. An unspanned method folds its latency into the caller and
+  # surfaces errors with no operation name.
+  - id: agora-must-open-span
+    languages: [go]
+    severity: ERROR
+    message: >-
+      $M takes a context but never opens an otel span, so its work is invisible
+      in traces. Open one with
+      `ctx, span := otel.Tracer().Start(ctx, "<layer>.<Operation>")`.
+    paths:
+      # internal/ only: pkg/go is a generated client and its mocks are not ours
+      # to instrument.
+      include:
+        - "internal/"
+      exclude:
+        - "*_test.go"
+        - "**/mocks/"
+        - "**/protogen/"
+    patterns:
+      # Both forms matter: core/dao/handlers expose methods, while internal/lib
+      # exposes plain functions (EncryptMasterKey, MasterKeyContext). Matching
+      # only the receiver form left the whole lib layer unchecked.
+      - pattern-either:
+          - pattern: "func ($R $T) $M(ctx context.Context, ...) { ... }"
+          - pattern: "func ($R $T) $M(ctx context.Context, ...) $RET { ... }"
+          - pattern: "func ($R $T) $M(ctx context.Context, ...) ($RET1, $RET2) { ... }"
+          - pattern: "func $M(ctx context.Context, ...) { ... }"
+          - pattern: "func $M(ctx context.Context, ...) $RET { ... }"
+          - pattern: "func $M(ctx context.Context, ...) ($RET1, $RET2) { ... }"
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) {
+            ...
+            otel.Tracer().Start(...)
+            ...
+          }
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) $RET {
+            ...
+            otel.Tracer().Start(...)
+            ...
+          }
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) ($RET1, $RET2) {
+            ...
+            otel.Tracer().Start(...)
+            ...
+          }
+      - pattern-not: |
+          func $M(ctx context.Context, ...) {
+            ...
+            otel.Tracer().Start(...)
+            ...
+          }
+      - pattern-not: |
+          func $M(ctx context.Context, ...) $RET {
+            ...
+            otel.Tracer().Start(...)
+            ...
+          }
+      - pattern-not: |
+          func $M(ctx context.Context, ...) ($RET1, $RET2) {
+            ...
+            otel.Tracer().Start(...)
+            ...
+          }
+      # A context.WithValue wrapper returns the context it derived and cannot
+      # fail; a span on it is an empty frame on every request.
+      - pattern-not: |
+          func $M(...) context.Context {
+            ...
+          }
+      # A pure delegator forwards to a spanned callee and does no work of its
+      # own; its span would be an empty frame in every trace.
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) ($RET1, $RET2) {
+            return $RECV.$INNER(ctx, ...)
+          }
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) $RET {
+            return $RECV.$INNER(ctx, ...)
+          }
+
+  # write-go: "Contexts flow downward only — caller to callee. Never return one."
+  # Scoped to the layers that carry request flow. internal/lib is exempt by
+  # design: a context helper (TransferMasterKeyContext, any WithX wrapper) must
+  # return the derived context — that is the whole pattern.
+  - id: agora-no-context-return
+    languages: [go]
+    severity: ERROR
+    message: >-
+      $F returns a context.Context. In the request layers a context flows
+      downward only — take one as the first parameter instead of handing one up.
+    paths:
+      include:
+        - "internal/core/"
+        - "internal/dao/"
+        - "internal/handlers/"
+      exclude:
+        - "*_test.go"
+        - "**/mocks/"
+        - "**/protogen/"
+    patterns:
+      - pattern-either:
+          - pattern: "func $F(...) context.Context { ... }"
+          - pattern: "func ($R $T) $F(...) context.Context { ... }"
+      # A context.WithValue wrapper has to hand back the context it derived —
+      # that is the whole pattern. Keyed on the body rather than on a directory,
+      # so it holds whether the helper lives in lib/ or handlers/middlewares/.
+      - pattern-not: |
+          func $F(...) context.Context {
+            ...
+            return context.WithValue(...)
+          }
+
+  # write-go-service: "One method per interface, named Exec." A dependency
+  # interface is the contract the consumer owns; a differently-named method means
+  # the boundary was drawn by hand instead of by the pattern.
+  #
+  # The compliant case is excluded with pattern-not rather than a negated regex:
+  # semgrep's regex engine has no lookahead. Return arity is enumerated because
+  # Go patterns have no wildcard for it.
+  - id: agora-dep-interface-method-must-be-exec
+    languages: [go]
+    severity: ERROR
+    message: >-
+      Dependency interface $NAME declares $METHOD; layer contracts expose exactly
+      one method, named Exec.
+    paths:
+      include:
+        - "internal/core/"
+        - "internal/handlers/"
+      exclude:
+        - "*_test.go"
+        - "**/mocks/"
+        - "**/protogen/"
+    patterns:
+      - pattern-either:
+          - pattern: |
+              type $NAME interface {
+                $METHOD(ctx context.Context, ...) ($RET1, $RET2)
+              }
+          - pattern: |
+              type $NAME interface {
+                $METHOD(ctx context.Context, ...) $RET
+              }
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: .*(Dao|Service[A-Za-z]*)$
+      - pattern-not: |
+          type $NAME interface {
+            Exec(ctx context.Context, ...) ($RET1, $RET2)
+          }
+      - pattern-not: |
+          type $NAME interface {
+            Exec(ctx context.Context, ...) $RET
+          }
+      # A protoc-generated client method is named by the proto, not by us. The
+      # `opts ...grpc.CallOption` tail is the shape that identifies one, which
+      # holds wherever the interface lives — unlike a path exemption.
+      - pattern-not: |
+          type $NAME interface {
+            $ANY(ctx context.Context, ..., $OPTS ...grpc.CallOption) ($O1, $O2)
+          }
+
+  # write-go-service: the Exec signature is
+  # `(ctx context.Context, request *XxxRequest)` so the request can gain a field
+  # without breaking callers. This catches the non-pointer case; a pointer to a
+  # badly-named struct needs the lookahead semgrep does not have.
+  - id: agora-exec-takes-request-pointer
+    languages: [go]
+    severity: ERROR
+    message: >-
+      Exec on $NAME takes $PARAM by value; it must take a
+      *<Entity><Operation>Request so the signature can gain a field later.
+    paths:
+      include:
+        - "internal/core/"
+        - "internal/handlers/"
+      exclude:
+        - "*_test.go"
+        - "**/mocks/"
+        - "**/protogen/"
+    patterns:
+      - pattern-either:
+          - pattern: |
+              type $NAME interface {
+                Exec(ctx context.Context, $ARG $PARAM) ($RET1, $RET2)
+              }
+          - pattern: |
+              type $NAME interface {
+                Exec(ctx context.Context, $ARG $PARAM) $RET
+              }
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: .*(Dao|Service[A-Za-z]*)$
+      - metavariable-regex:
+          metavariable: $PARAM
+          regex: ^[^*]
+
+  # write-go, Secrets: "Never log, trace, or put in span attributes: passwords,
+  # tokens, API keys, private keys ... Record identifiers only." A span attribute
+  # is the easiest of these to add by reflex and the hardest to notice later.
+  - id: agora-no-secret-in-span-attribute
+    languages: [go]
+    severity: ERROR
+    message: >-
+      Span attribute "$KEY" names credential material. Traces are retained and
+      widely readable — record an identifier (`user.id`, `key.id`) instead.
+    paths:
+      exclude:
+        - "*_test.go"
+    patterns:
+      - pattern-either:
+          - pattern: attribute.String($KEY, ...)
+          - pattern: attribute.StringSlice($KEY, ...)
+      - metavariable-regex:
+          metavariable: $KEY
+          regex: (?i)"?([a-z0-9_.]*\.)?(password|passwd|secret|token|apikey|api_key|privatekey|private_key|ciphertext|signature|bearer)"?$
+
+  # write-go-service: service and DAO types are "stateless after construction —
+  # every field is set by New* and never mutated, so every type is safe for
+  # concurrent use without synchronization. This is a requirement."
+  #
+  # Constructors are plain functions, not methods, so matching the receiver form
+  # targets exactly the mutation this forbids.
+  - id: agora-no-receiver-mutation
+    languages: [go]
+    severity: ERROR
+    message: >-
+      $M assigns to $R.$FIELD after construction. These types are shared across
+      concurrent requests unsynchronised; every field must be set by New$T only.
+    paths:
+      include:
+        - "internal/core/"
+        - "internal/dao/"
+        - "internal/handlers/"
+      exclude:
+        - "*_test.go"
+        - "**/mocks/"
+        - "**/protogen/"
+    patterns:
+      - pattern-either:
+          - pattern: |
+              func ($R $T) $M(...) {
+                ...
+                $R.$FIELD = $VAL
+                ...
+              }
+          - pattern: |
+              func ($R $T) $M(...) $RET {
+                ...
+                $R.$FIELD = $VAL
+                ...
+              }
+          - pattern: |
+              func ($R $T) $M(...) ($RET1, $RET2) {
+                ...
+                $R.$FIELD = $VAL
+                ...
+              }

--- a/security-actions/lint-semgrep/rules/service.yaml
+++ b/security-actions/lint-semgrep/rules/service.yaml
@@ -1,33 +1,16 @@
-# Conventions specific to the clean-architecture SERVICES (`cmd/` +
-# `internal/{config,lib,dao,core,handlers,models}`).
+# Structural conventions for the clean-architecture services: a call that must be
+# present, a pairing that must hold.
 #
-# There is no companion generic ruleset. Every rule that survived the audit turned
-# out to be service-shaped: tracing is a service concern (a library repo emits no
-# spans — golib only provides the helpers), and the conventions that do hold
-# everywhere are already covered by golangci-lint. Libraries get the linters and
-# nothing here. If a genuinely repo-shape-agnostic rule ever appears, it earns its
-# own file then, rather than an empty one kept warm now.
+# Not duplicated here — golangci-lint owns them: span lifecycle and error
+# reporting (spancheck), layer import direction (depguard), context in a struct
+# (containedctx).
 #
-# What is deliberately NOT here, because golangci-lint already owns it:
-#   - `defer span.End()`          -> spancheck (on by default)
-#   - error recorded on the span  -> spancheck `record-error` + `set-status`
-#   - layer import direction      -> depguard
-#   - context stored in a struct  -> containedctx
-# Adding a second checker for any of those buys nothing and doubles the places a
-# false positive must be silenced.
-#
-# Two Semgrep limits shape what can live here:
-#   - Go patterns must enumerate return arity; there is no wildcard for it, so
-#     every signature match is repeated for no-return, one return, two returns.
-#   - Test files are skipped by Semgrep's built-in .semgrepignore, so NO rule can
-#     target *_test.go without replacing that default wholesale. Test conventions
-#     (sub-test naming, mock.Anything for ctx, AssertExpectations) therefore stay
-#     with review and the write-go-tests skill.
-
+# Two Semgrep limits to know before adding a rule: Go has no return-arity
+# wildcard, so signature matches repeat per arity; and *_test.go is skipped by
+# its built-in ignore list, so no rule can target tests.
 rules:
-  # Every layer that carries a context is traced: core, dao, handlers and lib all
-  # open spans today. An unspanned method folds its latency into the caller and
-  # surfaces errors with no operation name.
+  # An unspanned method folds its latency into the caller and surfaces errors
+  # with no operation name.
   - id: agora-must-open-span
     languages: [go]
     severity: ERROR

--- a/security-actions/lint-semgrep/rules/service.yaml
+++ b/security-actions/lint-semgrep/rules/service.yaml
@@ -107,6 +107,16 @@ rules:
           func ($R $T) $M(ctx context.Context, ...) $RET {
             return $RECV.$INNER(ctx, ...)
           }
+      # Same delegation, plain-function form: internal/lib and handler
+      # middlewares wrap a spanned callee without a receiver.
+      - pattern-not: |
+          func $M(ctx context.Context, ...) ($RET1, $RET2) {
+            return $INNER(ctx, ...)
+          }
+      - pattern-not: |
+          func $M(ctx context.Context, ...) $RET {
+            return $INNER(ctx, ...)
+          }
 
   # write-go: "Contexts flow downward only — caller to callee. Never return one."
   # Scoped to the layers that carry request flow. internal/lib is exempt by

--- a/security-actions/lint-workflows/action.yaml
+++ b/security-actions/lint-workflows/action.yaml
@@ -1,15 +1,9 @@
 name: lint workflows
 description: >
-  Audit a repo's GitHub Actions workflows with zizmor. This is what replaces CodeQL's `actions`
-  analysis: zizmor's `excessive-permissions` is the class CodeQL reported as
-  `actions/missing-workflow-permissions`, and it audits several more — credentials left in
-  .git/config by checkout, cache poisoning, template injection, floating action refs.
-
-  A baseline config ships with the action, tuned to this fleet's conventions: tag pins are accepted
-  (ref-pin), because Renovate moves the whole workflows reference set as one grouped update and a
-  per-action hash pin breaks that grouping.
-
-  Runs `--offline`, so like the other gates nothing off-repo can stall it.
+  Audit GitHub Actions workflows with zizmor. Replaces CodeQL's `actions` analysis: its
+  `excessive-permissions` is the class CodeQL reported as `actions/missing-workflow-permissions`,
+  plus checkout credential leaks, cache poisoning and floating refs. Config ships with the action;
+  runs `--offline`.
 
 inputs:
   config:
@@ -27,12 +21,8 @@ inputs:
   version:
     required: true
     description: >
-      REQUIRED. Pin it in the caller so Renovate sees it there and can bump it per repo,
-      rather than every tool upgrade waiting on a workflows release. The caller annotates it:
+      zizmor image tag. Pinned by the caller so Renovate bumps it per repo. Annotate it:
       `# renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor`.
-      The zizmor image tag to pin. Run as a container step rather than a `container:` job: the
-      image has no libstdc++, and a job container makes GitHub inject its Node runtime into it,
-      so actions/checkout cannot start there.
 
 runs:
   using: composite

--- a/security-actions/lint-workflows/action.yaml
+++ b/security-actions/lint-workflows/action.yaml
@@ -25,9 +25,11 @@ inputs:
       When "true", findings go to the run summary and the log but the check passes — for a repo
       adopting the audit over an existing backlog. When "false" (the default), any finding fails.
   version:
-    required: false
-    default: "1.28.0"
+    required: true
     description: >
+      REQUIRED. Pin it in the caller so Renovate sees it there and can bump it per repo,
+      rather than every tool upgrade waiting on a workflows release. The caller annotates it:
+      `# renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor`.
       The zizmor image tag to pin. Run as a container step rather than a `container:` job: the
       image has no libstdc++, and a job container makes GitHub inject its Node runtime into it,
       so actions/checkout cannot start there.

--- a/security-actions/lint-workflows/action.yaml
+++ b/security-actions/lint-workflows/action.yaml
@@ -1,0 +1,93 @@
+name: lint workflows
+description: >
+  Audit a repo's GitHub Actions workflows with zizmor. This is what replaces CodeQL's `actions`
+  analysis: zizmor's `excessive-permissions` is the class CodeQL reported as
+  `actions/missing-workflow-permissions`, and it audits several more — credentials left in
+  .git/config by checkout, cache poisoning, template injection, floating action refs.
+
+  A baseline config ships with the action, tuned to this fleet's conventions: tag pins are accepted
+  (ref-pin), because Renovate moves the whole workflows reference set as one grouped update and a
+  per-action hash pin breaks that grouping.
+
+  Runs `--offline`, so like the other gates nothing off-repo can stall it.
+
+inputs:
+  config:
+    required: false
+    default: ""
+    description: >
+      Path to a repo-local zizmor config, relative to the workspace. Empty (the default) uses the
+      baseline shipped with this action.
+  advisory:
+    required: false
+    default: "false"
+    description: >
+      When "true", findings go to the run summary and the log but the check passes — for a repo
+      adopting the audit over an existing backlog. When "false" (the default), any finding fails.
+  version:
+    required: false
+    default: "1.28.0"
+    description: >
+      The zizmor image tag to pin. Run as a container step rather than a `container:` job: the
+      image has no libstdc++, and a job container makes GitHub inject its Node runtime into it,
+      so actions/checkout cannot start there.
+
+runs:
+  using: composite
+  steps:
+    - name: zizmor
+      shell: bash
+      env:
+        CONFIG: ${{ inputs.config }}
+        ADVISORY: ${{ inputs.advisory }}
+        ZIZMOR_VERSION: ${{ inputs.version }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+
+        if [ ! -d .github/workflows ]; then
+          echo "no .github/workflows — nothing to audit."
+          exit 0
+        fi
+
+        if [ -n "${CONFIG:-}" ]; then
+          if [ ! -f "$CONFIG" ]; then
+            echo "::error::config '$CONFIG' not found in the workspace."
+            exit 1
+          fi
+          mount_cfg="$PWD/$CONFIG"
+        else
+          mount_cfg="$ACTION_PATH/zizmor.yml"
+        fi
+
+        # errexit is disabled around the audit deliberately: zizmor exits
+        # non-zero on findings and this step decides gating from that code.
+        set +e
+        docker run --rm \
+          -v "$PWD:/src:ro" -v "$mount_cfg:/zizmor.yml:ro" \
+          "ghcr.io/zizmorcore/zizmor:$ZIZMOR_VERSION" \
+          --offline --config /zizmor.yml /src/.github/workflows \
+          | tee /tmp/zizmor.out
+        code=${PIPESTATUS[0]}
+        set -e
+
+        if [ "$code" = "0" ]; then
+          echo "zizmor: no findings" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        {
+          echo "### zizmor findings"
+          echo ""
+          echo '```'
+          tail -c 60000 /tmp/zizmor.out
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "$ADVISORY" = "true" ]; then
+          echo "::warning::zizmor reported findings; advisory mode, not failing the check."
+          exit 0
+        fi
+
+        echo "::error::zizmor reported findings."
+        exit "$code"

--- a/security-actions/lint-workflows/zizmor.yml
+++ b/security-actions/lint-workflows/zizmor.yml
@@ -1,0 +1,24 @@
+# Baseline zizmor config, shipped with the lint-workflows action.
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Tag pins are deliberate across this fleet, not an oversight: Renovate
+        # moves the whole a-novel-kit/workflows reference set as one grouped
+        # update, and a repo must sit at a single workflows version. Per-action
+        # hash pins break that grouping and make the diff unreadable.
+        #
+        # ref-pin still fails a genuinely floating `@master` or a missing ref,
+        # which is the failure this audit exists to catch. It only accepts a tag
+        # as sufficient.
+        "*": ref-pin
+
+  cache-poisoning:
+    ignore:
+      # main.yaml both restores a build cache and builds images, which is the
+      # shape this audit looks for. The attack needs a lower-trust branch to
+      # write a cache a release run then reads; GitHub scopes cache writes so a
+      # PR branch cannot reach the default branch's scope, and releases are cut
+      # from release.yaml. zizmor rates the finding Low for the same reason.
+      - main.yaml

--- a/security-actions/scan-secrets/action.yaml
+++ b/security-actions/scan-secrets/action.yaml
@@ -1,0 +1,99 @@
+name: scan secrets
+description: >
+  Scan the working tree for committed credentials with gitleaks. A baseline config ships with the
+  action, so most repos need none of their own; a repo with local fixtures adds a .gitleaks.toml
+  that extends it. The scan is offline and finishes in tens of milliseconds, which is what makes it
+  safe on the merge path — unlike a hosted scanner, nothing off-repo can stall it.
+
+  History is deliberately out of scope: a secret that was committed and later deleted is invisible
+  here. That gap belongs to a scheduled sweep, where a slower, network-dependent scan costs an
+  investigation rather than a blocked merge.
+
+  The gitleaks BINARY is used, not gitleaks-action: the action is separately licensed and its free
+  tier covers a single repo per organisation.
+
+inputs:
+  config:
+    required: false
+    default: ""
+    description: >
+      Path to a repo-local gitleaks config, relative to the workspace. Empty (the default) uses the
+      baseline shipped with this action. A repo that needs a local allowlist points here at a file
+      whose [extend] path is the value this action exports as GITLEAKS_BASE in the step summary.
+  advisory:
+    required: false
+    default: "false"
+    description: >
+      When "true", findings go to the run summary and the log but the check passes — for a repo
+      adopting the scan over an existing backlog. When "false" (the default), any finding fails.
+  version:
+    required: false
+    default: "8.30.1"
+    description: >
+      The gitleaks release to pin — a `gitleaks/gitleaks` tag without the leading v. The binary is
+      fetched from that release; it is not preinstalled on the runner.
+
+runs:
+  using: composite
+  steps:
+    - name: install gitleaks
+      shell: bash
+      env:
+        GITLEAKS_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        curl -sSfL --retry 3 --retry-delay 2 \
+          "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          | tar -xz -C /usr/local/bin gitleaks
+        gitleaks version
+
+    - name: scan working tree
+      shell: bash
+      env:
+        CONFIG: ${{ inputs.config }}
+        ADVISORY: ${{ inputs.advisory }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+
+        base="$ACTION_PATH/gitleaks.toml"
+        config="${CONFIG:-}"
+        if [ -z "$config" ]; then
+          config="$base"
+        elif [ ! -f "$config" ]; then
+          echo "::error::config '$config' not found in the workspace."
+          exit 1
+        fi
+        echo "GITLEAKS_BASE=$base" >> "$GITHUB_STEP_SUMMARY"
+
+        # errexit is disabled around the scan deliberately: gitleaks exits
+        # non-zero on findings and this step decides gating from that code.
+        set +e
+        gitleaks dir . --config "$config" --redact --exit-code 1 --verbose | tee /tmp/gitleaks.out
+        code=${PIPESTATUS[0]}
+        set -e
+
+        if [ "$code" = "0" ]; then
+          echo "gitleaks: no leaks found" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        {
+          echo "### gitleaks findings"
+          echo ""
+          echo "Values are redacted. Inspect each one before allowlisting: scope an allowlist to the"
+          echo "exact value or path, never to a whole rule, so a real credential in the same file"
+          echo "still fails."
+          echo ""
+          echo '```'
+          tail -c 60000 /tmp/gitleaks.out
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "$ADVISORY" = "true" ]; then
+          echo "::warning::gitleaks reported findings; advisory mode, not failing the check."
+          exit 0
+        fi
+
+        echo "::error::gitleaks reported findings."
+        exit "$code"

--- a/security-actions/scan-secrets/action.yaml
+++ b/security-actions/scan-secrets/action.yaml
@@ -18,8 +18,18 @@ inputs:
     default: ""
     description: >
       Path to a repo-local gitleaks config, relative to the workspace. Empty (the default) uses the
-      baseline shipped with this action. A repo that needs a local allowlist points here at a file
-      whose [extend] path is the value this action exports as GITLEAKS_BASE in the step summary.
+      baseline shipped with this action.
+
+      A repo config EXTENDS the baseline rather than replacing it. Before scanning, the action
+      writes the baseline into the workspace as `.gitleaks-base.toml`, so a repo names it by a
+      path it can author — the action's own path lives under _actions/<tag>/ and is not knowable
+      when the file is written. The repo config opens with:
+
+        [extend]
+        path = ".gitleaks-base.toml"
+
+      Without that block the repo config replaces the baseline outright, which is occasionally
+      what you want and never what you want by accident.
   advisory:
     required: false
     default: "false"
@@ -27,9 +37,11 @@ inputs:
       When "true", findings go to the run summary and the log but the check passes — for a repo
       adopting the scan over an existing backlog. When "false" (the default), any finding fails.
   version:
-    required: false
-    default: "8.30.1"
+    required: true
     description: >
+      REQUIRED. Pin it in the caller so Renovate sees it there and can bump it per repo,
+      rather than every tool upgrade waiting on a workflows release. The caller annotates it:
+      `# renovate: datasource=github-releases depName=gitleaks/gitleaks`.
       The gitleaks release to pin — a `gitleaks/gitleaks` tag without the leading v. The binary is
       fetched from that release; it is not preinstalled on the runner.
 
@@ -56,15 +68,21 @@ runs:
       run: |
         set -euo pipefail
 
-        base="$ACTION_PATH/gitleaks.toml"
+        # Materialise the baseline where a repo config can name it. gitleaks
+        # resolves `[extend] path` against its own working directory, which is
+        # the workspace here — not against the config file's location.
+        cp "$ACTION_PATH/gitleaks.toml" .gitleaks-base.toml
+        trap 'rm -f .gitleaks-base.toml' EXIT
+
         config="${CONFIG:-}"
         if [ -z "$config" ]; then
-          config="$base"
+          config=".gitleaks-base.toml"
         elif [ ! -f "$config" ]; then
           echo "::error::config '$config' not found in the workspace."
           exit 1
+        elif ! grep -q 'gitleaks-base\.toml' "$config"; then
+          echo "::warning::$config does not extend .gitleaks-base.toml, so it REPLACES the shared baseline. Add [extend] path = \".gitleaks-base.toml\" unless that is deliberate."
         fi
-        echo "GITLEAKS_BASE=$base" >> "$GITHUB_STEP_SUMMARY"
 
         # errexit is disabled around the scan deliberately: gitleaks exits
         # non-zero on findings and this step decides gating from that code.

--- a/security-actions/scan-secrets/action.yaml
+++ b/security-actions/scan-secrets/action.yaml
@@ -1,35 +1,25 @@
 name: scan secrets
 description: >
   Scan the working tree for committed credentials with gitleaks. A baseline config ships with the
-  action, so most repos need none of their own; a repo with local fixtures adds a .gitleaks.toml
-  that extends it. The scan is offline and finishes in tens of milliseconds, which is what makes it
-  safe on the merge path — unlike a hosted scanner, nothing off-repo can stall it.
+  action; most repos need none of their own. Offline and sub-second, which is what makes it safe on
+  the merge path.
 
-  History is deliberately out of scope: a secret that was committed and later deleted is invisible
-  here. That gap belongs to a scheduled sweep, where a slower, network-dependent scan costs an
-  investigation rather than a blocked merge.
+  History is out of scope — a secret committed then deleted is invisible here. That belongs to a
+  scheduled sweep, where a network-dependent scan costs an investigation, not a blocked merge.
 
-  The gitleaks BINARY is used, not gitleaks-action: the action is separately licensed and its free
-  tier covers a single repo per organisation.
+  Uses the gitleaks binary, not gitleaks-action: the action's free tier covers one repo per org.
 
 inputs:
   config:
     required: false
     default: ""
     description: >
-      Path to a repo-local gitleaks config, relative to the workspace. Empty (the default) uses the
-      baseline shipped with this action.
+      Repo-local gitleaks config, relative to the workspace. Empty uses the shipped baseline.
 
-      A repo config EXTENDS the baseline rather than replacing it. Before scanning, the action
-      writes the baseline into the workspace as `.gitleaks-base.toml`, so a repo names it by a
-      path it can author — the action's own path lives under _actions/<tag>/ and is not knowable
-      when the file is written. The repo config opens with:
-
-        [extend]
-        path = ".gitleaks-base.toml"
-
-      Without that block the repo config replaces the baseline outright, which is occasionally
-      what you want and never what you want by accident.
+      To ADD to the baseline rather than replace it, open the file with
+      `[extend] path = ".gitleaks-base.toml"` — the action writes the baseline there before
+      scanning, because its own path under _actions/<tag>/ is not knowable when the repo file is
+      authored. Omitting the block replaces the baseline, and the action warns.
   advisory:
     required: false
     default: "false"
@@ -39,11 +29,8 @@ inputs:
   version:
     required: true
     description: >
-      REQUIRED. Pin it in the caller so Renovate sees it there and can bump it per repo,
-      rather than every tool upgrade waiting on a workflows release. The caller annotates it:
-      `# renovate: datasource=github-releases depName=gitleaks/gitleaks`.
-      The gitleaks release to pin — a `gitleaks/gitleaks` tag without the leading v. The binary is
-      fetched from that release; it is not preinstalled on the runner.
+      gitleaks release tag, without the leading v. Pinned by the caller so Renovate bumps it per
+      repo. Annotate it: `# renovate: datasource=github-releases depName=gitleaks/gitleaks`.
 
 runs:
   using: composite

--- a/security-actions/scan-secrets/action.yaml
+++ b/security-actions/scan-secrets/action.yaml
@@ -41,8 +41,11 @@ runs:
         GITLEAKS_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
+        # gitleaks tags its releases v-prefixed but names the archive without it.
+        # Accept either spelling of the input so a bump that keeps the v still resolves.
+        v="${GITLEAKS_VERSION#v}"
         curl -sSfL --retry 3 --retry-delay 2 \
-          "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          "https://github.com/gitleaks/gitleaks/releases/download/v${v}/gitleaks_${v}_linux_x64.tar.gz" \
           | tar -xz -C /usr/local/bin gitleaks
         gitleaks version
 

--- a/security-actions/scan-secrets/gitleaks.toml
+++ b/security-actions/scan-secrets/gitleaks.toml
@@ -5,8 +5,11 @@
 # adds its own .gitleaks.toml that extends this one:
 #
 #   [extend]
-#   path = "<the path the action passes as GITLEAKS_BASE>"
-#   useDefault = true
+#   path = ".gitleaks-base.toml"
+#
+# The action writes this file into the workspace before scanning, so the repo
+# names a path it can author. Allowlists chain: the repo's add to these rather
+# than replacing them.
 #
 # Every allowlist targets `generic-api-key` alone — the entropy heuristic. The
 # provider-specific rules (AWS, GitHub, Stripe, ...) stay active everywhere,

--- a/security-actions/scan-secrets/gitleaks.toml
+++ b/security-actions/scan-secrets/gitleaks.toml
@@ -1,0 +1,33 @@
+# Baseline gitleaks config, shipped with the scan-secrets action.
+#
+# It carries only the allowlists that are true for every repo in the fleet, so
+# most repos need no config of their own. A repo with genuinely local fixtures
+# adds its own .gitleaks.toml that extends this one:
+#
+#   [extend]
+#   path = "<the path the action passes as GITLEAKS_BASE>"
+#   useDefault = true
+#
+# Every allowlist targets `generic-api-key` alone — the entropy heuristic. The
+# provider-specific rules (AWS, GitHub, Stripe, ...) stay active everywhere,
+# including in tests, because a real cloud credential is never acceptable there.
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Checksum manifests: module digests are high-entropy by construction."
+targetRules = ["generic-api-key"]
+paths = ['''(^|/)(buf|go)\.sum$''', '''(^|/)pnpm-lock\.yaml$''']
+
+[[allowlists]]
+description = "Go test fixtures: sample keys and tokens generated per test, granting nothing."
+targetRules = ["generic-api-key"]
+paths = ['''_test\.go$''']
+
+[[allowlists]]
+description = "Compose and CI env blocks: throwaway credentials for a database that lives for one job."
+targetRules = ["generic-api-key"]
+regexes = [
+  '''postgres://postgres:postgres@''',
+]

--- a/tests/security-actions.sh
+++ b/tests/security-actions.sh
@@ -130,6 +130,20 @@ check "zizmor: findings fail when gating" 1 $?
 run_step "$TMP/zizmor.sh" "CONFIG=" "ADVISORY=true" "ZIZMOR_VERSION=x" "ACTION_PATH=$ZIZMOR_DIR"
 check "zizmor: findings pass in advisory mode" 0 $?
 
+# --- gitleaks version prefix -------------------------------------------------
+# gitleaks tags releases v-prefixed but names archives without it, and it is the only one of the
+# three whose datasource returns the v. A bump that keeps it must still resolve.
+extract "$SECRETS_ACTION" "install gitleaks" >"$TMP/install.sh"
+for spelling in 8.30.1 v8.30.1; do
+  got=$(GITLEAKS_VERSION="$spelling" bash -c '
+    v="${GITLEAKS_VERSION#v}"
+    echo "https://github.com/gitleaks/gitleaks/releases/download/v${v}/gitleaks_${v}_linux_x64.tar.gz"')
+  want="https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+  check "gitleaks: version '$spelling' builds the release URL" "$want" "$got"
+done
+# and the shipped script must actually strip it, not just the test's copy
+check "gitleaks: install step strips a leading v" 1 "$(grep -c 'GITLEAKS_VERSION#v' "$TMP/install.sh")"
+
 # --- version is required on all three ----------------------------------------
 # A default would pin the tool inside the action, where Renovate in the consuming repo cannot see
 # it, and every upgrade would wait on a workflows release.

--- a/tests/security-actions.sh
+++ b/tests/security-actions.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Gating tests for the three security actions.
+#
+# Each step's script is extracted verbatim from its manifest and run with the scanner stubbed, so
+# the assertions are on the shipped code rather than a copy. The run bodies read their inputs from
+# env: only — no ${{ }} — which is what makes that possible.
+#
+# Gating is the whole point of the tests: a check that reports findings and exits 0 looks identical
+# to a clean run in the checks UI, and one that fails in advisory mode blocks a repo that was only
+# meant to be watching.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+check() { # $1=label $2=expected $3=actual
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected [$2], got [$3]"
+    fails=$((fails + 1))
+  fi
+}
+
+# Extract one step's `run:` body verbatim from a manifest.
+extract() { # $1=manifest $2=step name
+  python3 -c "
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+for s in d['runs']['steps']:
+    if s.get('name') == sys.argv[2]:
+        sys.stdout.write(s['run']); break
+else:
+    sys.exit('no step named ' + sys.argv[2])
+" "$1" "$2"
+}
+
+# A stub scanner that exits with $1 and prints a finding line, placed ahead of the real one on PATH.
+stub() { # $1=name $2=exit code
+  mkdir -p "$TMP/bin"
+  printf '#!/usr/bin/env bash\necho "stub-%s finding"\nexit %s\n' "$1" "$2" >"$TMP/bin/$1"
+  chmod +x "$TMP/bin/$1"
+}
+
+run_step() { # $1=script file; remaining args are env assignments
+  local script="$1"
+  shift
+  (
+    cd "$TMP/work" || exit 99
+    export PATH="$TMP/bin:$PATH"
+    export GITHUB_STEP_SUMMARY="$TMP/summary"
+    for kv in "$@"; do export "${kv?}"; done
+    bash "$script" >"$TMP/out" 2>&1
+  )
+}
+
+mkdir -p "$TMP/work"
+: >"$TMP/summary"
+
+# --- lint-semgrep ------------------------------------------------------------
+SEMGREP_ACTION="$ROOT/security-actions/lint-semgrep/action.yaml"
+extract "$SEMGREP_ACTION" semgrep >"$TMP/semgrep.sh"
+SEMGREP_DIR="$ROOT/security-actions/lint-semgrep"
+
+stub docker 0
+run_step "$TMP/semgrep.sh" "RULESET=none" "ADVISORY=false" "SEMGREP_VERSION=x" "ACTION_PATH=$SEMGREP_DIR"
+check "semgrep: ruleset=none is a clean pass" 0 $?
+
+run_step "$TMP/semgrep.sh" "RULESET=nope" "ADVISORY=false" "SEMGREP_VERSION=x" "ACTION_PATH=$SEMGREP_DIR"
+check "semgrep: unknown ruleset fails" 1 $?
+
+run_step "$TMP/semgrep.sh" "RULESET=service" "ADVISORY=false" "SEMGREP_VERSION=x" "ACTION_PATH=$SEMGREP_DIR"
+check "semgrep: clean scan passes" 0 $?
+
+stub docker 1
+run_step "$TMP/semgrep.sh" "RULESET=service" "ADVISORY=false" "SEMGREP_VERSION=x" "ACTION_PATH=$SEMGREP_DIR"
+check "semgrep: findings fail when gating" 1 $?
+
+run_step "$TMP/semgrep.sh" "RULESET=service" "ADVISORY=true" "SEMGREP_VERSION=x" "ACTION_PATH=$SEMGREP_DIR"
+check "semgrep: findings pass in advisory mode" 0 $?
+
+# --- scan-secrets ------------------------------------------------------------
+SECRETS_ACTION="$ROOT/security-actions/scan-secrets/action.yaml"
+extract "$SECRETS_ACTION" "scan working tree" >"$TMP/secrets.sh"
+SECRETS_DIR="$ROOT/security-actions/scan-secrets"
+
+stub gitleaks 0
+run_step "$TMP/secrets.sh" "CONFIG=" "ADVISORY=false" "ACTION_PATH=$SECRETS_DIR"
+check "gitleaks: clean scan passes" 0 $?
+
+run_step "$TMP/secrets.sh" "CONFIG=nope.toml" "ADVISORY=false" "ACTION_PATH=$SECRETS_DIR"
+check "gitleaks: missing config fails" 1 $?
+
+stub gitleaks 1
+run_step "$TMP/secrets.sh" "CONFIG=" "ADVISORY=false" "ACTION_PATH=$SECRETS_DIR"
+check "gitleaks: findings fail when gating" 1 $?
+
+run_step "$TMP/secrets.sh" "CONFIG=" "ADVISORY=true" "ACTION_PATH=$SECRETS_DIR"
+check "gitleaks: findings pass in advisory mode" 0 $?
+
+# A repo config that does not extend the baseline replaces it silently; the action must say so.
+stub gitleaks 0
+printf '[extend]\nuseDefault = true\n' >"$TMP/work/own.toml"
+run_step "$TMP/secrets.sh" "CONFIG=own.toml" "ADVISORY=false" "ACTION_PATH=$SECRETS_DIR"
+check "gitleaks: config not extending the baseline warns" 1 "$(grep -c '::warning::.*REPLACES' "$TMP/out")"
+
+printf '[extend]\npath = ".gitleaks-base.toml"\n' >"$TMP/work/ext.toml"
+run_step "$TMP/secrets.sh" "CONFIG=ext.toml" "ADVISORY=false" "ACTION_PATH=$SECRETS_DIR"
+check "gitleaks: config extending the baseline is quiet" 0 "$(grep -c '::warning::.*REPLACES' "$TMP/out")"
+
+# --- lint-workflows ----------------------------------------------------------
+ZIZMOR_ACTION="$ROOT/security-actions/lint-workflows/action.yaml"
+extract "$ZIZMOR_ACTION" zizmor >"$TMP/zizmor.sh"
+ZIZMOR_DIR="$ROOT/security-actions/lint-workflows"
+
+stub docker 0
+run_step "$TMP/zizmor.sh" "CONFIG=" "ADVISORY=false" "ZIZMOR_VERSION=x" "ACTION_PATH=$ZIZMOR_DIR"
+check "zizmor: no workflows dir is a clean pass" 0 $?
+
+mkdir -p "$TMP/work/.github/workflows"
+run_step "$TMP/zizmor.sh" "CONFIG=" "ADVISORY=false" "ZIZMOR_VERSION=x" "ACTION_PATH=$ZIZMOR_DIR"
+check "zizmor: clean audit passes" 0 $?
+
+stub docker 1
+run_step "$TMP/zizmor.sh" "CONFIG=" "ADVISORY=false" "ZIZMOR_VERSION=x" "ACTION_PATH=$ZIZMOR_DIR"
+check "zizmor: findings fail when gating" 1 $?
+
+run_step "$TMP/zizmor.sh" "CONFIG=" "ADVISORY=true" "ZIZMOR_VERSION=x" "ACTION_PATH=$ZIZMOR_DIR"
+check "zizmor: findings pass in advisory mode" 0 $?
+
+# --- version is required on all three ----------------------------------------
+# A default would pin the tool inside the action, where Renovate in the consuming repo cannot see
+# it, and every upgrade would wait on a workflows release.
+for a in lint-semgrep scan-secrets lint-workflows; do
+  got=$(python3 -c "
+import yaml, sys
+v = yaml.safe_load(open(sys.argv[1]))['inputs']['version']
+print('required' if v.get('required') and 'default' not in v else 'optional')
+" "$ROOT/security-actions/$a/action.yaml")
+  check "$a: version is required with no default" required "$got"
+done
+
+if [ "$fails" -gt 0 ]; then
+  echo "::error::$fails security-action assertion(s) failed"
+  exit 1
+fi
+echo "security-actions: all assertions passed"


### PR DESCRIPTION
## Summary

The shared half of replacing GitGuardian and CodeQL with checks that run in CI. Three composite
actions, each shipping its own config so a **consuming repo carries none** — it pins a workflows
tag and gets the rules that tag shipped.

| Action | Replaces | Repo-side config |
| --- | --- | --- |
| `lint-semgrep` | — (new: conventions golangci-lint cannot express) | none |
| `scan-secrets` | GitGuardian | none, unless the repo has local fixtures |
| `lint-workflows` | CodeQL's `actions` analysis | none |

## Why

`GitGuardian Security Checks` was a required check backed by a hosted service. On 2026-07-23 it
saturated to roughly **one scan per minute** against a fleet opening **144 PRs/day**, and because a
required check that never arrives has no timeout, every affected PR became permanently unmergeable.
It self-resolved and recurs on each Renovate burst.

The rule that follows is narrower than "GitGuardian is bad":

> **A required status check must not depend on a third-party network service.**

All three actions run offline. Anything needing the network — history scanning, credential
verification — belongs to a scheduled sweep, off the merge path.

## Adoption

Every action takes `advisory: "true"`, following `generic-actions/lint-dockerfile`. A repo adopts
non-gating, clears its backlog, then flips to gating. That matters: validating the ruleset against a
second service surfaced real debt that should not block anyone's merges on day one.

Libraries pass `ruleset: none` to `lint-semgrep` — every rule assumes the clean-architecture layout,
and library conventions are golangci-lint's job.

## The ruleset was validated on two repos, not one

Rules were tuned on `service-json-keys` (55 files), then run **unchanged** against
`service-authentication` (85 files):

| | findings |
| --- | --- |
| first run | **31** |
| after anchoring the secret regex + `**/mocks/` glob | 12 |
| after shape-keyed exemptions | 7 |
| after context-wrapper + delegator exemptions | **6** |

The residual 6 are genuine debt plus two judgement calls, not rule bugs — which is what `advisory`
is for.

**Exemptions are keyed on code shape, never on paths.** A protoc client method is identified by its
`opts ...grpc.CallOption` tail; a context helper by returning `context.WithValue`. The path-keyed
versions described one repo's layout (`internal/lib`) and were wrong for the next
(`handlers/middlewares`). In a shared ruleset that error is wrong for fifteen repos at once.

## Landed gotchas, so they are not rediscovered

- **zizmor runs as a container step, not a `container:` job.** Its image has no `libstdc++`, and a
  job container makes GitHub inject its Node runtime into it, so `actions/checkout` dies *before*
  zizmor runs — a config that looks correct and never executes the tool.
- **`scan-secrets` uses the gitleaks binary, not `gitleaks-action`.** The action is separately
  licensed; its free tier covers one repo per organisation.
- **Image tags are pinned, never `latest`.** A `latest` manifest lookup measured 118s of the 119s a
  scan took; pinned, the same scan is ~12s.

## Not in this PR

- Dropping GitGuardian from `checks.yaml` and the per-repo `main.yaml` job blocks. Those land
  together in one sweep so there is never a window with no secret gate, and one `a-novel repo
  update` reconciles each ruleset.
- `a-novel/service-json-keys#877` is the validated reference implementation this was extracted from.

## Test plan

- [x] `lint-action-manifests` — no composite-illegal expression contexts
- [x] every step script parses (`bash -n`)
- [x] prettier clean
- [x] ruleset validated against two services
- [ ] CI green