### PR TITLE
ci(go): add reliable generation action

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ the configured path; the `append-only-override` PR label is the reviewed escape 
 
 ### `go-actions`
 
-| Action    | Purpose                                                     |
-| --------- | ----------------------------------------------------------- |
-| `lint-go` | Run `golangci-lint` (supports a non-root module dir).       |
-| `test-go` | Run the workspace's Go tests with coverage via `gotestsum`. |
+| Action        | Purpose                                                                    |
+| ------------- | -------------------------------------------------------------------------- |
+| `lint-go`     | Run `golangci-lint` (supports a non-root module dir).                      |
+| `test-go`     | Run the workspace's Go tests with coverage via `gotestsum`.                |
 | `generate-go` | Generate Go code with retries and fail when the committed output is stale. |
 
 ### `node-actions`

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ the configured path; the `append-only-override` PR label is the reviewed escape 
 | --------- | ----------------------------------------------------------- |
 | `lint-go` | Run `golangci-lint` (supports a non-root module dir).       |
 | `test-go` | Run the workspace's Go tests with coverage via `gotestsum`. |
+| `generate-go` | Generate Go code with retries and fail when the committed output is stale. |
 
 ### `node-actions`
 

--- a/go-actions/generate-go/action.yaml
+++ b/go-actions/generate-go/action.yaml
@@ -1,0 +1,52 @@
+name: generate go
+description: Generate Go code with bounded retries and verify the committed output.
+
+inputs:
+  working_directory:
+    required: false
+    description: The Go module directory. Defaults to the repository root.
+  failure_message:
+    required: false
+    default: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
+    description: The message displayed when generation leaves uncommitted changes.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@v7
+      with:
+        go-version-file: ${{ inputs.working_directory && format('{0}/go.mod', inputs.working_directory) || 'go.mod' }}
+    - name: Generate Go code
+      shell: bash
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working_directory }}
+      run: |
+        set -euo pipefail
+
+        generate() {
+          local attempt delay
+
+          for attempt in 1 2 3; do
+            if (cd "${WORKING_DIRECTORY:-.}" && go generate ./...); then
+              return 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::go generate failed after 3 attempts." >&2
+              return 1
+            fi
+
+            delay=$((attempt * 5))
+            echo "::warning::go generate failed; retrying in ${delay}s." >&2
+            sleep "$delay"
+          done
+        }
+
+        generate
+    - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.27.1
+      with:
+        pathspec: ${{ inputs.working_directory || '.' }}
+        fail_message: ${{ inputs.failure_message }}

--- a/go-actions/generate-go/action.yaml
+++ b/go-actions/generate-go/action.yaml
@@ -29,8 +29,10 @@ runs:
         generate() {
           local attempt delay
 
+          cd "${WORKING_DIRECTORY:-.}"
+
           for attempt in 1 2 3; do
-            if (cd "${WORKING_DIRECTORY:-.}" && go generate ./...); then
+            if go generate ./...; then
               return 0
             fi
 

--- a/tests/generate-go.sh
+++ b/tests/generate-go.sh
@@ -55,11 +55,13 @@ run_case() { # $1=label $2=failures-before-success
 
   if (
     ATTEMPTS=0
+    # shellcheck disable=SC2329 # invoked indirectly by generate
     go() {
       ATTEMPTS=$((ATTEMPTS + 1))
       printf '%s\n' "$ATTEMPTS" >>"$case_dir/attempts"
       [ "$ATTEMPTS" -gt "$failures" ]
     }
+    # shellcheck disable=SC2329 # invoked indirectly by generate
     sleep() {
       printf '%s\n' "$1" >>"$case_dir/delays"
     }

--- a/tests/generate-go.sh
+++ b/tests/generate-go.sh
@@ -15,6 +15,7 @@ extract() {
   awk '
     /^    - name: Generate Go code$/ {step=1; next}
     step && /^      run: \|$/ {run=1; next}
+    run && /^        generate$/ {exit}
     run && /^    - / {exit}
     run {sub(/^        /, ""); print}
   ' "$ACTION"

--- a/tests/generate-go.sh
+++ b/tests/generate-go.sh
@@ -51,6 +51,7 @@ run_case() { # $1=label $2=failures-before-success
 
   case_dir="$WORK/$label"
   mkdir -p "$case_dir"
+  : >"$case_dir/delays"
 
   if (
     ATTEMPTS=0

--- a/tests/generate-go.sh
+++ b/tests/generate-go.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# ^ this suite extracts a manifest containing literal GitHub expressions.
+#
+# Regression tests for generate-go's retry loop. The action must retry transient generator failures
+# twice, retain the bounded backoff, and still fail after the final attempt.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION="${1:-$ROOT/go-actions/generate-go/action.yaml}"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+extract() {
+  awk '
+    /^    - name: Generate Go code$/ {step=1; next}
+    step && /^      run: \|$/ {run=1; next}
+    run && /^    - / {exit}
+    run {sub(/^        /, ""); print}
+  ' "$ACTION"
+}
+
+generated=$(extract)
+if [ -z "$generated" ]; then
+  echo "::error::could not extract the generation script from $ACTION"
+  exit 1
+fi
+
+printf '%s\n' "$generated" >"$WORK/generate.sh"
+if ! bash -n "$WORK/generate.sh"; then
+  echo "::error::extracted generation script does not parse"
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+. "$WORK/generate.sh"
+
+fails=0
+check() { # $1=label $2=expected $3=actual
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected [$2], got [$3]"
+    fails=$((fails + 1))
+  fi
+}
+
+run_case() { # $1=label $2=failures-before-success
+  local label=$1 failures=$2 case_dir status attempts delays
+
+  case_dir="$WORK/$label"
+  mkdir -p "$case_dir"
+
+  if (
+    ATTEMPTS=0
+    go() {
+      ATTEMPTS=$((ATTEMPTS + 1))
+      printf '%s\n' "$ATTEMPTS" >>"$case_dir/attempts"
+      [ "$ATTEMPTS" -gt "$failures" ]
+    }
+    sleep() {
+      printf '%s\n' "$1" >>"$case_dir/delays"
+    }
+    generate
+  ); then
+    status=0
+  else
+    status=1
+  fi
+
+  attempts=$(wc -l <"$case_dir/attempts")
+  delays=$(tr '\n' ' ' <"$case_dir/delays" | sed 's/ $//')
+  printf '%s|%s|%s\n' "$status" "$attempts" "$delays"
+}
+
+echo "== retry behavior =="
+
+result=$(run_case first-attempt 0)
+check "success on first attempt" "0|1|" "$result"
+
+result=$(run_case second-attempt 1)
+check "retry then success" "0|2|5" "$result"
+
+result=$(run_case final-failure 3)
+check "failure after final attempt" "1|3|5 10" "$result"
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "::error::$fails assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
## Summary

- Adds a shared `go-actions/generate-go` composite action with bounded retry for transient generator failures.
- Preserves generated-output validation and supports non-root Go module directories.
- Adds regression coverage for first-attempt success, retry recovery, and final failure.

## Layers changed

- **CI**: reusable Go-generation action and its catalog entry.

## Breaking changes

None.

## Test plan

- [x] `bash tests/*.sh` passes
- [x] `bash .github/scripts/lint-action-manifests.sh .` passes
- [x] `pnpm lint:prettier` passes
- [ ] CI green

Closes #387

Part of a-novel/.github#239.