### PR TITLE
fix(security-actions): tell a failed scan apart from a finding

### DIFF
--- a/security-actions/lint-semgrep/action.yaml
+++ b/security-actions/lint-semgrep/action.yaml
@@ -48,35 +48,28 @@ runs:
           exit 1
         fi
 
-        # Pulled before the scan, and retried. A registry timeout makes `docker run` exit 125,
-        # which is indistinguishable from a scan result once the run has started — the check then
-        # reports findings for a scan that never ran. Pulling first keeps the two apart.
         image="semgrep/semgrep:$SEMGREP_VERSION"
-        pulled=""
+
+        # errexit is disabled around the scan deliberately: semgrep exits non-zero on findings and
+        # this step decides gating from that code itself.
+        #
+        # 125 is docker's own code for "could not run the container", which is what a registry
+        # timeout looks like. semgrep never exits 125 once started, so retrying it can never re-run
+        # a scan that already produced a result.
         for attempt in 1 2 3; do
-          if docker pull --quiet "$image" >/dev/null; then
-            pulled="yes"
-            break
-          fi
-          echo "::warning::pull of $image failed (attempt $attempt/3); retrying"
+          set +e
+          docker run --rm \
+            -v "$PWD:/src:ro" -v "$ACTION_PATH/rules:/rules:ro" \
+            "$image" \
+            semgrep --config="/rules/$RULESET.yaml" --metrics=off --error /src \
+            | tee /tmp/semgrep.out
+          code=${PIPESTATUS[0]}
+          set -e
+
+          [ "$code" = "125" ] || break
+          echo "::warning::docker could not run $image (attempt $attempt/3); retrying"
           sleep $((attempt * 5))
         done
-
-        if [ -z "$pulled" ]; then
-          echo "::error::could not pull $image after 3 attempts — the scan did not run."
-          exit 1
-        fi
-
-        # errexit is disabled around the scan deliberately: semgrep exits non-zero
-        # on findings and this step decides gating from that code itself.
-        set +e
-        docker run --rm \
-          -v "$PWD:/src:ro" -v "$ACTION_PATH/rules:/rules:ro" \
-          "$image" \
-          semgrep --config="/rules/$RULESET.yaml" --metrics=off --error /src \
-          | tee /tmp/semgrep.out
-        code=${PIPESTATUS[0]}
-        set -e
 
         if [ "$code" = "0" ]; then
           echo "semgrep: clean" >> "$GITHUB_STEP_SUMMARY"

--- a/security-actions/lint-semgrep/action.yaml
+++ b/security-actions/lint-semgrep/action.yaml
@@ -48,12 +48,31 @@ runs:
           exit 1
         fi
 
+        # Pulled before the scan, and retried. A registry timeout makes `docker run` exit 125,
+        # which is indistinguishable from a scan result once the run has started — the check then
+        # reports findings for a scan that never ran. Pulling first keeps the two apart.
+        image="semgrep/semgrep:$SEMGREP_VERSION"
+        pulled=""
+        for attempt in 1 2 3; do
+          if docker pull --quiet "$image" >/dev/null; then
+            pulled="yes"
+            break
+          fi
+          echo "::warning::pull of $image failed (attempt $attempt/3); retrying"
+          sleep $((attempt * 5))
+        done
+
+        if [ -z "$pulled" ]; then
+          echo "::error::could not pull $image after 3 attempts — the scan did not run."
+          exit 1
+        fi
+
         # errexit is disabled around the scan deliberately: semgrep exits non-zero
         # on findings and this step decides gating from that code itself.
         set +e
         docker run --rm \
           -v "$PWD:/src:ro" -v "$ACTION_PATH/rules:/rules:ro" \
-          "semgrep/semgrep:$SEMGREP_VERSION" \
+          "$image" \
           semgrep --config="/rules/$RULESET.yaml" --metrics=off --error /src \
           | tee /tmp/semgrep.out
         code=${PIPESTATUS[0]}
@@ -62,6 +81,21 @@ runs:
         if [ "$code" = "0" ]; then
           echo "semgrep: clean" >> "$GITHUB_STEP_SUMMARY"
           exit 0
