### PR TITLE
fix(ci): extract composite action image pins

### DIFF
--- a/generic-actions/renovate/action.yaml
+++ b/generic-actions/renovate/action.yaml
@@ -60,8 +60,8 @@ runs:
         RENOVATE_ASSIGN_AUTOMERGE: true
         RENOVATE_ASSIGNEES_FROM_CODE_OWNERS: true
         RENOVATE_LABELS: "['dependencies', 'renovate']"
-        # Tool versions pinned in a workflow's `with:` block are invisible to every
-        # built-in manager. The annotation names the datasource; this reads it.
+        # Built-in managers cannot see workflow `with:` values or composite-action input defaults.
+        # The custom managers extract annotated workflow pins and registry-qualified image defaults.
         RENOVATE_CUSTOM_MANAGERS: |
           [
             {
@@ -72,6 +72,16 @@ runs:
                 "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
               ],
               "extractVersionTemplate": "^v?(?<version>.+)$"
+            },
+            {
+              "customType": "regex",
+              "description": "Registry-qualified Docker images pinned as repository-local composite-action input defaults.",
+              "managerFilePatterns": ["/^\\.github/actions/.+/action\\.ya?ml$/"],
+              "matchStrings": [
+                "(?:^|\\r?\\n)[ \\t]+default:\\s*[\"']?(?<depName>[a-z0-9.-]+(?::[0-9]+)?(?:/[a-z0-9._-]+)+):(?<currentValue>[^\\s\"'/:]+)[\"']?"
+              ],
+              "datasourceTemplate": "docker",
+              "versioningTemplate": "docker"
             }
           ]
 

--- a/tests/renovate-extraction.sh
+++ b/tests/renovate-extraction.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Verify Renovate extracts hidden workflow and composite-action dependency pins.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION="$ROOT/generic-actions/renovate/action.yaml"
+
+config=$(python3 - "$ACTION" <<'PY'
+import json
+import sys
+
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    manifest = yaml.safe_load(stream)
+
+renovate_step = next(
+    step
+    for step in manifest["runs"]["steps"]
+    if "RENOVATE_CUSTOM_MANAGERS" in step.get("env", {})
+)
+
+print(json.dumps({
+    "customManagers": json.loads(renovate_step["env"]["RENOVATE_CUSTOM_MANAGERS"]),
+    "packageRules": json.loads(renovate_step["env"]["RENOVATE_PACKAGE_RULES"]),
+}))
+PY
+)
+
+RENOVATE_CONFIG="$config" node --input-type=module <<'NODE'
+import assert from "node:assert/strict";
+
+const { customManagers, packageRules } = JSON.parse(process.env.RENOVATE_CONFIG);
+
+function compileRenovateRegex(value) {
+  const separator = value.lastIndexOf("/");
+  assert.equal(value[0], "/");
+  return new RegExp(value.slice(1, separator), value.slice(separator + 1));
+}
+
+function extract(manager, fixture) {
+  return manager.matchStrings.flatMap((pattern) =>
+    [...fixture.matchAll(new RegExp(pattern, "g"))].map(({ groups }) => groups),
+  );
+}
+
+const workflowManager = customManagers.find(({ description }) =>
+  description.includes("workflow with: blocks"),
+);
+assert(workflowManager, "workflow annotation manager is missing");
+assert(
+  workflowManager.managerFilePatterns.some((pattern) =>
+    compileRenovateRegex(pattern).test(".github/workflows/main.yaml"),
+  ),
+  "workflow annotation manager does not scan caller workflows",
+);
+assert.deepEqual(
+  extract(
+    workflowManager,
+    `# renovate: datasource=github-releases depName=koalaman/shellcheck
+version: "0.11.0"`,
+  ).map(({ datasource, depName, currentValue }) => ({ datasource, depName, currentValue })),
+  [
+    {
+      datasource: "github-releases",
+      depName: "koalaman/shellcheck",
+      currentValue: "0.11.0",
+    },
+  ],
+);
+
+const imageManager = customManagers.find(({ description }) =>
+  description.includes("composite-action input defaults"),
+);
+assert(imageManager, "composite-action image manager is missing");
+assert.equal(imageManager.datasourceTemplate, "docker");
+assert.equal(imageManager.versioningTemplate, "docker");
+assert(
+  imageManager.managerFilePatterns.some((pattern) =>
+    compileRenovateRegex(pattern).test(".github/actions/start-ci-services/action.yml"),
+  ),
+  "composite-action image manager does not scan repository-local actions",
+);
+
+const imagePins = extract(
+  imageManager,
+  `inputs:
+  database_image:
+    default: ghcr.io/a-novel/service-json-keys/database:v2.4.1
+  grpc_image:
+    default: "ghcr.io/a-novel/service-json-keys/standalone-grpc:v2.4.1"
+  local_image:
+    default: service-under-test:ci
+  callback:
+    default: https://example.test:8443/path`,
+).map(({ depName, currentValue }) => ({ depName, currentValue }));
+
+assert.deepEqual(imagePins, [
+  {
+    depName: "ghcr.io/a-novel/service-json-keys/database",
+    currentValue: "v2.4.1",
+  },
+  {
+    depName: "ghcr.io/a-novel/service-json-keys/standalone-grpc",
+    currentValue: "v2.4.1",
+  },
+]);
+
+const jsonKeysRule = packageRules.find(({ groupName }) => groupName === "service json keys");
+assert(jsonKeysRule, "service JSON Keys group rule is missing");
+const groupPatterns = jsonKeysRule.matchPackageNames.map(compileRenovateRegex);
+for (const dependency of [
+  "github.com/a-novel/service-json-keys/v2",
+  "ghcr.io/a-novel/service-json-keys/database",
+  "ghcr.io/a-novel/service-json-keys/standalone-grpc",
+]) {
+  assert(
+    groupPatterns.some((pattern) => pattern.test(dependency)),
+    `${dependency} does not join the service JSON Keys group`,
+  );
+}
+
+console.log("renovate-extraction: all assertions passed");
+NODE


### PR DESCRIPTION
## Summary

- Make registry-qualified Docker images stored in repository-local composite-action defaults visible to Renovate.
- Reuse the existing per-service package groups, so action defaults land with Go module and Compose image pins.
- Avoid per-consumer annotations because each default already contains the Docker registry and complete dependency name.

## Breaking changes

None.

## Test plan

- [x] `bash tests/renovate-extraction.sh`
- [x] Full `tests/*.sh` action-suite harness
- [x] `pnpm lint`
- [x] Composite-action manifest guard
- [ ] CI green