### PR TITLE
ci(ci): make the workflows repo audit its own workflows

### DIFF
--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -12,6 +12,8 @@ jobs:
     if: ${{ github.event.pull_request.user.login != vars.DEPENDENCY_BOT_LOGIN }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./generic-actions/assign-bot
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ jobs:
         language: ["javascript-typescript", "actions"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: github/codeql-action/init@v4
         with:
           languages: "${{ matrix.language }}"

--- a/.github/workflows/hotfix-run.yaml
+++ b/.github/workflows/hotfix-run.yaml
@@ -134,6 +134,7 @@ jobs:
         env:
           LINE: ${{ inputs.line }}
           FIX_REF: ${{ inputs.fix_ref }}
+          APP_SLUG: ${{ steps.token.outputs.app-slug }}
         run: |
           set -euo pipefail
 
@@ -156,8 +157,8 @@ jobs:
           ephemeral="hotfix/v${LINE}.x"
           echo "Baseline: \`$baseline\` → ephemeral branch \`$ephemeral\`." | tee -a "$GITHUB_STEP_SUMMARY"
 
-          git config user.name "${{ steps.token.outputs.app-slug }}[bot]"
-          git config user.email "${{ steps.token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
 
           # A leftover ephemeral branch from an aborted run blocks a fresh cut, so remove it.
           git push origin --delete "$ephemeral" 2>/dev/null || true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./node-actions/lint-node
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +44,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       # The detector lives in a script so tests/lint-action-manifests.sh runs the shipped code
       # against fixtures, including the violations this gate exists to catch.
       - name: No composite-illegal expression contexts in action manifests
@@ -57,6 +61,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Run the action test suites
         shell: bash
         run: |
@@ -90,6 +96,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./generic-actions/lint-shell
         with:
           # renovate: datasource=github-releases depName=koalaman/shellcheck

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,3 +102,21 @@ jobs:
         with:
           # renovate: datasource=github-releases depName=koalaman/shellcheck
           version: "0.11.0"
+
+  # The repo that ships the audit was the one repo not running it, so its own workflows went
+  # unchecked until a fleet sweep ran zizmor here by hand. Dogfooded with a relative path, against
+  # the repo-local config — see .github/zizmor.yml for why it exists rather than the shipped
+  # baseline.
+  lint-workflows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./security-actions/lint-workflows
+        with:
+          config: .github/zizmor.yml
+          # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
+          version: "1.28.0"

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -13,6 +13,8 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./node-actions/audit
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,8 @@ jobs:
       # This checkout makes the local ./publish-actions/* actions available; release-core
       # re-checks-out with the bot token to push.
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - id: core
         uses: ./publish-actions/release-core
         with:
@@ -68,5 +70,10 @@ jobs:
           project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
 
       # Surface the cut version in the run summary, since the run name carries only the bump type.
+      # Both values arrive through env rather than ${{ }}: an expression is substituted into the
+      # script before bash sees it, so its contents would be code; as variables they are data.
       - if: ${{ !inputs.dry_run }}
-        run: echo "## 🚀 Released \`${{ steps.core.outputs.tag }}\` (${{ inputs.release_type }})" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          TAG: ${{ steps.core.outputs.tag }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        run: echo "## 🚀 Released \`${TAG}\` (${RELEASE_TYPE})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,6 +17,8 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./generic-actions/renovate
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,58 @@
+# Repo-local zizmor config for a-novel-kit/workflows.
+#
+# security-actions/lint-workflows mounts EITHER this file OR the baseline it ships, never both, so
+# this file must carry the baseline's rules as well as the ones specific to this repo. Keep the two
+# in sync: security-actions/lint-workflows/zizmor.yml is the original.
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Tag pins are deliberate across this fleet, not an oversight: Renovate
+        # moves the whole a-novel-kit/workflows reference set as one grouped
+        # update, and a repo must sit at a single workflows version. Per-action
+        # hash pins break that grouping and make the diff unreadable.
+        #
+        # ref-pin still fails a genuinely floating `@master` or a missing ref,
+        # which is the failure this audit exists to catch. It only accepts a tag
+        # as sufficient.
+        "*": ref-pin
+
+  cache-poisoning:
+    ignore:
+      # main.yaml both restores a build cache and builds images, which is the
+      # shape this audit looks for. The attack needs a lower-trust branch to
+      # write a cache a release run then reads; GitHub scopes cache writes so a
+      # PR branch cannot reach the default branch's scope, and releases are cut
+      # from release.yaml. zizmor rates the finding Low for the same reason.
+      - main.yaml
+
+  github-app:
+    ignore:
+      # Each mints an App token with `owner:` and no `repositories:`, which zizmor reads as
+      # over-broad. For these three it is the requirement, not an oversight — each is an org-wide
+      # sweep, and the suggested fix (naming specific repositories) would blind it:
+      #
+      #   token-expiry.yaml — enumerates the ORGANISATION's PATs. Its one permission,
+      #     organization-personal-access-tokens:read, is an org-level grant; a repository list
+      #     does not narrow an org-level read, it just breaks it.
+      #   watchdog.yaml — scans every repo in the org for stale required checks and stuck hotfix
+      #     runs. Naming repositories would mean the sweep silently stops covering whatever is not
+      #     on the list, which is the exact failure it exists to catch.
+      #   reconcile-board.yaml — same shape: an org-scoped PR search feeding the board reconcile.
+      #
+      # All three already hold the narrow line that IS available to them: `permissions: {}` on the
+      # job, so the default token is unused, and read-only `permission-*` scopes on the App token.
+      # Widen any of them and this suppression stops being justified.
+      - token-expiry.yaml
+      - watchdog.yaml
+      - reconcile-board.yaml
+
+  artipacked:
+    ignore:
+      # The one checkout in this repo that must keep its credentials. It checks out with an
+      # explicitly minted, repo-scoped bot token and then pushes and deletes the ephemeral hotfix
+      # branch with plain `git push` (hotfix-run.yaml:183, :295) — no credential helper of its own,
+      # so the persisted one is what authenticates. Setting persist-credentials: false here does
+      # not harden the workflow, it breaks it. Every other checkout in the repo sets it.
+      - hotfix-run.yaml


### PR DESCRIPTION
## Summary

The repo that ships `security-actions/lint-workflows` was the one repo not running it, so its own
workflows went unaudited. This adds the job and clears everything it finds.

Running zizmor 1.28.0 by hand against `master` — offline, with the baseline config this repo ships:

```
84 findings (71 suppressed): 3 informational, 6 low, 0 medium, 4 high
```

After this PR: **`No findings to report. Good job! (4 ignored, 71 suppressed)`**, exit 0.

## What was fixed

**`artipacked` ×10** — checkouts leaving `GITHUB_TOKEN` in `.git/config` for the rest of the job.
Fixed in `main.yaml` (4), `renovate.yaml`, `release.yaml`, `node-audit.yaml`, `codeql.yml`,
`auto-assign-author.yaml`. Each was verified not to need the credential first: `renovate` and
`node-audit` re-check-out internally through `setup-node` → `pull-bot` (which already sets
`persist-credentials: false`) and push with an explicitly configured `url.insteadOf` credential;
`release.yaml`'s own comment says `release-core` re-checks-out with the bot token to push; `codeql`
and `assign-bot` run no git operations.

**`template-injection` ×3** — `${{ }}` expanded directly into a `run:` body, which makes the value
code rather than data. `release.yaml`'s run-summary line and `hotfix-run.yaml`'s two `git config`
lines now bind through `env:`, the same way `hotfix-run.yaml` already handles `LINE` and `FIX_REF`.

## What is suppressed, and why

A repo-local `.github/zizmor.yml`, passed via the action's `config:` input. Note the action mounts
**either** the repo config **or** its shipped baseline, never both, so this file re-states the
baseline's `unpinned-uses` policy and `cache-poisoning` ignore. Kept in sync by hand; the original is
`security-actions/lint-workflows/zizmor.yml`.

- **`github-app`** on `token-expiry.yaml`, `watchdog.yaml`, `reconcile-board.yaml`. Each mints an App
  token with `owner:` and no `repositories:`. For these three that is the requirement, not an
  oversight — each is an **org-wide sweep**, and zizmor's suggested fix (naming specific
  repositories) would blind it. `token-expiry` enumerates the *organisation's* PATs, and its one
  permission, `organization-personal-access-tokens:read`, is an org-level grant that a repository
  list cannot narrow. `watchdog` scans every repo for stale required checks — naming repositories
  would mean it silently stops covering whatever is not on the list, the exact failure it exists to
  catch. All three already hold the line that *is* available to them: `permissions: {}` on the job
  and read-only `permission-*` scopes on the token.

- **`artipacked`** on `hotfix-run.yaml`. The one checkout here that must keep its credentials: it
  checks out with an explicitly minted, repo-scoped bot token and then pushes and deletes the
  ephemeral hotfix branch with plain `git push` (`:183`, `:295`) and no credential helper of its own.
  `persist-credentials: false` there does not harden it, it breaks it.

## Required checks

⚠️ **This adds a job**, so `lint-workflows` becomes a required check on the next
`a-novel repo update` — please run it after merge. This is the safe direction: the new context
reports on this PR, unlike a rename or a removal.

## Test plan

- [x] `zizmor` 1.28.0, offline, repo-local config: **exit 0**, no findings
- [x] `pnpm lint` (prettier) clean
- [x] `bash .github/scripts/lint-action-manifests.sh .` clean
- [x] all 11 `tests/*.sh` action suites pass
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)