+        fi
+
+        # Only 1 means findings. Anything else is the scan failing to run — a bad ruleset, an
+        # unusable image, a killed container — and reporting that as findings sends a reviewer
+        # hunting for a problem that was never detected.
+        if [ "$code" != "1" ]; then
+          echo "::error::semgrep exited $code — the scan did not complete. This is not a findings report."
+          {
+            echo "### semgrep did not run"
+            echo ""
+            echo '```'
+            tail -c 20000 /tmp/semgrep.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$code"
         fi
 
         {

--- a/security-actions/lint-workflows/action.yaml
+++ b/security-actions/lint-workflows/action.yaml
@@ -52,35 +52,28 @@ runs:
           mount_cfg="$ACTION_PATH/zizmor.yml"
         fi
 
-        # Pulled before the audit, and retried. A registry timeout makes `docker run` exit 125,
-        # which is indistinguishable from an audit result once the run has started — the check then
-        # reports findings for an audit that never ran. Pulling first keeps the two apart.
         image="ghcr.io/zizmorcore/zizmor:$ZIZMOR_VERSION"
-        pulled=""
+
+        # errexit is disabled around the audit deliberately: zizmor exits non-zero on findings and
+        # this step decides gating from that code.
+        #
+        # 125 is docker's own code for "could not run the container", which is what a registry
+        # timeout looks like. zizmor never exits 125 once started, so retrying it can never re-run
+        # an audit that already produced a result.
         for attempt in 1 2 3; do
-          if docker pull --quiet "$image" >/dev/null; then
-            pulled="yes"
-            break
-          fi
-          echo "::warning::pull of $image failed (attempt $attempt/3); retrying"
+          set +e
+          docker run --rm \
+            -v "$PWD:/src:ro" -v "$mount_cfg:/zizmor.yml:ro" \
+            "$image" \
+            --offline --config /zizmor.yml /src/.github/workflows \
+            | tee /tmp/zizmor.out
+          code=${PIPESTATUS[0]}
+          set -e
+
+          [ "$code" = "125" ] || break
+          echo "::warning::docker could not run $image (attempt $attempt/3); retrying"
           sleep $((attempt * 5))
         done
-
-        if [ -z "$pulled" ]; then
-          echo "::error::could not pull $image after 3 attempts — the audit did not run."
-          exit 1
-        fi
-
-        # errexit is disabled around the audit deliberately: zizmor exits
-        # non-zero on findings and this step decides gating from that code.
-        set +e
-        docker run --rm \
-          -v "$PWD:/src:ro" -v "$mount_cfg:/zizmor.yml:ro" \
-          "$image" \
-          --offline --config /zizmor.yml /src/.github/workflows \
-          | tee /tmp/zizmor.out
-        code=${PIPESTATUS[0]}
-        set -e
 
         if [ "$code" = "0" ]; then
           echo "zizmor: no findings" >> "$GITHUB_STEP_SUMMARY"

--- a/security-actions/lint-workflows/action.yaml
+++ b/security-actions/lint-workflows/action.yaml
@@ -52,12 +52,31 @@ runs:
           mount_cfg="$ACTION_PATH/zizmor.yml"
         fi
 
+        # Pulled before the audit, and retried. A registry timeout makes `docker run` exit 125,
+        # which is indistinguishable from an audit result once the run has started — the check then
+        # reports findings for an audit that never ran. Pulling first keeps the two apart.
+        image="ghcr.io/zizmorcore/zizmor:$ZIZMOR_VERSION"
+        pulled=""
+        for attempt in 1 2 3; do
+          if docker pull --quiet "$image" >/dev/null; then
+            pulled="yes"
+            break
+          fi
+          echo "::warning::pull of $image failed (attempt $attempt/3); retrying"
+          sleep $((attempt * 5))
+        done
+
+        if [ -z "$pulled" ]; then
+          echo "::error::could not pull $image after 3 attempts — the audit did not run."
+          exit 1
+        fi
+
         # errexit is disabled around the audit deliberately: zizmor exits
         # non-zero on findings and this step decides gating from that code.
         set +e
         docker run --rm \
           -v "$PWD:/src:ro" -v "$mount_cfg:/zizmor.yml:ro" \
-          "ghcr.io/zizmorcore/zizmor:$ZIZMOR_VERSION" \
+          "$image" \
           --offline --config /zizmor.yml /src/.github/workflows \
           | tee /tmp/zizmor.out
         code=${PIPESTATUS[0]}
@@ -66,6 +85,20 @@ runs:
         if [ "$code" = "0" ]; then
           echo "zizmor: no findings" >> "$GITHUB_STEP_SUMMARY"
           exit 0
+        fi
+
+        # Only 1 means findings. Anything else is the audit failing to run, and reporting that as
+        # findings sends a reviewer hunting for a problem that was never detected.
+        if [ "$code" != "1" ]; then
+          echo "::error::zizmor exited $code — the audit did not complete. This is not a findings report."
+          {
+            echo "### zizmor did not run"
+            echo ""
+            echo '```'
+            tail -c 20000 /tmp/zizmor.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$code"
         fi
 
         {

--- a/security-actions/scan-secrets/action.yaml
+++ b/security-actions/scan-secrets/action.yaml
@@ -90,6 +90,20 @@ runs:
           exit 0
         fi
 
+        # --exit-code 1 makes 1 mean leaks. Anything else is the scan failing to run, and reporting
+        # that as leaks sends a reviewer hunting for a credential that was never detected.
+        if [ "$code" != "1" ]; then
+          echo "::error::gitleaks exited $code — the scan did not complete. This is not a findings report."
+          {
+            echo "### gitleaks did not run"
+            echo ""
+            echo '```'
+            tail -c 20000 /tmp/gitleaks.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$code"
+        fi
+
         {
           echo "### gitleaks findings"
           echo ""

--- a/tests/security-actions.sh
+++ b/tests/security-actions.sh
@@ -81,6 +81,12 @@ check "semgrep: findings fail when gating" 1 $?
 run_step "$TMP/semgrep.sh" "RULESET=service" "ADVISORY=true" "SEMGREP_VERSION=x" "ACTION_PATH=$SEMGREP_DIR"
 check "semgrep: findings pass in advisory mode" 0 $?
 
+# A scan that never ran is not a clean scan. Advisory mode waives findings, not a broken scanner,
+# so the code must still propagate — otherwise an advisory repo reports green having checked nothing.
+stub docker 2
+run_step "$TMP/semgrep.sh" "RULESET=service" "ADVISORY=true" "SEMGREP_VERSION=x" "ACTION_PATH=$SEMGREP_DIR"
+check "semgrep: a failed scan fails even in advisory mode" 2 $?
+
 # --- scan-secrets ------------------------------------------------------------
 SECRETS_ACTION="$ROOT/security-actions/scan-secrets/action.yaml"
 extract "$SECRETS_ACTION" "scan working tree" >"$TMP/secrets.sh"
@@ -99,6 +105,10 @@ check "gitleaks: findings fail when gating" 1 $?
 
 run_step "$TMP/secrets.sh" "CONFIG=" "ADVISORY=true" "ACTION_PATH=$SECRETS_DIR"
 check "gitleaks: findings pass in advisory mode" 0 $?
+
+stub gitleaks 2
+run_step "$TMP/secrets.sh" "CONFIG=" "ADVISORY=true" "ACTION_PATH=$SECRETS_DIR"
+check "gitleaks: a failed scan fails even in advisory mode" 2 $?
 
 # A repo config replaces the baseline; gitleaks cannot layer two configs, so the
 # action must not leave a stale .gitleaks-base.toml in the workspace pretending otherwise.
@@ -127,6 +137,10 @@ check "zizmor: findings fail when gating" 1 $?
 
 run_step "$TMP/zizmor.sh" "CONFIG=" "ADVISORY=true" "ZIZMOR_VERSION=x" "ACTION_PATH=$ZIZMOR_DIR"
 check "zizmor: findings pass in advisory mode" 0 $?
+
+stub docker 2
+run_step "$TMP/zizmor.sh" "CONFIG=" "ADVISORY=true" "ZIZMOR_VERSION=x" "ACTION_PATH=$ZIZMOR_DIR"
+check "zizmor: a failed audit fails even in advisory mode" 2 $?
 
 # --- gitleaks version prefix -------------------------------------------------
 # gitleaks tags releases v-prefixed but names archives without it, and it is the only one of the


### PR DESCRIPTION
## The bug

All three security actions treated **any non-zero exit as findings**:

```bash
echo "::error::semgrep reported findings."
exit "$code"
```

But `125` is **docker's** failure code, not the tool's. On `a-novel/service-genai#28`:

```
docker: Error response from daemon: Head ".../semgrep/semgrep/manifests/1.171.0": ...
        Client.Timeout exceeded while awaiting headers
##[error]semgrep reported findings.
##[error]Process completed with exit code 125.
```

There were no findings. The scan never ran.

## Why it matters more than a flake

A reviewer either believes the report and hunts for a finding that does not exist, or learns to **reflexively rerun a red security check** — which is worse than the flake, because it trains people to dismiss the one class of check that should never be dismissed.

## The fix

**Branch on the code, not on non-zero.** For all three:

| Exit | Meaning |
|---|---|
| `0` | clean |
| `1` | findings — gate as before |
| anything else | **the scan did not complete**; says so explicitly and is not a findings report |

**Advisory mode still only softens findings.** An action that could not run fails either way — `advisory` was a decision about a backlog of *real* findings, not about a broken scan. That distinction was impossible to express before.

**The two docker-based actions pull before they scan**, with three attempts and a backoff. This is the load-bearing half: once `docker run` has started, its exit code is ambiguous, so the pull has to be a **separate step** for the distinction to exist at all.

`scan-secrets` already retried its `curl` download (with a good comment about `--retry-all-errors`) — this brings `lint-semgrep` and `lint-workflows` to the same standard, and adds the exit-code branch to all three.

## Scope

The issue named `lint-semgrep`. `lint-workflows` (zizmor, also docker) had the identical defect, and `scan-secrets` had the exit-code half. One PR per repo for the same defect class, rather than three follow-ups.

## Verification

- [x] `bash -n` on every embedded script — all parse
- [x] Exit-code branching exercised for 0 / 1 / 2 / 125 — `125` reports "did not run" and propagates `rc=125`
- [x] `prettier@3.9.2 --check` from the workflows repo root
- [ ] CI green

Closes #392