### PR TITLE
fix(ci): retry transport resets when downloading shellcheck and gitleaks

### DIFF
--- a/generic-actions/lint-shell/action.yaml
+++ b/generic-actions/lint-shell/action.yaml
@@ -41,9 +41,21 @@ runs:
         # archives drop it. Normalise so either spelling of the input works.
         v="v${SHELLCHECK_VERSION#v}"
         tmp=$(mktemp -d)
-        curl -sSfL --retry 3 --retry-delay 2 \
+        # Downloaded to a file, then extracted, rather than piped into tar — and the retry flag
+        # alone fixes neither half. `--retry-all-errors` is what retries a transport-level reset
+        # (curl exit 35); plain `--retry` covers only transient HTTP statuses and timeouts, so the
+        # reset failed the job on the first attempt. And retrying *into a pipe* is unsound anyway:
+        # curl restarts the transfer while tar has already consumed the partial bytes, leaving its
+        # stream corrupt. Both were observed on one run — `curl: (35) Recv failure` followed by
+        # `xz: (stdin): File format not recognized` — reddening a PR that only bumped prettier.
+        # generic-actions/lint-dockerfile already downloads this way for the same reason.
+        if ! curl -sSfL --retry 3 --retry-delay 2 --retry-all-errors \
           "https://github.com/koalaman/shellcheck/releases/download/${v}/shellcheck-${v}.linux.x86_64.tar.xz" \
-          | tar -xJ -C "$tmp" --strip-components=1
+          -o "$tmp/shellcheck.tar.xz"; then
+          echo "::error::failed to download shellcheck ${v} after 3 retries"
+          exit 1
+        fi
+        tar -xJ -C "$tmp" --strip-components=1 -f "$tmp/shellcheck.tar.xz"
         install -m 0755 "$tmp/shellcheck" /usr/local/bin/shellcheck
         rm -rf "$tmp"
         shellcheck --version

--- a/security-actions/scan-secrets/action.yaml
+++ b/security-actions/scan-secrets/action.yaml
@@ -44,9 +44,21 @@ runs:
         # gitleaks tags its releases v-prefixed but names the archive without it.
         # Accept either spelling of the input so a bump that keeps the v still resolves.
         v="${GITLEAKS_VERSION#v}"
-        curl -sSfL --retry 3 --retry-delay 2 \
+        tmp=$(mktemp -d)
+        # Downloaded to a file, then extracted, rather than piped into tar. `--retry-all-errors` is
+        # what retries a transport-level reset (curl exit 35); plain `--retry` covers only transient
+        # HTTP statuses and timeouts. Retrying into a pipe would not help either — curl restarts the
+        # transfer while tar has already consumed the partial bytes. The sibling shellcheck download
+        # failed exactly this way, reddening a PR that only bumped prettier; this one is the same
+        # shape and was fixed with it.
+        if ! curl -sSfL --retry 3 --retry-delay 2 --retry-all-errors \
           "https://github.com/gitleaks/gitleaks/releases/download/v${v}/gitleaks_${v}_linux_x64.tar.gz" \
-          | tar -xz -C /usr/local/bin gitleaks
+          -o "$tmp/gitleaks.tar.gz"; then
+          echo "::error::failed to download gitleaks ${v} after 3 retries"
+          exit 1
+        fi
+        tar -xz -C /usr/local/bin -f "$tmp/gitleaks.tar.gz" gitleaks
+        rm -rf "$tmp"
         gitleaks version
 
     - name: scan working tree


### PR DESCRIPTION
## Summary

`a-novel-kit/jwt#509` — a Renovate PR that bumps **prettier and nothing else** — is red on
`lint-shell`. The failure has nothing to do with the bump:

```
curl: (35) Recv failure: Connection reset by peer
xz: (stdin): File format not recognized
tar: Child returned status 1
```

The shellcheck tarball was reset mid-transfer. That is a transient network flake, but it is one the
action was written to survive and did not — for two compounding reasons.

**1. `--retry` does not cover a transport reset.** Plain `--retry` retries transient *HTTP statuses*
and timeouts. curl exit 35 is neither, so `--retry 3 --retry-delay 2` never fired and the job died on
the first attempt. `--retry-all-errors` is what covers it.

**2. The download was piped straight into `tar`.** Even with the right retry flag this stays broken:
curl restarts the transfer while `tar` has already consumed the partial bytes, so its stream is
corrupt. That is the second line of the log — `xz: (stdin): File format not recognized`.

Fixing only one of the two would not have fixed the failure.

## Prior art in this repo

`generic-actions/lint-dockerfile` already downloads correctly, and its comment names this exact
failure:

> `--retry-all-errors` is what covers a transport-level reset (curl exit 35) — plain `--retry` only
> covers transient HTTP statuses and timeouts, and the reset is what was actually observed.

That fix was never propagated to the two siblings with the same shape:

| action | `--retry-all-errors` | to a file | |
| --- | --- | --- | --- |
| `generic-actions/lint-dockerfile` (hadolint) | ✅ | ✅ | already correct |
| `generic-actions/lint-shell` (shellcheck) | ❌ → ✅ | ❌ → ✅ | **this PR** |
| `security-actions/scan-secrets` (gitleaks) | ❌ → ✅ | ❌ → ✅ | **this PR** |

## Why it matters beyond one PR

`lint-shell` and `scan-secrets` are required checks in nearly every repo across both orgs, so **any**
PR could be reddened at random by a reset on the releases CDN and needed a manual re-run. It is the
same class of problem that got GitGuardian removed from the merge path — a network dependency that
can stall a PR — except this one is ours to fix.

## Test plan

- [x] Both rewritten install scripts extracted from the manifests and **executed verbatim**:
      shellcheck 0.11.0 and gitleaks 8.30.1 each download, extract and report their version
- [x] Both extracted scripts pass `shellcheck -S style` clean
- [x] `pnpm lint` (prettier) clean
- [x] `lint-action-manifests.sh` clean
- [x] all 11 `tests/*.sh` action suites pass
- [x] `zizmor` 1.28.0 exit 0
- [ ] CI green on this branch

## Rollout

The fix reaches consumers only when they re-pin to the next `a-novel-kit/workflows` release — the
repos keep tag-pinned references. `jwt#509` itself just needs a re-run in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)