### PR TITLE
feat(ci): add append-only artifact check

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | `assign-bot`             | Assign a PR to its author, or to the code owner when the author is a bot.                                         |
 | `auto-merge-bot`         | Enable auto-merge on a PR.                                                                                        |
 | `board-write`            | Set one single-select/date board field as [Agent] — the single write path.                                        |
+| `check-append-only`      | Allow additions under a path while freezing every file that already landed.                                       |
 | `check-changes`          | Detect uncommitted changes in a pathspec; optionally fail.                                                        |
 | `codecov`                | Upload the coverage artifact to Codecov.                                                                          |
 | `derive-status`          | Derive a Task's board Status from its PR's current state (single writer).                                         |
@@ -67,6 +68,20 @@ Pin to a release tag, never `@master`. The actions ship as one unit, so bump eve
 | `renovate`               | Run self-hosted Renovate as the bot.                                                                              |
 | `rollup-board`           | Roll an epic's Status + Start date up from its children.                                                          |
 | `token-expiry-notify`    | Remind (Discord) before a fine-grained PAT expires, with the regen steps.                                         |
+
+`check-append-only` needs the full base history. It rejects every change except additions under
+the configured path; the `append-only-override` PR label is the reviewed escape hatch.
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    fetch-depth: 0
+
+- uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.0
+  with:
+    path: internal/models/migrations
+    base: ${{ github.event.pull_request.base.sha }}
+```
 
 ### `github-pages-actions`
 

--- a/generic-actions/check-append-only/action.yaml
+++ b/generic-actions/check-append-only/action.yaml
@@ -1,0 +1,111 @@
+name: check append-only
+description: >
+  Allow new files under a path while rejecting changes to existing files. A visible PR label is the
+  deliberate override for bulk regeneration or another reviewed exception.
+
+inputs:
+  path:
+    required: true
+    description: Path whose files become immutable after landing.
+  base:
+    required: true
+    description: >
+      Full base-branch commit SHA. The checkout must use `fetch-depth: 0`; shallow history fails
+      closed because Git cannot resolve the pull request's merge base reliably.
+  override_label:
+    required: false
+    default: append-only-override
+    description: PR label that bypasses the check. Empty disables the override.
+
+runs:
+  using: composite
+  steps:
+    - name: Check append-only path
+      shell: bash
+      env:
+        BASE: ${{ inputs.base }}
+        PATH_TO_CHECK: ${{ inputs.path }}
+        OVERRIDE_LABEL: ${{ inputs.override_label }}
+        EVENT_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+      run: |
+        set -euo pipefail
+
+        has_override() {
+          [ -n "${OVERRIDE_LABEL:-}" ] &&
+            jq -e --arg label "$OVERRIDE_LABEL" \
+              'type == "array" and index($label) != null' \
+              <<<"${EVENT_LABELS:-null}" >/dev/null
+        }
+
+        collect_changes() { # $1=output file
+          git diff --name-status --no-renames -z "${BASE}...HEAD" -- "$PATH_TO_CHECK" > "$1"
+        }
+
+        classify_changes() { # $1=name-status file
+          VIOLATIONS=()
+          local status file
+          while IFS= read -r -d '' status && IFS= read -r -d '' file; do
+            [ "$status" = "A" ] || VIOLATIONS+=("$status"$'\t'"$file")
+          done < "$1"
+          [ "${#VIOLATIONS[@]}" -eq 0 ]
+        }
+
+        if has_override; then
+          printf '::warning::append-only check bypassed by label "%s"\n' "$OVERRIDE_LABEL"
+          printf '## Append-only check\n\nBypassed by `%s`.\n' "$OVERRIDE_LABEL" \
+            >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        if [ -z "${PATH_TO_CHECK:-}" ]; then
+          printf '%s\n' '::error::path must not be empty'
+          exit 1
+        fi
+        if ! [[ "${BASE:-}" =~ ^([0-9a-fA-F]{40}|[0-9a-fA-F]{64})$ ]]; then
+          printf '::error::base must be a full commit SHA, got "%s"\n' "${BASE:-}"
+          exit 1
+        fi
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          printf '%s\n' \
+            '::error::check-append-only requires actions/checkout with fetch-depth: 0'
+          exit 1
+        fi
+        if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+          printf '::error::base commit %s is absent from the checkout\n' "$BASE"
+          exit 1
+        fi
+        if ! git merge-base "$BASE" HEAD >/dev/null; then
+          printf '::error::base commit %s has no merge base with HEAD\n' "$BASE"
+          exit 1
+        fi
+
+        changes=$(mktemp)
+        trap 'rm -f "$changes"' EXIT
+        if ! collect_changes "$changes"; then
+          printf '::error::failed to compare %s...HEAD under %s\n' "$BASE" "$PATH_TO_CHECK"
+          exit 1
+        fi
+
+        if classify_changes "$changes"; then
+          printf 'Append-only path unchanged except for additions: %s\n' "$PATH_TO_CHECK"
+          printf '## Append-only check\n\nOnly additions found under `%s`.\n' "$PATH_TO_CHECK" \
+            >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        printf '%s\n' \
+          '::error::existing files changed under an append-only path; see the job summary'
+        {
+          printf '## Append-only check failed\n\nExisting files changed under `%s`:\n\n' \
+            "$PATH_TO_CHECK"
+          for violation in "${VIOLATIONS[@]}"; do
+            status=${violation%%$'\t'*}
+            file=${violation#*$'\t'}
+            printf -v quoted '%q' "$file"
+            printf -- '- `%s` (%s)\n' "$quoted" "$status"
+          done
+          if [ -n "${OVERRIDE_LABEL:-}" ]; then
+            printf '\nAdd the `%s` label only for a reviewed exception.\n' "$OVERRIDE_LABEL"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+        exit 1

--- a/tests/check-append-only.sh
+++ b/tests/check-append-only.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Exercises the functions shipped in check-append-only against real Git histories.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION="${1:-$ROOT/generic-actions/check-append-only/action.yaml}"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+extract() {
+  awk -v n="$1" '
+    $0 ~ "^        "n"\\(\\)" {f=1}
+    f {print}
+    f && /^        \}$/ {exit}
+  ' "$ACTION" | sed 's/^        //'
+}
+
+for function_name in has_override collect_changes classify_changes; do
+  body=$(extract "$function_name")
+  if [ -z "$body" ]; then
+    printf '::error::could not extract %s from %s\n' "$function_name" "$ACTION"
+    exit 1
+  fi
+  printf '%s\n' "$body" >> "$WORK/lib.sh"
+done
+
+bash -n "$WORK/lib.sh"
+# shellcheck source=/dev/null
+. "$WORK/lib.sh"
+
+REPO="$WORK/repo"
+mkdir -p "$REPO/frozen" "$REPO/outside"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+printf 'locked\n' > "$REPO/frozen/locked.txt"
+printf 'outside\n' > "$REPO/outside/file.txt"
+git -C "$REPO" add frozen/locked.txt outside/file.txt
+git -C "$REPO" commit -qm base
+BASE=$(git -C "$REPO" rev-parse HEAD)
+PATH_TO_CHECK=frozen
+
+fails=0
+check_case() { # $1=label $2=expected(pass|fail)
+  local label=$1 expected=$2 got changes
+  changes="$WORK/changes"
+  if (cd "$REPO" && collect_changes "$changes") && classify_changes "$changes"; then
+    got=pass
+  else
+    got=fail
+  fi
+  if [ "$got" = "$expected" ]; then
+    printf '  ok   %s\n' "$label"
+  else
+    printf '  FAIL %s: expected %s, got %s\n' "$label" "$expected" "$got"
+    fails=$((fails + 1))
+  fi
+}
+
+reset_case() {
+  git -C "$REPO" reset --hard -q "$BASE"
+  git -C "$REPO" clean -fdq
+}
+
+commit_case() {
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm case
+}
+
+printf '== path changes ==\n'
+
+printf 'new\n' > "$REPO/frozen/new.txt"
+commit_case
+check_case "added file passes" pass
+
+reset_case
+printf 'changed\n' > "$REPO/frozen/locked.txt"
+commit_case
+check_case "modified file fails" fail
+
+reset_case
+rm "$REPO/frozen/locked.txt"
+commit_case
+check_case "deleted file fails" fail
+
+reset_case
+printf 'changed\n' > "$REPO/outside/file.txt"
+commit_case
+check_case "change outside path passes" pass
+
+reset_case
+mv "$REPO/frozen/locked.txt" "$REPO/frozen/renamed.txt"
+commit_case
+check_case "renamed file fails" fail
+
+printf '== override label ==\n'
+
+OVERRIDE_LABEL=append-only-override
+EVENT_LABELS='["bug","append-only-override"]'
+if has_override; then
+  printf '  ok   configured label passes\n'
+else
+  printf '  FAIL configured label was not detected\n'
+  fails=$((fails + 1))
+fi
+
+EVENT_LABELS='["bug"]'
+if has_override; then
+  printf '  FAIL unrelated label bypassed the check\n'
+  fails=$((fails + 1))
+else
+  printf '  ok   unrelated label does not bypass\n'
+fi
+
+EVENT_LABELS=null
+if has_override; then
+  printf '  FAIL non-PR event bypassed the check\n'
+  fails=$((fails + 1))
+else
+  printf '  ok   non-PR event does not bypass\n'
+fi
+
+printf '\n'
+if [ "$fails" -ne 0 ]; then
+  printf '::error::%s assertion(s) failed\n' "$fails"
+  exit 1
+fi
+printf 'all assertions passed\n'

--- a/tests/check-append-only.sh
+++ b/tests/check-append-only.sh
@@ -38,7 +38,7 @@ printf 'outside\n' > "$REPO/outside/file.txt"
 git -C "$REPO" add frozen/locked.txt outside/file.txt
 git -C "$REPO" commit -qm base
 BASE=$(git -C "$REPO" rev-parse HEAD)
-PATH_TO_CHECK=frozen
+export PATH_TO_CHECK=frozen
 
 fails=0
 check_case() { # $1=label $2=expected(pass|fail)
@@ -95,8 +95,8 @@ check_case "renamed file fails" fail
 
 printf '== override label ==\n'
 
-OVERRIDE_LABEL=append-only-override
-EVENT_LABELS='["bug","append-only-override"]'
+export OVERRIDE_LABEL=append-only-override
+export EVENT_LABELS='["bug","append-only-override"]'
 if has_override; then
   printf '  ok   configured label passes\n'
 else


### PR DESCRIPTION
## Summary

- Enforces immutable landed artifacts by accepting only added files under a configured path.
- Fails closed on incomplete history or invalid inputs; a visible PR label provides the reviewed exception path.
- Uses the pull request merge base, so concurrent base-branch additions do not become false violations.

## Breaking changes

None.

## Test plan

- [x] Full `tests/*.sh` action suite passes
- [x] Composite action manifest lint passes
- [x] Prettier check passes
- [x] CI green

Closes #384.
Part of a-novel/.github#237.
