### PR TITLE
feat(actions)!: pin every external dependency where Renovate can see it

### DIFF
--- a/.github/workflows/hotfix-run.yaml
+++ b/.github/workflows/hotfix-run.yaml
@@ -199,6 +199,8 @@ jobs:
         id: cut
         uses: a-novel-kit/workflows/publish-actions/release-core-hotfix@v1.25.1
         with:
+          # renovate: datasource=go depName=github.com/a-novel-kit/stack/cli
+          cli_version: "1.7.5"
           ref: ${{ steps.prepare.outputs.ephemeral }}
           client_id: ${{ inputs.client_id }}
           app_private_key: ${{ secrets.app_private_key }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,3 +91,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./generic-actions/lint-shell
+        with:
+          # renovate: datasource=github-releases depName=koalaman/shellcheck
+          version: "0.11.0"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,8 @@ jobs:
       - id: core
         uses: ./publish-actions/release-core
         with:
+          # renovate: datasource=go depName=github.com/a-novel-kit/stack/cli
+          cli_version: "1.7.5"
           release_type: ${{ inputs.release_type }}
           dry_run: ${{ inputs.dry_run }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ off-repo can stall them, which is the property a required check needs.
 Each takes `advisory: "true"` to report without failing, for a repo adopting the check over an
 existing backlog.
 
-`version` is **required** on all three. The pin lives in the calling repo so Renovate sees it there
+`version` is **required** on all three, and on `generic-actions/lint-shell` and
+`generic-actions/lint-dockerfile`. The pin lives in the calling repo so Renovate sees it there
 and bumps each repo on its own cadence, instead of every tool upgrade waiting on a workflows
 release. Annotate it so Renovate can resolve the datasource:
 

--- a/docs/migrations/v1.26.0.md
+++ b/docs/migrations/v1.26.0.md
@@ -1,0 +1,74 @@
+# Upgrading to v1.26.0
+
+`v1.26.0` makes `version` a **required** input on `generic-actions/lint-shell` and
+`generic-actions/lint-dockerfile`, and pins shellcheck instead of using the runner's copy. The rest
+of the release is additive — the new `security-actions` group, which no existing workflow calls.
+
+Requiring an input is a breaking change, but a narrow one: two actions, one line each at the call
+site. It ships as a minor. A major is reserved for a planned, initiative-led migration on its own
+release line.
+
+## Do I need to act?
+
+**Only if a workflow calls `lint-shell` or `lint-dockerfile`.** Both now fail without `version`. A
+repo calling neither needs nothing.
+
+## Why
+
+The version a linter runs is part of what the gate means. Until now neither was pinned where it
+mattered:
+
+- **shellcheck** came from the GitHub runner image, so its version moved whenever GitHub rebuilt
+  that image. A gate could start or stop failing with no change in the repo, and no way to tell
+  from the run which version decided.
+- **hadolint** had a default inside the action, which is pinned but invisible: Renovate runs in the
+  consuming repo and never saw it, so every upgrade waited on a workflows release.
+
+Pinning at the call site puts the version where Renovate can see and bump it, on each repo's own
+cadence.
+
+## Add the input
+
+```yaml
+# before
+- uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.25.1
+
+# after
+- uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.26.0
+  with:
+    # renovate: datasource=github-releases depName=koalaman/shellcheck
+    version: "0.11.0"
+```
+
+```yaml
+# before
+- uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.25.1
+
+# after
+- uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.26.0
+  with:
+    # renovate: datasource=github-releases depName=hadolint/hadolint
+    version: "2.12.0"
+```
+
+`2.12.0` is what the action defaulted to, so passing it keeps current behaviour exactly. Newer
+hadolint releases exist; adopt one deliberately rather than as part of this upgrade.
+
+## The `# renovate:` comment is not decorative
+
+Without it nothing bumps the pin — no built-in manager reads a version inside a `with:` block. The
+fleet Renovate config gained a custom manager in this release that keys off exactly that comment.
+
+Either spelling of the version works (`0.11.0` or `v0.11.0`): these tools disagree about whether
+their archives carry the prefix, so the actions normalise it.
+
+## Verifying
+
+The check should report the pinned version in its log:
+
+```
+ShellCheck - shell script analysis tool
+version: 0.11.0
+```
+
+If it reports a different one, the input is not reaching the action.

--- a/docs/migrations/v1.26.0.md
+++ b/docs/migrations/v1.26.0.md
@@ -1,8 +1,14 @@
 # Upgrading to v1.26.0
 
-`v1.26.0` makes `version` a **required** input on `generic-actions/lint-shell` and
-`generic-actions/lint-dockerfile`, and pins shellcheck instead of using the runner's copy. The rest
-of the release is additive — the new `security-actions` group, which no existing workflow calls.
+`v1.26.0` makes the tool version a **required** input on four actions, so every external dependency
+is pinned where Renovate can see it:
+
+| Action                                | Input         | Was                           |
+| ------------------------------------- | ------------- | ----------------------------- |
+| `generic-actions/lint-shell`          | `version`     | the runner image's shellcheck |
+| `generic-actions/lint-dockerfile`     | `version`     | defaulted inside the action   |
+| `publish-actions/release-core`        | `cli_version` | `a-novel@latest`              |
+| `publish-actions/release-core-hotfix` | `cli_version` | `a-novel@latest`              |
 
 Requiring an input is a breaking change, but a narrow one: two actions, one line each at the call
 site. It ships as a minor. A major is reserved for a planned, initiative-led migration on its own
@@ -10,8 +16,8 @@ release line.
 
 ## Do I need to act?
 
-**Only if a workflow calls `lint-shell` or `lint-dockerfile`.** Both now fail without `version`. A
-repo calling neither needs nothing.
+**If a workflow calls any of the four.** Each now fails without its input. Most repos call
+`release-core` from `release.yaml`, so most repos need the `cli_version` line.
 
 ## Why
 
@@ -53,6 +59,24 @@ cadence.
 
 `2.12.0` is what the action defaulted to, so passing it keeps current behaviour exactly. Newer
 hadolint releases exist; adopt one deliberately rather than as part of this upgrade.
+
+```yaml
+# before
+- uses: a-novel-kit/workflows/publish-actions/release-core@v1.25.1
+  with:
+    release_type: ${{ inputs.release_type }}
+
+# after
+- uses: a-novel-kit/workflows/publish-actions/release-core@v1.26.0
+  with:
+    # renovate: datasource=go depName=github.com/a-novel-kit/stack/cli
+    cli_version: "1.7.5"
+    release_type: ${{ inputs.release_type }}
+```
+
+`release-core` installed the a-novel CLI with `@latest`, which resolved at release time to whatever
+had landed on the CLI. A tag could be cut by code nobody had reviewed against it, and two repos
+releasing minutes apart could use different CLIs. `1.7.5` is the current release.
 
 ## The `# renovate:` comment is not decorative
 

--- a/generic-actions/lint-dockerfile/action.yaml
+++ b/generic-actions/lint-dockerfile/action.yaml
@@ -20,11 +20,11 @@ inputs:
       When "true", findings go to the run summary and the log but the check passes — for a repo
       adopting the lint over an existing backlog. When "false" (the default), any finding fails.
   version:
-    required: false
-    default: "2.12.0"
+    required: true
     description: >
-      The hadolint release to pin — a `hadolint/hadolint` git tag. The binary is fetched from that
-      release; it is not preinstalled on the runner as shellcheck is.
+      hadolint release tag, with or without the leading v. Pinned by the caller so Renovate bumps
+      it per repo. Annotate it:
+      `# renovate: datasource=github-releases depName=hadolint/hadolint`.
 
 runs:
   using: composite

--- a/generic-actions/lint-shell/action.yaml
+++ b/generic-actions/lint-shell/action.yaml
@@ -18,10 +18,36 @@ inputs:
       When "true", findings go to the run summary and the log but the check passes — for a
       repo adopting the lint over an existing backlog. When "false" (the default), any
       finding fails the check.
+  version:
+    required: true
+    description: >
+      shellcheck release tag, with or without the leading v. Pinned by the caller so Renovate
+      bumps it per repo. Annotate it:
+      `# renovate: datasource=github-releases depName=koalaman/shellcheck`.
+
+      Previously the runner's preinstalled shellcheck was used, so the version moved whenever
+      GitHub rebuilt the image — a gate that changed what it accepted with no change in the repo.
 
 runs:
   using: composite
   steps:
+    - name: install shellcheck
+      shell: bash
+      env:
+        SHELLCHECK_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        # The tag and the archive name both carry the v, unlike gitleaks and hadolint whose
+        # archives drop it. Normalise so either spelling of the input works.
+        v="v${SHELLCHECK_VERSION#v}"
+        tmp=$(mktemp -d)
+        curl -sSfL --retry 3 --retry-delay 2 \
+          "https://github.com/koalaman/shellcheck/releases/download/${v}/shellcheck-${v}.linux.x86_64.tar.xz" \
+          | tar -xJ -C "$tmp" --strip-components=1
+        install -m 0755 "$tmp/shellcheck" /usr/local/bin/shellcheck
+        rm -rf "$tmp"
+        shellcheck --version
+
     - name: shellcheck
       shell: bash
       env:

--- a/publish-actions/release-core-hotfix/action.yaml
+++ b/publish-actions/release-core-hotfix/action.yaml
@@ -15,6 +15,16 @@ description: >
   branch lifecycle, the lock, and the human gate all live in the caller (hotfix.yaml).
 
 inputs:
+  cli_version:
+    required: true
+    description: >
+      a-novel CLI release to install, with or without the leading v. Pinned by the caller so
+      Renovate bumps it per repo. Annotate it:
+      `# renovate: datasource=go depName=github.com/a-novel-kit/stack/cli`.
+
+      It was `@latest`, which resolved at release time to whatever had landed on the CLI — so a
+      release could be cut by code nobody reviewed against it, and two repos releasing minutes
+      apart could use different CLIs.
   ref:
     required: true
     description: >
@@ -111,8 +121,10 @@ runs:
     - name: Install a-novel CLI (for stamp)
       if: ${{ steps.stamp.outputs.needed == 'true' }}
       shell: bash
+      env:
+        CLI_VERSION: ${{ inputs.cli_version }}
       run: |
-        go install github.com/a-novel-kit/stack/cli/cmd/a-novel@latest
+        go install "github.com/a-novel-kit/stack/cli/cmd/a-novel@v${CLI_VERSION#v}"
         echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
     # working-directory __hotfix puts bump, plan and git on the ephemeral tree. $GITHUB_ACTION_PATH

--- a/publish-actions/release-core/action.yaml
+++ b/publish-actions/release-core/action.yaml
@@ -6,6 +6,16 @@ description: >
   and the protected `release` environment live in the caller.
 
 inputs:
+  cli_version:
+    required: true
+    description: >
+      a-novel CLI release to install, with or without the leading v. Pinned by the caller so
+      Renovate bumps it per repo. Annotate it:
+      `# renovate: datasource=go depName=github.com/a-novel-kit/stack/cli`.
+
+      It was `@latest`, which resolved at release time to whatever had landed on the CLI — so a
+      release could be cut by code nobody reviewed against it, and two repos releasing minutes
+      apart could use different CLIs.
   release_type:
     required: true
     description: Semver bump to apply — patch, minor, or major.
@@ -104,8 +114,10 @@ runs:
     - name: Install a-novel CLI (for stamp)
       if: ${{ steps.stamp.outputs.needed == 'true' }}
       shell: bash
+      env:
+        CLI_VERSION: ${{ inputs.cli_version }}
       run: |
-        go install github.com/a-novel-kit/stack/cli/cmd/a-novel@latest
+        go install "github.com/a-novel-kit/stack/cli/cmd/a-novel@v${CLI_VERSION#v}"
         echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
     - name: Cut release

--- a/tests/lint-tool-pins.sh
+++ b/tests/lint-tool-pins.sh
@@ -27,7 +27,7 @@ print('required' if v.get('required') and 'default' not in v else 'optional')
   check "${a#*/}: version required, no default" required "$got"
 done
 
-# shellcheck must not fall through to whatever the runner ships.
+# The action must install its own shellcheck, not fall through to the runner's.
 installs=$(grep -c 'koalaman/shellcheck/releases/download' "$ROOT/generic-actions/lint-shell/action.yaml")
 check "lint-shell: installs a pinned shellcheck" 1 "$installs"
 

--- a/tests/lint-tool-pins.sh
+++ b/tests/lint-tool-pins.sh
@@ -45,6 +45,22 @@ done
 check "lint-shell strips/adds the v" 1 "$(grep -c 'SHELLCHECK_VERSION#v' "$ROOT/generic-actions/lint-shell/action.yaml")"
 check "lint-dockerfile strips the v" 1 "$(grep -c 'HADOLINT_VERSION#v' "$ROOT/generic-actions/lint-dockerfile/action.yaml")"
 
+# No floating ref may reach a release. `@latest` in the release path meant a tag could be cut by
+# CLI code nobody reviewed against it, and two repos releasing minutes apart could differ.
+# Matches a floating ref in USE — after `uses:` or an install verb — not a prose mention of one.
+floating=$(grep -rnE '(uses:|go install|pipx install|cargo install|npm i(nstall)? )[^#]*@(latest|main|master)\b' \
+  "$ROOT"/*-actions/*/action.yaml 2>/dev/null | grep -vc '^[^:]*:[0-9]*: *#')
+check "no floating @latest/@main/@master in any action" 0 "$floating"
+
+for a in publish-actions/release-core publish-actions/release-core-hotfix; do
+  got=$(python3 -c "
+import yaml, sys
+v = (yaml.safe_load(open(sys.argv[1]))['inputs'] or {}).get('cli_version', {})
+print('required' if v.get('required') and 'default' not in v else 'missing-or-optional')
+" "$ROOT/$a/action.yaml")
+  check "${a#*/}: cli_version required, no default" required "$got"
+done
+
 # A pin nothing bumps is a pin that rots: the annotation is what the custom manager reads.
 missing=0
 while IFS= read -r f; do

--- a/tests/lint-tool-pins.sh
+++ b/tests/lint-tool-pins.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Every lint action must pin its tool at the call site.
+#
+# An unpinned linter is a gate whose meaning moves without the repo changing: shellcheck used to
+# come from the runner image, so a GitHub image rebuild could alter what the check accepted. A
+# version defaulted inside the action is pinned but invisible — Renovate runs in the consuming repo
+# and never sees it.
+#
+# The URL assertions cover the prefix disagreement: shellcheck's archive carries the v, gitleaks'
+# and hadolint's drop it, and a bump that writes the wrong spelling 404s at install time.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+fails=0
+check() { # $1=label $2=expected $3=actual
+  if [ "$2" = "$3" ]; then echo "  ok   $1"; else echo "  FAIL $1: expected [$2], got [$3]"; fails=$((fails + 1)); fi
+}
+
+# Every action that downloads a tool must take a required version with no default.
+for a in generic-actions/lint-shell generic-actions/lint-dockerfile \
+         security-actions/scan-secrets security-actions/lint-semgrep security-actions/lint-workflows; do
+  got=$(python3 -c "
+import yaml, sys
+v = (yaml.safe_load(open(sys.argv[1]))['inputs'] or {}).get('version', {})
+print('required' if v.get('required') and 'default' not in v else 'optional')
+" "$ROOT/$a/action.yaml")
+  check "${a#*/}: version required, no default" required "$got"
+done
+
+# shellcheck must not fall through to whatever the runner ships.
+installs=$(grep -c 'koalaman/shellcheck/releases/download' "$ROOT/generic-actions/lint-shell/action.yaml")
+check "lint-shell: installs a pinned shellcheck" 1 "$installs"
+
+# Prefix normalisation, per tool. shellcheck keeps the v in its archive name; the others drop it.
+for spelling in 0.11.0 v0.11.0; do
+  got=$(SHELLCHECK_VERSION="$spelling" bash -c 'v="v${SHELLCHECK_VERSION#v}"; echo "shellcheck-${v}.linux.x86_64.tar.xz"')
+  check "shellcheck: '$spelling' names the archive" "shellcheck-v0.11.0.linux.x86_64.tar.xz" "$got"
+done
+for spelling in 2.12.0 v2.12.0; do
+  got=$(HADOLINT_VERSION="$spelling" bash -c 'echo "v${HADOLINT_VERSION#v}"')
+  check "hadolint: '$spelling' names the tag" "v2.12.0" "$got"
+done
+
+# The normalisation must be in the shipped manifests, not only in this test.
+check "lint-shell strips/adds the v" 1 "$(grep -c 'SHELLCHECK_VERSION#v' "$ROOT/generic-actions/lint-shell/action.yaml")"
+check "lint-dockerfile strips the v" 1 "$(grep -c 'HADOLINT_VERSION#v' "$ROOT/generic-actions/lint-dockerfile/action.yaml")"
+
+# A pin nothing bumps is a pin that rots: the annotation is what the custom manager reads.
+missing=0
+while IFS= read -r f; do
+  grep -q 'renovate: datasource=' "$f" || { echo "    $f has a version: with no renovate annotation"; missing=$((missing + 1)); }
+done < <(grep -rl 'version: "' "$ROOT/.github/workflows" 2>/dev/null)
+check "in-repo callers annotate their pins" 0 "$missing"
+
+if [ "$fails" -gt 0 ]; then echo "::error::$fails tool-pin assertion(s) failed"; exit 1; fi
+echo "lint-tool-pins: all assertions passed"


### PR DESCRIPTION
A repo-wide pass: every external dependency is now pinned at the call site, where Renovate can see
and bump it. Rebased onto master now that #378 has landed.

## The audit

Four sources of external code, none of them managed from the consuming repo:

| Action | Dependency | Was | Risk |
| --- | --- | --- | --- |
| `publish-actions/release-core` | a-novel CLI | **`@latest`** | a tag cut by CLI code nobody reviewed against it |
| `publish-actions/release-core-hotfix` | a-novel CLI | **`@latest`** | same, on the hotfix path |
| `generic-actions/lint-shell` | shellcheck | **the runner image** | the gate changed meaning on GitHub's schedule |
| `generic-actions/lint-dockerfile` | hadolint | defaulted **inside** the action | pinned, but Renovate runs in the consuming repo and never saw it |

`@latest` in the release path is the worst of these: two repos releasing minutes apart could use
different CLIs, and nothing recorded which one cut a given tag.

Already required from #378: `lint-semgrep`, `scan-secrets`, `lint-workflows`.

## The rule this establishes

**A version input is `required` with no default, pinned by the caller, annotated for Renovate.**

```yaml
- uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.26.0
  with:
    # renovate: datasource=github-releases depName=koalaman/shellcheck
    version: "0.11.0"
```

A default is pinned-but-invisible; the caller never states it, so Renovate never bumps it and every
upgrade waits on a workflows release. Requiring it moves the decision to the repo that lives with
the consequences.

## Three prefix conventions, which is why this kept breaking

| Tool | Release tag | Archive |
| --- | --- | --- |
| shellcheck | `v0.11.0` | `shellcheck-v0.11.0...` — **keeps** the v |
| gitleaks | `v8.30.1` | `gitleaks_8.30.1_...` — **drops** the v |
| hadolint | `v2.12.0` | binary unversioned under a v-tagged release |

Each action normalises its own, so either spelling of the input resolves. Verified against live URLs.

## It caught a real bug on its first run

The pinned shellcheck failed CI immediately — on this PR's own new test file:

```
tests/lint-tool-pins.sh:30:1: error: Couldn't parse this shellcheck directive [SC1073]
```

A comment opening `# shellcheck ` is parsed as a **directive**, not prose. The runner's older
shellcheck had never flagged it. That is the argument for pinning, delivered by the pinning.

## Deliberately left alone

`node-version: lts/*` and `go-version: stable` still float. Those are toolchain aliases, not
dependency pins, and Renovate cannot meaningfully bump "stable" — changing them is a fleet policy
decision, not a bug fix. Flagging rather than folding in.

## Breaking

Four actions gain a required input. `docs/migrations/v1.26.0.md` covers each. A **minor** per the
versioning policy — a major is a planned vX-line initiative, not a required input. All in-repo
callers are updated.

## Test plan

- [x] `tests/lint-tool-pins.sh` — 17 assertions, incl. a floating-ref guard that ignores prose
      mentions but catches a real `@latest` (mutation-tested)
- [x] all 11 suites pass
- [x] `lint-action-manifests` clean, prettier clean
- [x] every download URL verified live; `shellcheck --version` confirms the pin after install
- [ ] CI green