### PR TITLE
fix(ci): tag docker jobs on pull requests

### DIFF
--- a/build-actions/docker-job/action.yaml
+++ b/build-actions/docker-job/action.yaml
@@ -80,6 +80,7 @@ runs:
         images: ghcr.io/${{ inputs.image_name }}
         tags: |
           # Ref-derived tags for the tag-push flow, off when a version is passed.
+          type=ref,event=pr,enable=${{ inputs.version == '' }}
           type=schedule,pattern=nightly,enable=${{ inputs.version == '' }}
           type=ref,event=branch,enable=${{ inputs.version == '' }}
           type=ref,event=tag,enable=${{ inputs.version == '' }}

--- a/tests/docker-tags.sh
+++ b/tests/docker-tags.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Keep pull-request tagging consistent across the Docker build actions.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+for action in docker docker-job; do
+  manifest="$ROOT/build-actions/$action/action.yaml"
+  count=$(grep -c "type=ref,event=pr,enable=" "$manifest" || true)
+  if [ "$count" -ne 1 ]; then
+    printf "FAIL %s: expected one pull-request tag rule, found %s\n" "$action" "$count" >&2
+    exit 1
+  fi
+  printf "ok %s\n" "$action"
+done


### PR DESCRIPTION
## Summary

- add the missing pull-request ref tag to `build-actions/docker-job`
- keep PR tagging aligned across both Docker build actions
- cover the shared invariant in the action test suite

## Why

`docker-job` pushes its successful build, but under a `pull_request` event its metadata rules produced no tag. Buildx then failed with `tag is needed when pushing to registry`. The sibling `docker` action already handles this event with `type=ref,event=pr`; this applies the same generic rule.

## Tests

- `pnpm format`
- `pnpm lint`
- all `tests/*.sh` suites
- `bash -n tests/docker-tags.sh`